### PR TITLE
Add the option to pass pretrained  parameters to the NFs

### DIFF
--- a/src/distributions/random_effects/NormalizingPlanarFlows.jl
+++ b/src/distributions/random_effects/NormalizingPlanarFlows.jl
@@ -1,6 +1,7 @@
 using NormalizingFlows, Bijectors, FunctionChains, Functors, Optimisers, Distributions
 import StaticArrays
 import Random: AbstractRNG, default_rng
+import Statistics
 
 export AbstractNormalizingFlow
 export NormalizingPlanarFlow
@@ -175,3 +176,8 @@ Distributions.rand(rng::AbstractRNG, d::NormalizingPlanarFlow, dims::Dims...) = 
 
 # Use the underlying transformed distribution's bijector for HMC/NUTS.
 Bijectors.bijector(d::NormalizingPlanarFlow) = Bijectors.bijector(d.base)
+
+# Estimate covariance via sampling — used only for MH step-size initialisation,
+# so an empirical approximation is sufficient.
+Statistics.cov(d::NormalizingPlanarFlow; n_samples::Int=2000) =
+    Statistics.cov(rand(default_rng(), d, n_samples)')

--- a/src/model/Parameters.jl
+++ b/src/model/Parameters.jl
@@ -328,6 +328,7 @@ end
 
 function NPFParameter(n_input::Integer, n_layers::Integer; name::Symbol = :unnamed, seed::Integer = 0,
     init::Function = x -> sqrt((1 / n_input)) .* x, base_dist = nothing,
+    weights::Union{AbstractVector, Nothing} = nothing,
     prior = Priorless(), calculate_se::Bool = false)
     n_input > 0 || error("Invalid n_input for parameter $(name). Expected n_input > 0; got $(n_input).")
     n_layers > 0 || error("Invalid n_layers for parameter $(name). Expected n_layers > 0; got $(n_layers).")
@@ -337,7 +338,12 @@ function NPFParameter(n_input::Integer, n_layers::Integer; name::Symbol = :unnam
     ts = fchain(Ls)
     flat, reconstructor = Optimisers.destructure(ts)
     T = eltype(flat) <: AbstractFloat ? eltype(flat) : Float64
-    v = T.(flat)
+    if !isnothing(weights)
+        length(weights) == length(flat) || error("Provided weights length ($(length(weights))) does not match expected flat parameter length ($(length(flat))) for parameter $(name).")
+        v = T.(weights)
+    else
+        v = T.(flat)
+    end
     l = fill(T(-Inf), length(v))
     u = fill(T(Inf), length(v))
     _check_nn_prior(prior, name, length(v))


### PR DESCRIPTION
* Updated the `NPFParameter` constructor to accept an optional `weights` argument, allowing users to specify custom initial weights for parameters. (`src/model/Parameters.jl`)
* Added a method to estimate the covariance matrix for `NormalizingPlanarFlow` using empirical samples, which can be useful for initializing Metropolis-Hastings step sizes. 



