### PR TITLE
Fix simulate_data uses theta_untransformed for RE distributions

### DIFF
--- a/src/data_simulation/data_simulation.jl
+++ b/src/data_simulation/data_simulation.jl
@@ -346,7 +346,8 @@ end
 """
     simulate_data(dm::DataModel; rng, replace_missings, serialization, theta_untransformed) -> DataFrame
 
-Simulate observations from a `DataModel` using the model's initial parameter values.
+Simulate observations from a `DataModel` using the provided parameter values, or the model's initial parameter values if none are given.
+
 
 Random effects are drawn from their prior distributions and observation columns are
 replaced with draws from the model's observation distributions. Non-observation columns

--- a/src/data_simulation/data_simulation.jl
+++ b/src/data_simulation/data_simulation.jl
@@ -273,7 +273,7 @@ function _warn_bad_value(dm::DataModel, row::Int, col::Symbol, dist, val)
     return nothing
 end
 
-function _sample_random_effects(dm::DataModel, rng)
+function _sample_random_effects(dm::DataModel, rng, θ)
     model = dm.model
     re_names = get_re_names(model.random.random)
     isempty(re_names) && return Dict{Symbol, Any}()
@@ -281,7 +281,7 @@ function _sample_random_effects(dm::DataModel, rng)
     re_values = dm.re_group_info.values
     re_index_by_row = dm.re_group_info.index_by_row
     cov = model.covariates.covariates
-    θ = get_θ0_untransformed(model.fixed.fixed)
+
     model_funs = get_model_funs(model)
     helpers = get_helper_funs(model)
     create = get_create_random_effect_distribution(model.random.random)
@@ -371,7 +371,7 @@ function simulate_data(dm::DataModel; rng=Random.default_rng(),
     df = deepcopy(dm.df)
     θ = _resolve_sim_theta(dm, theta_untransformed)
 
-    re_samples = _sample_random_effects(dm, rng)
+    re_samples = _sample_random_effects(dm, rng, θ)
     _attach_random_effects!(df, dm, re_samples)
 
     rngs = _rngs_for_serialization(rng, serialization)

--- a/test/data_simulation_tests.jl
+++ b/test/data_simulation_tests.jl
@@ -588,3 +588,47 @@ end
     @test all(path -> all(diff(path) .>= 0), paths)
     @test any(path -> any(==(3), path), paths)
 end
+
+@testset "simulate_data uses theta_untransformed for random effect distributions" begin
+    model = @Model begin
+        @fixedEffects begin
+            a   = RealNumber(0.0)
+            σ_y = RealNumber(0.01)
+            σ_η = RealNumber(1.0, scale=:log)   # θ0: σ_η = 1
+        end
+
+        @covariates begin
+            t = Covariate()
+        end
+
+        @randomEffects begin
+            η = RandomEffect(Normal(0.0, σ_η); column=:ID)
+        end
+
+        @formulas begin
+            y ~ Normal(a + η, σ_y)
+        end
+    end
+
+    n_ind = 100
+    df = DataFrame(
+        ID = repeat(1:n_ind, inner=2),
+        t  = repeat([0.0, 1.0], n_ind),
+        y  = zeros(2 * n_ind),
+    )
+
+    dm = DataModel(model, df; primary_id=:ID, time_col=:t)
+
+    fitted_theta = (a=0.0, σ_y=0.01, σ_η=20.0)
+
+    sim_θ0     = simulate_data(dm; rng=MersenneTwister(42))
+    sim_fitted = simulate_data(dm; rng=MersenneTwister(42), theta_untransformed=fitted_theta)
+
+    # One η per individual (constant within ID)
+    η_θ0     = [sim_θ0.η[findfirst(==(id), sim_θ0.ID)]        for id in 1:n_ind]
+    η_fitted = [sim_fitted.η[findfirst(==(id), sim_fitted.ID)] for id in 1:n_ind]
+
+    # σ_η = 1 (θ0) → std ≈ 1; σ_η = 20 (fitted) → std ≈ 20
+    @test std(η_θ0)     < 5.0
+    @test std(η_fitted) > 5.0
+end


### PR DESCRIPTION
Bug: _sample_random_effects always used get_θ0_untransformed to parameterise random effect distributions, ignoring the theta_untransformed argument passed to simulate_data. This meant simulating with fitted parameters still drew random effects from the initial-value distribution.

Fix: Pass the already-resolved θ through to _sample_random_effects so the fitted variance parameters are used.

Test: Added a test that verifies random effects are drawn from the the correct distribution when theta_untransformed is provided.