### PR TITLE
Covariate vectors usable as numeric vectors

### DIFF
--- a/src/data_model/DataModel.jl
+++ b/src/data_model/DataModel.jl
@@ -584,7 +584,8 @@ function _probe_varying_covariates(covariates, df, rows, obs_row::Int, time_col:
         if v isa AbstractVector
             push!(pairs, name => v[1])
         elseif v isa NamedTuple
-            sub = NamedTuple{keys(v)}(Tuple(getfield(v, k)[1] for k in keys(v)))
+            sub = _covariate_vector(NamedTuple{keys(v)}(Tuple(getfield(v, k)[1]
+            for k in keys(v))))
             push!(pairs, name => sub)
         end
     end
@@ -775,6 +776,22 @@ function _extract_constants(params, rows)
     return params
 end
 
+# Materialise a covariate-vector value from a NamedTuple of its per-column entries.
+# When every entry is `Real`, return a `ComponentArray` so the value behaves both as a
+# labelled record (`x.Age`, `x.weight`) AND as a numeric vector (`x' * β`, `dot(x, β)`,
+# `sum(x)`, indexing). Non-numeric (e.g. categorical) covariate vectors stay NamedTuples:
+# field access still works and vector arithmetic is undefined for them anyway. The branch
+# is decided at compile time from the NamedTuple type, so the hot per-row path stays
+# type-stable.
+@generated function _covariate_vector(nt::NamedTuple)
+    fts = fieldtypes(nt.parameters[2])
+    if !isempty(fts) && all(ft -> ft <: Real, fts)
+        return :(ComponentArray(nt))
+    else
+        return :(nt)
+    end
+end
+
 function _build_const_cov(covariates, df, rows)
     params = covariates.params
     out = Pair{Symbol, Any}[]
@@ -785,8 +802,8 @@ function _build_const_cov(covariates, df, rows)
             val = _get_col(df, col)[rows[1]]
             push!(out, name => val)
         elseif p isa ConstantCovariateVector
-            vals = NamedTuple{Tuple(p.columns)}(Tuple(_get_col(df, c)[rows[1]]
-            for c in p.columns))
+            vals = _covariate_vector(NamedTuple{Tuple(p.columns)}(Tuple(_get_col(df, c)[rows[1]]
+            for c in p.columns)))
             push!(out, name => vals)
         end
     end

--- a/src/data_simulation/data_simulation.jl
+++ b/src/data_simulation/data_simulation.jl
@@ -27,7 +27,8 @@ function _varying_at(dm::DataModel, ind::Individual, idx::Int, row::Int)
         if v isa AbstractVector
             push!(pairs, name => v[idx])
         elseif v isa NamedTuple
-            sub = NamedTuple{keys(v)}(Tuple(getfield(v, k)[idx] for k in keys(v)))
+            sub = _covariate_vector(NamedTuple{keys(v)}(Tuple(getfield(v, k)[idx]
+            for k in keys(v))))
             push!(pairs, name => sub)
         end
     end

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -1703,7 +1703,7 @@ end
 # forces dynamic dispatch at each `calculate_formulas_obs` call site (and breaks
 # Enzyme reverse mode). Going through the NamedTuple structure keeps row types concrete.
 @inline _vary_value_at(v::AbstractVector, idx::Int) = v[idx]
-@inline _vary_value_at(v::NamedTuple, idx::Int) = map(x -> x[idx], v)
+@inline _vary_value_at(v::NamedTuple, idx::Int) = _covariate_vector(map(x -> x[idx], v))
 
 @inline function _vary_row(vary::NamedTuple, dyn::NamedTuple, t_obs, idx::Int)
     t_val = hasproperty(vary, :t) ? vary.t[idx] : t_obs[idx]

--- a/src/estimation/pooled.jl
+++ b/src/estimation/pooled.jl
@@ -527,10 +527,10 @@ function _pooled_structural_syms(model)
     end
     initial = model.de.initial
     if initial !== nothing
-        m = get_initialde_meta(initial)
-        union!(syms, m.var_syms)
-        union!(syms, m.prop_syms)
-        union!(syms, m.call_syms)
+        ir_init = initial.ir
+        union!(syms, ir_init.var_syms)
+        union!(syms, ir_init.prop_syms)
+        union!(syms, ir_init.call_syms)
     end
     prede = model.de.prede
     if prede !== nothing

--- a/src/model/Covariates.jl
+++ b/src/model/Covariates.jl
@@ -61,7 +61,10 @@ data-frame columns to read:
     x = ConstantCovariateVector([:Age, :BMI]; constant_on=:ID)
 end
 ```
-Accessed in model blocks as `x.Age`, `x.BMI`.
+Inside model blocks the value supports both named-field access (`x.Age`, `x.BMI`) and
+numeric-vector operations in column order (`x' * β`, `dot(x, β)`, `sum(x)`, `x[1]`). The
+vector behaviour requires every column to be numeric; mixed/categorical vectors keep
+field access only.
 
 # Keyword Arguments
 - `constant_on`: a `Symbol` or vector of `Symbol`s naming the grouping column(s).
@@ -81,7 +84,10 @@ A vector of time-varying scalar covariates read row-by-row.
     z = CovariateVector([:z1, :z2])
 end
 ```
-Accessed in model blocks as `z.z1`, `z.z2`.
+Inside model blocks the per-row value supports both named-field access (`z.z1`, `z.z2`)
+and numeric-vector operations in column order (`z' * β`, `dot(z, β)`, `sum(z)`, `z[1]`).
+The vector behaviour requires every column to be numeric; mixed/categorical vectors keep
+field access only.
 
 # Arguments
 - `columns::Vector{Symbol}`: names of the data-frame columns to collect.
@@ -122,6 +128,11 @@ end
 
 # Arguments
 - `columns::Vector{Symbol}`: data-frame column names.
+
+Accessed in model blocks by named field, each called at a time point: `inputs.i1(t)`.
+Unlike `ConstantCovariateVector`/`CovariateVector`, the value is a bundle of interpolant
+functions, so whole-vector numeric operations (`inputs' * β`) are not supported — index
+a field and call it instead.
 
 # Keyword Arguments
 - `interpolations`: a `Vector` of DataInterpolations.jl types, one per column.

--- a/src/plotting/plotting.jl
+++ b/src/plotting/plotting.jl
@@ -862,7 +862,8 @@ function _varying_at_plot(dm::DataModel, ind::Individual, idx::Int, row::Int)
         if v isa AbstractVector
             push!(pairs, name => v[idx])
         elseif v isa NamedTuple
-            sub = NamedTuple{keys(v)}(Tuple(getfield(v, k)[idx] for k in keys(v)))
+            sub = _covariate_vector(NamedTuple{keys(v)}(Tuple(getfield(v, k)[idx]
+            for k in keys(v))))
             push!(pairs, name => sub)
         end
     end

--- a/test/covariates_tests.jl
+++ b/test/covariates_tests.jl
@@ -1,6 +1,9 @@
 using Test
 using NoLimits
 using DataInterpolations
+using ComponentArrays
+using Distributions
+using ForwardDiff
 
 @testset "Covariates macro" begin
     # Basic macro expansion builds names, groups, and interpolations.
@@ -155,4 +158,45 @@ end
 
     @test cov.params.c.constant_on == [:ID]
     @test cov.params.v.constant_on == [:ID, :SITE]
+end
+
+@testset "Covariate vectors usable as numeric vectors" begin
+    # Numeric covariate vectors materialise as ComponentArrays: both named-field access
+    # (x.Age) and numeric-vector operations (x' * β) work, in column order.
+    cv = NoLimits._covariate_vector((Age = 30.0, Weight = 70.0))
+    @test cv isa ComponentArray
+    @test cv.Age == 30.0 && cv.Weight == 70.0
+    @test cv' * [0.5, -0.2] ≈ 30.0 * 0.5 + 70.0 * (-0.2)
+    @test collect(cv) == [30.0, 70.0]
+    @test eltype(NoLimits._covariate_vector((a = 1.0f0, b = 2.0f0))) == Float32
+
+    # Mixed/categorical covariate vectors keep field access only (stay NamedTuples).
+    cat = NoLimits._covariate_vector((grp = "A", Age = 5.0))
+    @test cat isa NamedTuple && cat.Age == 5.0
+
+    # The per-row time-varying extraction also yields a ComponentArray.
+    row = NoLimits._vary_value_at((z1 = [1.0, 2.0], z2 = [3.0, 4.0]), 2)
+    @test row isa ComponentArray && collect(row) == [2.0, 4.0]
+
+    # End-to-end through generated formula code, including ForwardDiff (AD) over the
+    # fixed effects: ∂(x'β)/∂β = x and ∂(z'γ)/∂γ = z.
+    formulas = @formulas begin
+        lin = x' * β + z' * γ
+        obs ~ Normal(lin, σ)
+    end
+    (_, form_obs, _, _) = get_formulas_builders(formulas;
+        fixed_names = [:β, :γ, :σ], const_cov_names = [:x], varying_cov_names = [:z])
+    const_cov = (x = NoLimits._covariate_vector((Age = 30.0, Weight = 70.0)),)
+    vary = (t = 0.0, z = NoLimits._covariate_vector((z1 = 2.0, z2 = 5.0)))
+    obj = function (p)
+        ctx = (; fixed_effects = (β = p[1:2], γ = p[3:4], σ = 0.4),
+            random_effects = NamedTuple(), prede = NamedTuple(),
+            helpers = NamedTuple(), model_funs = NamedTuple())
+        return mean(form_obs(ctx, NamedTuple(), const_cov, vary).obs)
+    end
+    p0 = [0.5, -0.2, 1.0, 0.3]
+    @test obj(p0) ≈ (30.0 * 0.5 + 70.0 * (-0.2)) + (2.0 * 1.0 + 5.0 * 0.3)
+    g = ForwardDiff.gradient(obj, p0)
+    @test g[1:2] ≈ [30.0, 70.0]
+    @test g[3:4] ≈ [2.0, 5.0]
 end


### PR DESCRIPTION
## Summary

Covariate **vectors** are now usable as numeric vectors in all model blocks while keeping named-field access.

- `ConstantCovariateVector` / `CovariateVector` values are now materialised as **`ComponentArray`s** instead of plain `NamedTuple`s.
- A `ComponentArray` of scalars supports **both** field access (`x.age`, `x.weight`) **and** numeric-vector operations (`x' * β`, `dot(x, β)`, `sum(x)`, `x[1]`), in declared column order.
- Works everywhere a covariate vector is visible — `@formulas`, `@preDifferentialEquation`, `@DifferentialEquation`, `@initialDE`, and random-effect distributions — since those binding sites just `getproperty(...)` the value, and a `ComponentArray` satisfies both access patterns. ForwardDiff flows through cleanly.

### Categorical guard
Non-numeric covariate vectors (e.g. `[:Age, :gender]`) cannot be a numeric `ComponentArray`. A single `@generated` helper `_covariate_vector` decides at compile time — all-`Real` → `ComponentArray`, otherwise stays a `NamedTuple` (field access still works; vector math is undefined for categoricals). Compile-time dispatch keeps the per-row hot path type-stable.

### Scope
`DynamicCovariateVector` is intentionally left as a bundle of interpolant *functions* (`x.i1(t)`) — whole-vector arithmetic doesn't apply to functions of time (documented in its docstring).

## Files changed
- `src/data_model/DataModel.jl` — `_covariate_vector` helper; `_build_const_cov` + obs-probe wrap numeric covariate vectors
- `src/estimation/common.jl` — `_vary_value_at` (per-row hot path)
- `src/data_simulation/data_simulation.jl`, `src/plotting/plotting.jl` — parallel per-row builders
- `src/model/Covariates.jl` — docstrings
- `test/covariates_tests.jl` — one concise testset (Float64/Float32/Dual, categorical fallback, both materialization paths, formula path under ForwardDiff; no DataModel/optimizer/ODE)
- `src/estimation/pooled.jl` — unrelated refactor: read InitialDE IR directly in `_pooled_structural_syms`

## Testing
All green locally: covariates (60), model (7), data_model (85), data_simulation (56), laplace (47), pooled (101). JuliaFormatter v1 (sciml) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)