### PR TITLE
perf: hot-path type-instability + allocation fixes; docs polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,32 +39,26 @@
 </p>
 
 NoLimits.jl is an open-source framework for building, estimating, and diagnosing hierarchical
-models of longitudinal data. It is aimed at life-science applications such as pharmacometrics
-and systems biology, where population variability and mechanistic dynamics must be modeled
-together.
-
-The package is developed and maintained by the
+models of longitudinal data, aimed at life-science applications such as pharmacometrics and
+systems biology where population variability and mechanistic dynamics must be modeled together.
+It is developed and maintained by the
 [Hasenauer Lab](https://www.mathematics-and-life-sciences.uni-bonn.de/en/research/hasenauer-group)
 at the University of Bonn, with
 [Manuel Huth](https://www.mathematics-and-life-sciences.uni-bonn.de/en/group-members/people/hasenauer-group-members/manuel-huth)
-as the lead developer.
+as lead developer.
 
 ## Why NoLimits.jl?
 
 Nonlinear mixed-effects (NLME) models are the standard tool for longitudinal analysis in the
-biomedical sciences, but existing software enforces trade-offs between *expressiveness*,
-*estimation flexibility*, and *modern machine-learning integration*. Mechanistic ODE tools
-rarely support latent-state outcomes or learned components; general mixed-effects packages do
-not handle ODE systems; and probabilistic programming languages leave the NLME machinery to
-the user.
+biomedical sciences, but existing software forces trade-offs between *expressiveness*,
+*estimation flexibility*, and *machine-learning integration*: mechanistic ODE tools rarely
+support latent-state outcomes or learned components, general mixed-effects packages do not
+handle ODE systems, and probabilistic programming languages leave the NLME machinery to the user.
 
-NoLimits.jl provides a single, composable modeling language in which
-mechanistic structure, learned components, flexible random-effect distributions, and diverse
-outcome types coexist in one coherent specification, and can be estimated with multiple
-inference paradigms without rewriting the model.
-
-NoLimits.jl is designed for mixed-effects models, but it can equally be used for
-fixed-effects-only analysis when random effects are not required.
+NoLimits.jl provides a single, composable modeling language in which mechanistic structure,
+learned components, flexible random-effect distributions, and diverse outcome types coexist in
+one specification, and can be estimated with several inference paradigms without rewriting the
+model. It is built for mixed-effects models but works equally for fixed-effects-only analysis.
 
 ## Key Features
 
@@ -72,15 +66,13 @@ fixed-effects-only analysis when random effects are not required.
 
 A model is assembled from freely composable blocks: a structural model (algebraic functions,
 ODE systems via OrdinaryDiffEq.jl, and derived signals); differentiable machine-learning
-components (neural networks, soft decision trees, and B-splines) embeddable in formulas, ODE
+components (neural networks, soft decision trees, B-splines) embeddable in formulas, ODE
 right-hand sides, initial conditions, or random-effect distributions; univariate and
-multivariate random effects over multiple simultaneous grouping structures (e.g., subject and
-site), with Gaussian, non-Gaussian, or normalizing-flow distributions optionally parameterized
-by covariates and learned functions; outcomes from any `Distributions.jl` family (such as
-Normal, LogNormal, Poisson, Bernoulli, and NegativeBinomial) as well as observed-state and
-hidden Markov models; time-varying, group-constant, and interpolated dynamic covariates (eight
-interpolation types); and likelihood-based handling of missing data and left- or
-interval-censored observations. A single model can use all of these at once.
+multivariate random effects over multiple grouping structures (e.g. subject and site) with
+Gaussian, non-Gaussian, or normalizing-flow distributions; outcomes from any `Distributions.jl`
+family as well as observed-state and hidden Markov models; time-varying, constant, and
+interpolated covariates; and likelihood-based handling of missing and censored data. A single
+model can use all of these at once.
 
 ### One model, many estimators
 
@@ -104,10 +96,11 @@ A unified `compute_uq` interface exposes:
 
 ### Diagnostics and visualization
 
-Visual predictive checks (VPCs), residual diagnostics (QQ, PIT, ACF), random-effects
-distribution diagnostics, observation-level predictive distribution plots, multistart waterfall
-plots, UQ parameter distributions, and cross-validation workflows with principled handling of
-random-effects predictions for both seen and unseen individuals.
+Visual predictive checks (VPCs); residual diagnostics (QQ, PIT, ACF); random-effects
+distribution diagnostics; observation-level predictive plots; UQ parameter distributions; and
+cross-validation with principled random-effects predictions for seen and unseen individuals.
+
+See [Capabilities](https://manuhuth.github.io/NoLimits.jl/dev/capabilities) for the complete list.
 
 ## Installation
 
@@ -123,103 +116,65 @@ registered in the Julia General Registry.
 
 ## Quickstart
 
-The example below fits a one-compartment pharmacokinetic model with subject-level random effects
-on clearance and volume using a Laplace approximation.
+This example fits an exponential-decay model with a subject-level random intercept by Laplace
+approximation. The snippet is self-contained — copy it into a Julia session and run.
 
 ```julia
-using NoLimits, DataFrames, Distributions, OrdinaryDiffEq, Random
+using NoLimits, DataFrames, Distributions, Plots
 
-# --- 1. Define the model ---
 model = @Model begin
     @fixedEffects begin
-        log_cl   = RealNumber(log(5.0))           # log-clearance (population)
-        log_v    = RealNumber(log(30.0))          # log-volume (population)
-        omega_cl = RealNumber(0.3, scale=:log)    # RE SD for clearance
-        omega_v  = RealNumber(0.3, scale=:log)    # RE SD for volume
-        sigma    = RealNumber(0.2, scale=:log)    # residual SD
+        A0    = RealNumber(10.0, scale=:log)   # population baseline
+        k     = RealNumber(0.5,  scale=:log)   # population decay rate
+        omega = RealNumber(0.3,  scale=:log)   # between-subject SD
+        sigma = RealNumber(0.5,  scale=:log)   # residual SD
     end
 
     @covariates begin
-        t = Covariate()                           # observation time column
+        time = Covariate()
     end
 
     @randomEffects begin
-        eta_cl = RandomEffect(Normal(0.0, omega_cl); column=:ID)
-        eta_v  = RandomEffect(Normal(0.0, omega_v);  column=:ID)
-    end
-
-    @preDifferentialEquation begin
-        cl = exp(log_cl + eta_cl)
-        v  = exp(log_v  + eta_v)
-    end
-
-    @DifferentialEquation begin
-        D(A) ~ -(cl / v) * A                      # one-compartment elimination
-    end
-
-    @initialDE begin
-        A = 100.0                                 # bolus dose at t = 0
+        eta = RandomEffect(Normal(0.0, omega); column=:ID)
     end
 
     @formulas begin
-        conc = A(t) / v
-        y ~ Normal(conc, sigma)
+        pred = A0 * exp(eta) * exp(-k * time)
+        y ~ Normal(pred, sigma)
     end
 end
 
-# --- 2. Simulate a small dataset (or bring your own DataFrame with columns :ID, :t, :y) ---
-rng   = MersenneTwister(1)
-times = [0.5, 1.0, 2.0, 4.0, 8.0, 12.0, 24.0]
-df = DataFrame(ID=Int[], t=Float64[], y=Float64[])
-for id in 1:12
-    cl = 5.0  * exp(0.3 * randn(rng))      # subject-specific clearance
-    v  = 30.0 * exp(0.3 * randn(rng))      # subject-specific volume
-    for t in times
-        conc = (100.0 / v) * exp(-(cl / v) * t)
-        push!(df, (id, t, conc + 0.2 * randn(rng)))
-    end
-end
+df = DataFrame(
+    ID   = repeat([:s1, :s2, :s3, :s4], inner=4),
+    time = repeat([0.0, 1.0, 2.0, 4.0], outer=4),
+    y    = [10.2, 6.1, 3.6, 1.4, 12.5, 7.8, 4.9, 1.9,
+             8.1, 4.9, 3.0, 1.1, 11.0, 6.5, 4.1, 1.6],
+)
 
-# --- 3. Bind to data ---
-dm = DataModel(model, df; primary_id=:ID, time_col=:t)
-
-# --- 4. Fit ---
+dm  = DataModel(model, df; primary_id=:ID, time_col=:time)
 res = fit_model(dm, Laplace())
 
-# --- 5. Inspect results ---
-get_params(res; scale=:untransformed)
-re  = get_random_effects(res)
-uq  = compute_uq(res; method=:wald)
-
-# --- 6. Diagnostics ---
-plot_fits(res)
-plot_vpc(res; n_simulations=200)
-plot_residuals(res)
+get_params(res; scale=:untransformed)   # population estimates
+get_random_effects(res)                 # per-subject effects
+compute_uq(res; method=:wald)           # uncertainty
+plot_fits(res)                          # fit vs. data
 ```
 
 Swapping the inference paradigm is a one-line change: `fit_model(dm, SAEM())`, `fit_model(dm, MCEM())`,
-or `fit_model(dm, MCMC())` all fit the *same* model. More examples (neural-ODE models, Markov-model
+or `fit_model(dm, MCMC())` all fit the *same* model. More examples — neural-ODE models, Markov-model
 outcomes, normalizing-flow random effects, count outcomes, censored data, and multi-method
-comparison) are in the [Tutorials](https://manuhuth.github.io/NoLimits.jl/dev/tutorials/mixed-effects-multiple-methods).
+comparison — are in the [Tutorials](https://manuhuth.github.io/NoLimits.jl/dev/tutorials/mixed-effects-multiple-methods).
 
 ## Built on the Julia ecosystem
 
-NoLimits.jl integrates directly with established Julia packages, so users familiar with any of
-them will find the interfaces immediately recognizable. It interfaces with
+NoLimits.jl builds directly on established Julia packages, so their interfaces stay familiar:
 [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl) for ODE solving,
-[Distributions.jl](https://github.com/JuliaStats/Distributions.jl) for observation and
-random-effect distributions,
-[Optimization.jl](https://github.com/SciML/Optimization.jl) for numerical optimization,
-[Turing.jl](https://github.com/TuringLang/Turing.jl) and
-[MCMCChains.jl](https://github.com/TuringLang/MCMCChains.jl) for MCMC sampling and diagnostics,
-[Lux.jl](https://github.com/LuxDL/Lux.jl) and
+[Distributions.jl](https://github.com/JuliaStats/Distributions.jl) for outcome and random-effect
+distributions, [Turing.jl](https://github.com/TuringLang/Turing.jl) for MCMC and variational
+inference, [Lux.jl](https://github.com/LuxDL/Lux.jl) and
 [SimpleChains.jl](https://github.com/PumasAI/SimpleChains.jl) for neural-network components,
-[ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) for automatic differentiation,
-[ComponentArrays.jl](https://github.com/jonniedie/ComponentArrays.jl) for named parameter arrays,
-[DataFrames.jl](https://github.com/JuliaData/DataFrames.jl) for tabular data,
-[DataInterpolations.jl](https://github.com/SciML/DataInterpolations.jl) for dynamic covariates,
-[LikelihoodProfiler.jl](https://github.com/insysbio/LikelihoodProfiler.jl) for profile-likelihood
-uncertainty quantification, and [Plots.jl](https://github.com/JuliaPlots/Plots.jl) for visualization.
+[ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) for automatic differentiation, and
+[Optimization.jl](https://github.com/SciML/Optimization.jl) for optimization — among others.
 
 ## Documentation
 
@@ -246,9 +201,8 @@ Full documentation is hosted at **[manuhuth.github.io/NoLimits.jl](https://manuh
 
 ## Citation
 
-If you use NoLimits.jl in published work, please cite the software. GitHub's
-**"Cite this repository"** button (generated from [`CITATION.cff`](CITATION.cff)) provides
-ready-made APA and BibTeX exports; the BibTeX entry is:
+If you use NoLimits.jl in published work, please cite it — GitHub's **"Cite this repository"**
+button (from [`CITATION.cff`](CITATION.cff)) provides APA and BibTeX exports:
 
 ```bibtex
 @software{NoLimits_jl_2026,
@@ -261,12 +215,11 @@ ready-made APA and BibTeX exports; the BibTeX entry is:
 
 ## Development and AI assistance
 
-NoLimits.jl was developed with substantial assistance from large language models,
-primarily Anthropic's Claude (via Claude Code), used for code generation, refactoring,
-test authoring, and documentation. All contributions were reviewed, tested, and are
-understood by the maintainers, who take full responsibility for the correctness and
-behavior of the package. This disclosure follows the Julia General Registry's guidance on
-AI-assisted packages.
+NoLimits.jl was developed with substantial assistance from large language models, primarily
+Anthropic's Claude (via Claude Code), for code generation, refactoring, test authoring, and
+documentation. All contributions were reviewed, tested, and are understood by the maintainers,
+who take full responsibility for the package — disclosed per the Julia General Registry's
+guidance on AI-assisted packages.
 
 ## License
 

--- a/docs/src/developers-guide.md
+++ b/docs/src/developers-guide.md
@@ -59,12 +59,27 @@ against the `[compat]` bounds in `Project.toml`.
 
 A few conventions are load-bearing and enforced throughout the codebase:
 
-- **ForwardDiff compatibility.** All model and likelihood code must be differentiable with
-  ForwardDiff; this requires non-mutating implementations on the differentiated paths.
-- **Accessor functions.** Struct fields are accessed through `get_*` accessor functions
-  rather than direct field access, both internally and in the public API.
+- **Differentiability.** All model and likelihood code must be differentiable. ForwardDiff, the
+  default backend, propagates `Dual` numbers and handles in-place mutation fine; what it needs is
+  *type-generic* code that lets a `Dual` flow through, so allocate temporaries from the input
+  element type (`similar(x)`, `zeros(eltype(x), n)`) rather than a hard-coded `Float64`.
+  Non-mutating implementations are required only on paths that also run through a reverse-mode
+  backend such as Zygote (used for VI and normalizing flows), which cannot differentiate array
+  mutation. See [Helpers](model-building/helpers.md).
+- **Accessor functions.** Struct fields are reached through `get_*` accessor functions rather
+  than direct field access. This applies internally and, above all, in the public API: every
+  user-facing type ships `get_*` accessors, so users never have to reach into a struct with dot
+  syntax. Field layout is an implementation detail and may change between versions.
 - **`ComponentArray` construction.** Reuse existing axes with
   `ComponentArray(values, getaxes(existing))` rather than reconstructing axes.
+- **Formatting (JuliaFormatter).** Source, tests, and docs follow the SciML style, pinned in
+  `.JuliaFormatter.toml` (`style = "sciml"`). Run
+  [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl) v1 before committing
+  (`julia -e 'using JuliaFormatter; format(["src", "test", "docs"])'`), since the `Format` CI job
+  fails on any diff. Use v1 specifically; v2 formats differently and produces spurious diffs.
+- **Static quality (Aqua.jl).** `test/aqua_tests.jl` runs `Aqua.test_all(NoLimits)` with no
+  ignore lists, so contributions must keep method ambiguities at zero, avoid type piracy, and
+  give every dependency a `[compat]` entry. It runs as part of the test suite.
 
 See the source of an existing estimation method (for example `src/estimation/laplace.jl`)
 for the expected style when adding a new method.
@@ -129,7 +144,10 @@ Releases follow the standard Julia workflow:
 
 1. Bump the `version` field in `Project.toml` (semantic versioning) and update any
    `[compat]` bounds as needed.
-2. Merge to `main`; continuous integration runs the test suite and builds the documentation.
+2. Open a pull request against `main` and wait for continuous integration to pass. `main` is a
+   protected branch: it accepts no direct pushes, and a pull request can be merged only after the
+   required CI checks (test suite, formatting, and documentation build) are green. This is
+   enforced for maintainers too.
 3. Register the new version in the Julia General registry (e.g. via the Registrator bot).
    `TagBot` then creates the matching Git tag and GitHub release automatically, and the
    documentation for the tagged version is deployed to GitHub Pages.

--- a/docs/src/estimation/cv.md
+++ b/docs/src/estimation/cv.md
@@ -16,7 +16,7 @@ Two splitting strategies are available via the `kind` keyword:
 | `:id` | Whole individuals are assigned to folds. Test individuals are entirely absent from training - the unseen-individual prediction strategy applies to all of them. |
 | `:observation` | Observations from each individual are distributed across folds using a floor/ceiling round-robin. Event rows (dosing, resets) are always included in both train and test, so the ODE can be integrated correctly on either subset. |
 
-`:id`-wise CV measures generalisation to new subjects; `:observation`-wise CV measures how well the model interpolates within a subject's time series given a subset of their observations.
+`:id`-wise CV measures generalization to new subjects; `:observation`-wise CV measures how well the model interpolates within a subject's time series given a subset of their observations.
 
 ## Random-Effects Prediction Modes
 
@@ -190,7 +190,7 @@ println(first(os, 5))
 ## Example: ID-Wise CV with Conditional MC for Seen Subjects
 
 When `kind=:id`, some subjects are entirely absent from training. The defaults
-use the prior mean for unseen subjects. To instead marginalise over 50 draws
+use the prior mean for unseen subjects. To instead marginalize over 50 draws
 from the conditional posterior for seen subjects:
 
 ```julia

--- a/docs/src/estimation/ghquadrature.md
+++ b/docs/src/estimation/ghquadrature.md
@@ -40,7 +40,7 @@ Discrete distributions (`Poisson`, `Bernoulli`, etc.) are not supported and rais
 
 As a consequence:
 
-- When the data are highly informative and the posterior mode lies far from the prior mean, the nodes may miss the region of highest likelihood. In that case, the signed logsumexp can become numerically negative (especially at level ≥ 2), signalling poor quadrature accuracy.
+- When the data are highly informative and the posterior mode lies far from the prior mean, the nodes may miss the region of highest likelihood. In that case, the signed logsumexp can become numerically negative (especially at level ≥ 2), signaling poor quadrature accuracy.
 - The method works best when the posterior is roughly centered on the prior - for example, with moderate-information data, well-calibrated priors, or Gaussian random effects where the prior is a reasonable envelope for the posterior.
 - Level 1 in the current (prior-centered) form is **not** equivalent to the Laplace approximation. That equivalence holds only for the adaptive (posterior-centered) variant, which is not yet implemented.
 

--- a/docs/src/estimation/laplace.md
+++ b/docs/src/estimation/laplace.md
@@ -166,7 +166,7 @@ laplace_global_outer = NoLimits.Laplace(;
 
 ### Detailed Behavior
 
-This section explains the behaviour of the options whose effect is not obvious from their name. See the [`Laplace`](@ref) entry in the API reference for the complete keyword list and defaults.
+This section explains the behavior of the options whose effect is not obvious from their name. See the [`Laplace`](@ref) entry in the API reference for the complete keyword list and defaults.
 
 - `inner_grad_tol=:auto` resolves to `1e-8` for non-ODE models and `1e-2` for ODE models.
 - `multistart_sampling` supports `:lhs` (Latin hypercube sampling) and `:random`.

--- a/docs/src/estimation/saem.md
+++ b/docs/src/estimation/saem.md
@@ -232,7 +232,7 @@ When the M-step is performed numerically (i.e., no closed-form update is provide
   - Default: `(; iterations=10, g_abstol=1e-4, f_reltol=1e-6)`. The inner LBFGS is capped at 10 iterations per SAEM step; the outer SA loop provides the global convergence trajectory.
 - `mstep_sa_on_params`
   - When `true` (default), the M-step optimizes only the current iteration's samples and applies a Robbins-Monro parameter update: `θ_new = θ_old + γ*(θ̂ - θ_old)`. The ring buffer is capped to capacity 1, eliminating storage and reweighting overhead from previous snapshots. This is significantly more memory-efficient than the ring-buffer path and is the recommended mode.
-  - When `false`, the M-step minimizes the full ring-buffer Q-function and sets `θ_new = θ̂` directly. Useful as a diagnostic or when you want the classical ring-buffer SAEM behaviour.
+  - When `false`, the M-step minimizes the full ring-buffer Q-function and sets `θ_new = θ̂` directly. Useful as a diagnostic or when you want the classical ring-buffer SAEM behavior.
 
 SAEM uses the SciML [Optimization.jl](https://docs.sciml.ai/Optimization/stable/) interface for numerical M-step updates.
 
@@ -345,9 +345,9 @@ These arguments control the ring buffer used for numerical Q evaluation (the pat
 - `q_store_epsilon` (default `1e-10`)
   - Weight pruning threshold. After each push, snapshots whose SA weight falls below
     this value are removed from the oldest end of the buffer (subject to `q_store_min`).
-    During the γ=1 stabilisation phase all previous snapshots are immediately pruned,
+    During the γ=1 stabilization phase all previous snapshots are immediately pruned,
     keeping only the current iteration's sample in the buffer.
-  - The retained weights are renormalised to sum to 1 before evaluating Q, so the
+  - The retained weights are renormalized to sum to 1 before evaluating Q, so the
     objective is scale-invariant to pruning.
   - Has no effect when `suffstats` is provided; a warning is emitted if set to a
     non-default value alongside `suffstats`.
@@ -465,7 +465,7 @@ res = fit_model(dm, SAEM(sampler=AdaptiveNoLimitsMH()))
 Constructor keywords:
 - `adapt_start::Int = 50`: pooled sample count before Haario updates activate.
 - `init_scale::Float64 = 1.0`: multiplier on the prior-based initial proposal covariance.
-- `eps_reg::Float64 = 1e-6`: regularisation added to the diagonal to ensure positive-definiteness.
+- `eps_reg::Float64 = 1e-6`: regularization added to the diagonal to ensure positive-definiteness.
 
 `AdaptiveNoLimitsMH` is most useful when the RE posterior covariance differs substantially from the prior, when REs are correlated (`MvNormal` with `d ≥ 2`), or when the prior is weakly informative.
 

--- a/docs/src/how-to-contribute.md
+++ b/docs/src/how-to-contribute.md
@@ -16,8 +16,8 @@ improvements, and code.
 
 1. Fork the repository and create a topic branch from `main`.
 2. Set up the development environment and read the conventions in the
-   [Developers Guide](developers-guide.md) - in particular ForwardDiff compatibility
-   (non-mutating differentiated paths) and the `get_*` accessor pattern.
+   [Developers Guide](developers-guide.md) - in particular the differentiability, formatting,
+   and `get_*` accessor conventions.
 3. Make your change with accompanying tests. New functionality should add or extend a file
    under `test/` and stay wired into `test/runtests.jl`.
 4. Run the test suite locally before opening a pull request:

--- a/docs/src/model-building/fixed-effects.md
+++ b/docs/src/model-building/fixed-effects.md
@@ -85,13 +85,13 @@ priors = get_priors(fe)
 lp = logprior(fe, theta_u)
 ```
 
-The behaviour of each scale option is summarized below:
+The behavior of each scale option is summarized below:
 
 - **`:log` scale** applies an elementwise log transform and is supported for `RealNumber`, `RealVector`, and `RealDiagonalMatrix`. For inherently positive quantities such as standard deviations, `:log` enforces positivity in transformed space; an explicit `lower` bound is therefore optional.
 - **`:logit` scale** applies the logit transform (`log(x/(1-x))`, clamped to `[-20, 20]`) and is supported for `RealNumber` and `RealVector`. Use this for parameters that must lie in `(0, 1)`, such as probabilities. The inverse is the sigmoid function. The initial value must be strictly between 0 and 1; the constructor errors otherwise. Bounds are enforced implicitly via clamping - no explicit `lower`/`upper` are needed.
 - **`:cholesky`** (for `RealPSDMatrix`) parameterizes the matrix via its Cholesky factor with log-transformed diagonal entries.
 - **`:expm`** (for `RealPSDMatrix`) parameterizes the matrix via matrix logarithm/exponential, storing only the upper-triangular elements.
-- **`:stickbreak`** (for `ProbabilityVector`) maps a k-probability simplex to k-1 unconstrained reals via the logistic stick-breaking transform. Each element νᵢ = pᵢ/(1-Σⱼ<ᵢ pⱼ) is passed through logit. The last probability is determined and not stored. Silently normalises the initial value if the sum is within 1e-6 of 1.
+- **`:stickbreak`** (for `ProbabilityVector`) maps a k-probability simplex to k-1 unconstrained reals via the logistic stick-breaking transform. Each element νᵢ = pᵢ/(1-Σⱼ<ᵢ pⱼ) is passed through logit. The last probability is determined and not stored. Silently normalizes the initial value if the sum is within 1e-6 of 1.
 - **`:stickbreakrows`** (for `DiscreteTransitionMatrix`) applies the stick-breaking transform independently to each row of an n×n row-stochastic matrix, yielding n*(n-1) unconstrained parameters.
 - **`:lograterows`** (for `ContinuousTransitionMatrix`) maps each off-diagonal entry of a rate matrix to its logarithm, yielding n*(n-1) unconstrained reals. The diagonal is always recomputed as minus the row sum and is never stored as a free parameter. Initial off-diagonal values must be non-negative.
 

--- a/docs/src/model-building/formulas.md
+++ b/docs/src/model-building/formulas.md
@@ -212,7 +212,7 @@ DiscreteTimeObservedStatesMarkovModel(transition_matrix, initial_dist, state_lab
 The **third argument is `state_labels`** - a vector giving one label per state, whose
 length must equal the number of states (the size of `transition_matrix`). It maps state
 index → label and defaults to `[1, 2, ..., n_states]` if omitted. In the example below
-`[2, 3]` simply means the two states are labelled `2` and `3` (it is *not* a set of
+`[2, 3]` simply means the two states are labeled `2` and `3` (it is *not* a set of
 observed values).
 
 `state_labels` is distinct from the *coarsened observation* encoding used in the data. To
@@ -238,7 +238,7 @@ model = @Model begin
             DiscreteTimeObservedStatesMarkovModel(
                 P,
                 Categorical([0.5, 0.5]),  # prior over states at the previous time
-                [2, 3],                   # state_labels: the two states are labelled 2 and 3
+                [2, 3],                   # state_labels: the two states are labeled 2 and 3
             )
         )
     end
@@ -259,7 +259,7 @@ When each observation consists of several outcome variables that share the same 
 Two emission modes are supported:
 
 - **Conditionally independent**: the emission for state `k` is a `Tuple` of M scalar distributions, one per outcome. Missing entries in the observation vector are skipped (contribute zero log-likelihood).
-- **Joint `MvNormal`**: the emission for state `k` is a single `MvNormal`. Partial missings are handled by marginalising analytically over the observed indices.
+- **Joint `MvNormal`**: the emission for state `k` is a single `MvNormal`. Partial missings are handled by marginalizing analytically over the observed indices.
 
 ### Discrete time, conditionally independent emissions
 
@@ -331,7 +331,7 @@ model = @Model begin
 end
 ```
 
-Here `delta_t` is a time-varying covariate holding the elapsed time since the previous observation for each row. The `outcome` column must hold two-element vectors matching the dimension of the `MvNormal` emissions. Partially-missing vectors (e.g. `[1.2, missing]`) are handled by marginalising the `MvNormal` over the observed index.
+Here `delta_t` is a time-varying covariate holding the elapsed time since the previous observation for each row. The `outcome` column must hold two-element vectors matching the dimension of the `MvNormal` emissions. Partially-missing vectors (e.g. `[1.2, missing]`) are handled by marginalizing the `MvNormal` over the observed index.
 
 ## Related APIs
 

--- a/docs/src/plotting/index.md
+++ b/docs/src/plotting/index.md
@@ -138,7 +138,7 @@ p_ms
 
 Comparing fitted trajectories from different estimation methods or model specifications is a natural step in model selection. `plot_fits_comparison` overlays trajectories from multiple fit results on the same individual panels, making differences in structural predictions immediately visible.
 
-For vectors, legend labels are assigned as `Model 1`, `Model 2`, and so on in input order. For `NamedTuple` and `Dict` inputs, the provided keys serve as legend labels. Per-model line styles can be customized through `PlotStyle(comparison_line_styles=Dict(...))`; `PlotStyle` is the shared styling object accepted by all plotting functions (colours, line styles, layout) - see its docstring in the API reference for the full set of fields. The `individuals_idx` keyword (here `1:2`) restricts the panels to the selected individuals.
+For vectors, legend labels are assigned as `Model 1`, `Model 2`, and so on in input order. For `NamedTuple` and `Dict` inputs, the provided keys serve as legend labels. Per-model line styles can be customized through `PlotStyle(comparison_line_styles=Dict(...))`; `PlotStyle` is the shared styling object accepted by all plotting functions (colors, line styles, layout) - see its docstring in the API reference for the full set of fields. The `individuals_idx` keyword (here `1:2`) restricts the panels to the selected individuals.
 
 ```@example plotting_overview
 saem_quick = NoLimits.SAEM(;
@@ -218,7 +218,7 @@ The `residual` keyword chooses which residual metric to plot (one of the columns
 
 ## Visual predictive check
 
-The visual predictive check (VPC) is a widely used diagnostic in longitudinal modelling. It evaluates a model's ability to reproduce the distribution of observed data through simulation. `plot_vpc` generates predictive envelopes from repeated simulations under the fitted model and overlays them on the observed data summaries. Agreement between the simulated envelopes and observed trends indicates that the model captures both the central tendency and the variability structure of the data.
+The visual predictive check (VPC) is a widely used diagnostic in longitudinal modeling. It evaluates a model's ability to reproduce the distribution of observed data through simulation. `plot_vpc` generates predictive envelopes from repeated simulations under the fitted model and overlays them on the observed data summaries. Agreement between the simulated envelopes and observed trends indicates that the model captures both the central tendency and the variability structure of the data.
 
 ```@example plotting_overview
 p_vpc = plot_vpc(res; n_simulations=20, percentiles=[5, 50, 95])

--- a/docs/src/tutorials/fixed-effects-nonlinear-mle-map.md
+++ b/docs/src/tutorials/fixed-effects-nonlinear-mle-map.md
@@ -1,21 +1,17 @@
 # Fixed-Effects Tutorial 1: Nonlinear Longitudinal Model (MLE + MAP)
 
-Many biological processes - organ growth, tumor progression, enzyme saturation - follow sigmoidal trajectories that cannot be captured by linear regression. Fitting such curves to repeated measurements collected over time is a core task in longitudinal data analysis. In this tutorial, you will build a logistic growth model for tree-trunk circumference data, estimate its parameters with two complementary methods (maximum likelihood and maximum a posteriori), and examine how prior information shapes the result. No random effects are introduced here; a later tutorial extends the same model to account for inter-subject variability.
+Many biological processes — organ growth, tumour progression, enzyme saturation — follow sigmoidal trajectories that linear regression cannot capture. This tutorial builds a logistic growth model for tree-trunk circumference data and estimates its parameters by maximum likelihood (MLE) and maximum a posteriori (MAP), showing how prior information shapes the fit. Random effects are omitted here; a [later tutorial](mixed-effects-multiple-methods.md) adds between-subject variability.
 
 ## What You Will Learn
 
-This tutorial walks through the complete modelling cycle for a fixed-effects nonlinear model in NoLimits.jl. Along the way you will learn how to:
-
-- **Translate a scientific growth equation** into a NoLimits model specification.
-- **Connect that specification to observed data** by constructing a `DataModel`.
-- **Estimate parameters under two philosophies.** Maximum likelihood estimation (MLE) finds the parameter values that make the observed data most probable, treating the likelihood as the sole objective. Maximum a posteriori estimation (MAP) augments the likelihood with prior distributions on the parameters, which can improve numerical stability when some parameters are weakly identified - a common situation with sigmoidal models whose asymptote or inflection point lies outside the observed time window.
-- **Compare and diagnose** the resulting estimates by visualising fitted trajectories and inspecting observation-level distributions.
-
-By the end, you will have a working template that you can adapt to your own nonlinear longitudinal datasets.
+- Translate a growth equation into a NoLimits model specification.
+- Pair it with data in a `DataModel`.
+- Estimate parameters by MLE and MAP, and read the effect of priors.
+- Diagnose the fit with trajectory and observation-distribution plots.
 
 ## Step 1: Load the Data
 
-In this step, you will load the dataset used throughout the tutorial: the classic Orange tree growth study, originally published by Draper and Smith and available in R as `datasets::Orange`. It records the trunk circumference of five orange trees measured at seven time points each, making it a compact but representative example of nonlinear longitudinal data.
+The classic Orange tree growth study (Draper and Smith; R's `datasets::Orange`) records trunk circumference for five trees at seven time points each — a compact, representative example of nonlinear longitudinal data.
 
 ```julia
 using NoLimits
@@ -51,17 +47,15 @@ first(df, 8)
    8 │        8      2    118             33
 ```
 
-Each row records one measurement occasion. The `Tree` column identifies the individual, `age` gives the tree's age in days since planting, and `circumference` is the trunk circumference in millimetres. Because every tree is measured at the same set of ages, this is a balanced design - convenient for illustration, though NoLimits.jl handles unbalanced data equally well.
+Each row is one measurement: `Tree` identifies the individual, `age` is days since planting, and `circumference` is the trunk circumference in millimeters. The design is balanced (every tree shares the same ages), though NoLimits.jl handles unbalanced data equally well.
 
 ## Step 2: Define a Nonlinear Fixed-Effects Model
 
-In this step, you will express the scientific model as a NoLimits model specification. The structural model is a three-parameter logistic growth curve, one of the simplest sigmoidal functions used in biology:
+The structural model is a three-parameter logistic growth curve:
 
 $$\mu(t) = \frac{a}{1 + \exp\!\bigl(-k\,(t - t_0)\bigr)}$$
 
-Here, `a` sets the upper asymptote (the maximum circumference the model can predict), `k` controls the steepness of the growth phase, and `t0` locates the inflection point - the age at which growth is fastest. Observations are assumed normally distributed around this deterministic trajectory with standard deviation `sigma`.
-
-Notice that we also attach prior distributions to each parameter. MLE will ignore these priors entirely, but they become essential for MAP estimation in Step 4. The priors encode only weak domain knowledge: circumferences are positive and on the order of tens to hundreds of millimetres, growth rates are small and positive, and the inflection point falls somewhere within the range of observed ages.
+`a` is the upper asymptote, `k` the growth-phase steepness, and `t0` the inflection point (the age of fastest growth); observations are Normal around this curve with standard deviation `σ`. Each parameter also carries a weakly-informative prior — ignored by MLE, but used by MAP in Step 4.
 
 ```julia
 using NoLimits
@@ -86,11 +80,11 @@ model = @Model begin
 end
 ```
 
-A few points worth noting about this specification. The `@covariates` block declares `age` as a time-varying covariate, which tells NoLimits to look up a column called `age` in the data frame. The residual standard deviation `sigma` is parameterised on the log scale (`scale=:log`), which constrains it to be strictly positive during optimisation without requiring explicit bounds. Finally, the `@formulas` block first computes the deterministic prediction `mu` and then declares that the observed column `circumference` follows a normal distribution centred on that prediction.
+`@covariates` declares `age` as a time-varying covariate (read from the column of the same name). `σ` is parameterized on the log scale (`scale=:log`) to stay positive without explicit bounds. `@formulas` computes the deterministic mean `μ`, then ties the observed `circumference` to it through a Normal.
 
 ### Model Summary
 
-Before fitting, it is good practice to inspect the model structure programmatically. The summary confirms which parameters are declared as fixed effects, which covariates are expected, and what form the observation model takes.
+`summarize` confirms the declared fixed effects, expected covariates, and observation model:
 
 ```julia
 model_summary = NoLimits.summarize(model)
@@ -157,7 +151,7 @@ Helper functions
 
 ## Step 3: Build the DataModel and Configure Estimation
 
-With the model and data in hand, you will now pair them into a `DataModel` - the central object that validates the data against the model specification and prepares the internal structures needed for estimation. In the same step, you will configure the two estimation methods (MLE and MAP), specifying a maximum of 500 optimiser iterations for each.
+A `DataModel` validates the data against the model and prepares the internal structures for estimation. We also configure the two estimators (500 iterations each).
 
 ```julia
 dm = DataModel(model, df; primary_id=:Tree, time_col=:age)
@@ -168,11 +162,11 @@ map_method = NoLimits.MAP(; optim_kwargs=(maxiters=500,))
 serialization = SciMLBase.EnsembleThreads()
 ```
 
-The `primary_id=:Tree` argument tells NoLimits which column identifies individuals, and `time_col=:age` specifies the time axis. Setting `serialization=EnsembleThreads()` enables multi-threaded likelihood evaluation across individuals - a minor convenience here with only five trees, but essential for larger datasets where per-individual computations dominate runtime.
+`primary_id=:Tree` identifies individuals and `time_col=:age` sets the time axis; `EnsembleThreads()` evaluates the per-individual likelihood in parallel — minor here, but valuable on larger datasets.
 
 ### DataModel Summary
 
-It is worth verifying that the data were parsed correctly. The summary should confirm five individuals, seven observations each, no missing values, and no events.
+The summary confirms five individuals, seven observations each, no missing values, and no events.
 
 ```julia
 dm_summary = NoLimits.summarize(dm)
@@ -244,7 +238,7 @@ Covariate descriptive statistics (observation rows)
 
 ## Step 4: Fit with MLE and MAP
 
-You are now ready to estimate the model parameters under both methods. Each call to `fit_model` runs a gradient-based optimiser (L-BFGS by default), starting from the initial values declared in the `@fixedEffects` block. The key difference lies in the objective function: MLE maximises the log-likelihood alone, while MAP maximises the log-likelihood plus the log-prior.
+Each `fit_model` call runs the default L-BFGS optimizer from the declared initial values. MLE and MAP differ only in the objective: MLE uses the log-likelihood, MAP adds the log-prior, which can stabilize weakly identified parameters (see [MLE / MAP](../estimation/mle.md)).
 
 ```julia
 res_mle = fit_model(dm, mle_method; serialization=serialization, rng=Random.Xoshiro(41))
@@ -261,9 +255,9 @@ res_map = fit_model(dm, map_method; serialization=serialization, rng=Random.Xosh
 (objective_mle = 158.39871272191726, objective_map = 168.53669404545343)
 ```
 
-The returned objective values are negative log-likelihoods (for MLE) or negative log-posteriors (for MAP), so lower values indicate a better fit. Because the MAP objective includes additional prior penalty terms, its numerical value is not directly comparable to the MLE objective; what matters at this stage is that each method converged successfully.
+These objectives are negative log-likelihood (MLE) and negative log-posterior (MAP); the extra prior terms make the MAP value not directly comparable to MLE's.
 
-To verify convergence and examine standard errors, you can request a detailed fit summary. This reports convergence status, the final objective value, and standard errors for all parameters whose `calculate_se` flag was set to `true`.
+The fit summary reports convergence, the final objective, and standard errors for every parameter with `calculate_se=true`:
 
 ```julia
 fit_summary_mle = NoLimits.summarize(res_mle)
@@ -301,7 +295,7 @@ Outcome data coverage
 
 ## Step 5: Compare Parameter Estimates
 
-With both fits complete, you can now extract the estimated parameters on the original (untransformed) scale and compare them side by side.
+Extract the estimates on the natural (untransformed) scale and compare them side by side:
 
 ```julia
 θ_mle = NoLimits.get_params(res_mle; scale=:untransformed)
@@ -318,11 +312,11 @@ With both fits complete, you can now extract the estimated parameters on the ori
 (mle = (a = 192.68759193577552, k = 0.002828584934064404, t0 = 728.7563832627657, σ = 22.34804785876128), map = (a = 191.8757304534822, k = 0.0028588792012859006, t0 = 724.0263172113838, σ = 22.184112443700283))
 ```
 
-Because this dataset is relatively small (35 observations total), the priors exert a noticeable pull on the MAP estimates. In particular, parameters whose likelihood surface is flat - such as the asymptote `a`, which is only weakly constrained when few trees have approached their maximum size - will be drawn toward the prior mean under MAP but left at the pure likelihood optimum under MLE. As sample size grows, the likelihood dominates and the two methods converge to the same values. This behaviour serves as a useful diagnostic: large MLE-MAP discrepancies flag parameters that the data alone cannot pin down precisely.
+With only 35 observations the priors pull the MAP estimates noticeably, most so for weakly-constrained parameters like the asymptote `a` (few trees have neared their maximum size): MLE leaves it at the pure likelihood optimum, MAP shrinks it toward the prior mean. The gap closes as data accumulate, so a large MLE–MAP discrepancy flags a parameter the data alone cannot pin down.
 
 ## Step 6: Fitted Trajectories
 
-Plotting model predictions against raw observations is the most direct way to assess goodness of fit. In this step, you will overlay the estimated logistic curves on the data for the first two trees under each estimation method.
+Overlaying predictions on the raw data is the most direct goodness-of-fit check ([plotting reference](../plotting/index.md)). Here are the fitted curves for the first two trees under each method.
 
 ```julia
 inds = [1, 2]
@@ -355,7 +349,7 @@ p_fit_mle
 <!- injected:fe1-pfitmle ->
 ![Fitted population logistic trajectories under MLE for the first two trees.](figures/fe1/p_fit_mle.png)
 
-Because there are no random effects in this model, every tree is predicted by the same population-level curve. Deviations between the curve and individual data points therefore reflect both measurement noise and genuine between-tree variability that the current model does not capture. If these residual patterns appear systematic - for example, if one tree consistently lies above the curve while another lies below - that is a strong signal that random effects should be introduced (see the mixed-effects tutorials).
+With no random effects, every tree shares the same population curve, so deviations mix measurement noise with uncaptured between-tree variability. Systematic patterns — one tree consistently above the curve, another below — signal that random effects are needed (see the [mixed-effects tutorials](mixed-effects-multiple-methods.md)).
 
 MAP fit plot:
 
@@ -366,11 +360,11 @@ p_fit_map
 <!- injected:fe1-pfitmap ->
 ![Fitted population logistic trajectories under MAP for the first two trees.](figures/fe1/p_fit_map.png)
 
-The MAP trajectories may appear nearly identical to the MLE trajectories or show subtle shifts, depending on how informative the priors are relative to the data. Comparing the two plots is a quick visual assessment of prior influence.
+How far the MAP trajectories shift from the MLE ones is a quick visual read on prior influence.
 
 ## Step 7: Observation Distribution Diagnostics
 
-Beyond trajectory plots, it is informative to inspect the implied observation distribution at individual time points. In this step, you will plot the normal distribution predicted by the model at the first observation of the first tree, with the actual observed value marked. A well-calibrated model places observed values near the centre of the predicted distribution rather than in the tails.
+It also helps to inspect the predicted observation distribution at a single time point — here the first observation of the first tree, with the observed value marked. A well-calibrated model places observations near the center of the distribution, not in the tails.
 
 ```julia
 p_obs_mle = plot_observation_distributions(
@@ -406,13 +400,10 @@ p_obs_map
 <!- injected:fe1-pobsmap ->
 ![Predicted observation distribution at the first observation of the first tree (MAP).](figures/fe1/p_obs_map.png)
 
-If an observed value sits far in the tail of the predicted distribution, this may indicate model misspecification - for instance, a residual error distribution that is too narrow, or a structural model that systematically over- or under-predicts at certain ages.
+A value far in the tail points to misspecification — a residual distribution that is too narrow, or a structural model that systematically over- or under-predicts.
 
 ## Summary and Next Steps
 
-This tutorial demonstrated the end-to-end workflow for fixed-effects nonlinear modelling in NoLimits.jl: specifying a scientifically motivated structural model, pairing it with data, estimating parameters via MLE and MAP, and diagnosing the results. Several practical points are worth keeping in mind:
-
-- **MLE is purely data-driven.** It finds the parameter values that maximise the likelihood of the observed data. Declared priors have no effect on the MLE objective.
-- **MAP incorporates prior knowledge.** By adding log-prior terms to the objective, MAP can stabilise estimation when the data provide limited information about certain parameters - a common situation in nonlinear models with saturation or asymptotic behaviour.
-- **Fixed-effects models assume no between-subject variability.** Every individual is predicted by the same curve. When individual trajectories diverge systematically, random effects are needed to account for that heterogeneity. The mixed-effects tutorials show how to extend this model accordingly.
-- **Diagnostic tools are method-agnostic.** Whether you use MLE, MAP, or any other estimation method in NoLimits.jl, functions such as `plot_fits` and `plot_observation_distributions` work identically, making it straightforward to compare results across methods.
+- **MLE vs MAP.** MLE is purely data-driven; MAP adds log-prior terms that stabilize weakly identified parameters — common in nonlinear models with asymptotic behavior. Comparing them shows which parameters the data actually constrain.
+- **No random effects.** Every individual shares one curve; systematic per-tree deviations call for random effects — see the [mixed-effects tutorials](mixed-effects-multiple-methods.md).
+- **Diagnostics are method-agnostic.** `plot_fits` and `plot_observation_distributions` work identically across every estimator.

--- a/docs/src/tutorials/markov-models-observed-hidden-coarsed.md
+++ b/docs/src/tutorials/markov-models-observed-hidden-coarsed.md
@@ -1,25 +1,17 @@
 # Markov Models in NoLimits.jl: Observed, Hidden, Coarsed, and Pathsum
 
-Multi-state models are a natural framework for data in which an individual, system, or process moves between a finite number of discrete states over time. Rather than treating repeated observations as isolated outcomes, these models focus on the transitions between states: remaining where one is, moving forward, recovering, relapsing, or entering an absorbing state. This makes them useful across many settings, including disease progression, reliability analysis, behavioral processes, event history data, and longitudinal categorical outcomes.
+Multi-state models describe a process moving between a finite set of discrete states over time, focusing on the transitions — staying, progressing, recovering, relapsing, or being absorbed. Under the Markov property (the future depends only on the current state) the transition structure stays interpretable and tractable, and covariates, time, and random effects can shape it. This tutorial specifies and estimates four related Markov models in NoLimits:
 
-A common simplifying assumption is the Markov property: conditional on the current state, the future evolution of the process does not depend on the full past history. In practice, this assumption is often a useful modeling compromise. It captures the local dependence that is most directly observed in longitudinal state data, while keeping the transition structure interpretable and statistically tractable. Covariates, time effects, and subject-level random effects can then be used to explain differences in transition behavior across individuals or experimental units.
-
-In this tutorial, you will use NoLimits.jl to specify and estimate several Markov-type models for longitudinal state data. The examples illustrate how the same general idea - modeling movement through a discrete state space - can be adapted to different observation schemes and assumptions. We will consider four related models: 
-
-1. An observed Markov model, where the state sequence is directly measured; 
-2. A hidden Markov model, where the observed data are noisy proxies for an underlying latent state process; 
-3. A Markov model for set-valued observations, where each observation may correspond to multiple possible states; 
-4. An acyclic continuous-time Markov model, where the absence of cycles allows transition probabilities to be computed efficiently using the matrix exponential.
-
-Together, these examples show how Markov models can be used in NoLimits.jl to represent discrete dynamic systems, accommodate imperfect or partial state information, and move between discrete-time and continuous-time formulations.
+1. an **observed** Markov model, where the state sequence is measured directly;
+2. a **hidden** Markov model (HMM), where observations are noisy proxies for a latent state;
+3. a **coarsed** model, where each observation is a set of possible states;
+4. an **acyclic continuous-time** model, where the absence of cycles lets transition probabilities be computed by a fast path-sum.
 
 ## What You Will Learn
 
-By the end of this tutorial, you will be able to:
-
-- **Build** a Markov model in discrete and continuous time.
-- **Configure** the emission setup based on your modelling assumptions.
-- **Fit** DT-HMM and CT-HMM models in NoLimits to externally generated data.
+- Build Markov models in discrete and continuous time.
+- Configure the emission setup for your modeling assumptions.
+- Fit DT- and CT-HMM models to externally generated data.
 
 ## Step 0: Setup and Data generation
 
@@ -36,7 +28,7 @@ Random.seed!(2026)
 
 ### Define Relevant Model Components
 
-We use a 3-state setup as in the example scripts. To keep interpretation clear, we separate the components:
+We use a 3-state setup and separate the components:
 
 - `P_true`: discrete-time transition matrix for one-step transitions.
 - `Q_true`: continuous-time generator matrix for rate-based transitions across arbitrary `dt`.
@@ -71,7 +63,7 @@ B_true = [
 
 ### Generate Synthetic Data
 
-In this tutorial, data simulation is done manually with the following stpes:
+Data is simulated manually:
 
 - initial hidden-state draw from `pi_true`,
 - hidden-state transition draw from `P_true` (or `exp(Q_true*dt)`),
@@ -196,7 +188,7 @@ uq_par = uq = NoLimits.compute_uq(
 NoLimits.summarize(uq_par)
 ```
 
-**Note:** The parameters are named by the macro `@fixedEffects` based on the given parametrization and name. In this example the stick-breaking transform is applied toe ach row of the transition matrix, yielding a direct fit of the first two parameters in that row and the third is indirectly defined by the constrained, that row-sums are equal to one.
+**Note:** Parameters are named by `@fixedEffects` from the parametrization and name. The stick-breaking transform applies to each row of the transition matrix, fitting the first two entries per row directly; the third is determined by the row-sum-to-one constraint.
 
 ## Step 2: Fit a Continuous-Time HMM in NoLimits
 
@@ -394,9 +386,7 @@ This notebook focuses on fixed-effects HMMs for clarity, but the same NoLimits b
 - multivariate emissions
 - etc.
 
-Below is an example using covariate dependent transition rates on log-scale and emission with logistic parametrization.
-
-Using random effects also requires a different estimation method such as Laplace, SAEM or MCEM.
+Below is an example with covariate-dependent transition rates on the log scale and logistic-parametrized emissions. Random effects also require a marginal-likelihood estimator — [Laplace](../estimation/laplace.md), [SAEM](../estimation/saem.md), or [MCEM](../estimation/mcem.md).
 ```julia
 model_custom = @Model begin
     @covariates begin

--- a/docs/src/tutorials/mixed-effects-left-censored-virload50-laplace.md
+++ b/docs/src/tutorials/mixed-effects-left-censored-virload50-laplace.md
@@ -1,10 +1,6 @@
 # Mixed-Effects Tutorial 6: Left-Censored Nonlinear Model (Laplace)
 
-In many biomedical assays, measurements below a detection threshold cannot be reliably quantified. This situation, known as *left-censoring*, arises whenever an instrument's lower limit of quantification (LLOQ) truncates the observable range. HIV viral load monitoring is a canonical example: modern RT-PCR assays report "below detectable limit" for viral RNA concentrations under approximately 50 copies/mL - or equivalently, below about 1.7 on the log10 scale. In patients responding well to antiretroviral therapy, censored observations can account for 30-40% of all measurements, making proper statistical treatment essential.
-
-How should these below-limit values be handled? The answer matters. Dropping censored rows discards information and inflates uncertainty. Substituting the detection limit as though it were a true measurement concentrates probability mass at that value and biases parameter estimates downward. The principled approach is a *censored likelihood*: uncensored observations contribute their usual probability density, while censored observations contribute the cumulative probability of falling at or below the detection threshold. This formulation correctly encodes what we actually know - that the true value lies somewhere below the limit, without committing to a specific magnitude.
-
-In this tutorial, you will fit a nonlinear mixed-effects model to the `virload50` dataset from the `npde` R package, which contains longitudinal log10 viral load measurements from 50 HIV-positive patients. The structural model is a bi-exponential decay function that captures two distinct phases of viral dynamics: rapid initial suppression and slower long-term decline. Subject-specific parameters enter through `LogNormal` random effects, making the model nonlinear in the random effects. You will handle left-censoring directly in the observation model using NoLimits' `censored(...)` syntax and estimate the model with the Laplace approximation.
+In many biomedical assays, measurements below the lower limit of quantification (LLOQ) are *left-censored*: the value is known only to lie below a threshold. HIV viral load is the canonical case — assays report "undetectable" below ~50 copies/mL (≈1.7 on the log10 scale), and 30–40% of measurements can be censored in well-treated patients. Dropping these rows or substituting the limit biases estimates; the principled fix is a *censored likelihood*, where uncensored points contribute their density and censored points the cumulative probability of falling below the limit. This tutorial fits a bi-exponential decay model (fast then slow viral decline) to the `virload50` dataset (50 patients), with `LogNormal` random effects making it nonlinear in the random effects, using NoLimits' `censored(...)` syntax and the Laplace approximation.
 
 If your outcome is a discrete observed-state Markov model with ambiguous/set-valued state
 labels, use `coarsed(...)` instead of `censored(...)`. See the formulas documentation:
@@ -12,19 +8,14 @@ labels, use `coarsed(...)` instead of `censored(...)`. See the formulas document
 
 ## Learning Goals
 
-By the end of this tutorial, you will know how to:
-
-- **Prepare censored longitudinal data.** Structure a dataset where left-censored observations are flagged by an indicator variable and pinned at the detection limit value.
-- **Specify a nonlinear mixed-effects model.** Define subject-specific `LogNormal` random effects that parameterize a bi-exponential mean function, ensuring predicted viral loads remain positive.
-- **Encode left-censoring in the likelihood.** Use `censored(Normal(mu, sigma), lower=1.7, upper=Inf)` so that the likelihood automatically distinguishes between density contributions (for observed values) and cumulative probability contributions (for censored values).
-- **Estimate with the Laplace approximation.** Integrate over the random effects using a second-order expansion of the log-posterior around the empirical Bayes estimates.
-- **Diagnose and quantify uncertainty.** Inspect fitted trajectories, predictive observation distributions, and Wald-based confidence intervals for the fixed-effects parameters.
+- Flag left-censored observations and pin them at the detection limit.
+- Specify `LogNormal` random effects driving a bi-exponential mean.
+- Encode left-censoring with `censored(Normal(mu, sigma), lower=1.7, upper=Inf)`.
+- Estimate with Laplace, and diagnose with fits, observation distributions, and Wald intervals.
 
 ## Step 1: Data Setup
 
-In this step, you will load the `virload50` dataset and prepare it for modeling. The dataset contains four columns: a subject identifier (`ID`), observation time (`Time`), log10 viral load (`Log_VL`), and a censoring indicator (`cens`, where 1 flags values at or below the detection limit of 1.7). After selecting these columns, you will enforce the correct types and sort by subject and time - a requirement for the internal data structures used by NoLimits.
-
-The summary statistics printed at the end provide a quick overview of the dataset dimensions and the fraction of censored observations.
+The `virload50` dataset has four columns: `ID`, `Time`, log10 viral load `Log_VL`, and a censoring flag `cens` (1 at or below the detection limit of 1.7). We enforce types and sort by subject and time; the printed summary reports the dataset size and the censored fraction.
 
 ```julia
 using NoLimits
@@ -61,16 +52,16 @@ sort!(df, [:ID, :Time])
 
 ## Step 2: Define the Nonlinear Left-Censored Mixed-Effects Model
 
-In this step, you will define the structural model for viral load dynamics. The bi-exponential decay function captures two biologically distinct phases: the rapid initial clearance of free virus from the plasma, and the slower decline driven by the loss of productively infected cells. On the original scale, the model for subject $i$ at time $t$ is:
+The bi-exponential decay captures two phases of viral dynamics — rapid initial clearance, then slower decline. For subject $i$ at time $t$:
 
 ```math
 V_i(t) = A_i e^{-k_{1,i} t} + B_i e^{-k_{2,i} t},
 \qquad \mu_{it} = \log_{10}(V_i(t)).
 ```
 
-Each subject-specific parameter ($A_i$, $B_i$, $k_{1,i}$, $k_{2,i}$) is drawn from a `LogNormal` distribution, which guarantees positivity - a necessary constraint since both amplitudes and rate constants must be strictly positive for the model to be biologically meaningful. The fixed effects (`beta_A`, `beta_B`, `beta_k1`, `beta_k2`) represent population-level medians on the log scale, while the `omega` parameters govern the magnitude of between-subject variability for each parameter.
+Each subject parameter ($A_i$, $B_i$, $k_{1,i}$, $k_{2,i}$) is `LogNormal`, keeping amplitudes and rates positive; the fixed effects (`beta_A`, `beta_B`, `beta_k1`, `beta_k2`) are population log-medians and the `omega` parameters set the between-subject spread.
 
-The observation model is where the censoring logic enters. By writing `censored(Normal(mu, sigma), lower=1.7, upper=Inf)`, you specify a Normal distribution that is left-censored at the log10 detection limit of 1.7. NoLimits handles this as follows: when the recorded `Log_VL` value exceeds 1.7, the observation contributes the standard Normal density; when `Log_VL` equals 1.7 (the pinned value for censored rows in this dataset), the observation instead contributes the cumulative probability $\Phi\bigl((1.7 - \mu) / \sigma\bigr)$, representing the probability that the true value falls below the detection limit. This censored-likelihood approach is statistically exact and avoids the biases introduced by ad hoc imputation or deletion strategies.
+`censored(Normal(mu, sigma), lower=1.7, upper=Inf)` does the rest: above 1.7 an observation contributes the Normal density, and at the pinned value 1.7 it contributes the cumulative probability $\Phi\bigl((1.7 - \mu) / \sigma\bigr)$ that the true value lies below the limit. This is statistically exact, unlike imputation or deletion (see [formulas](../model-building/formulas.md)).
 
 ```julia
 model = @Model begin
@@ -180,9 +171,7 @@ Helper functions
 
 ## Step 3: Build `DataModel` and Configure `Laplace`
 
-In this step, you will bind the model to the dataset by constructing a `DataModel`. This validates that all required columns are present and correctly typed, groups observations by subject, and assembles the internal data structures needed for estimation.
-
-Next, you will configure the Laplace approximation. This method approximates the marginal likelihood by finding the mode of each subject's conditional random-effects distribution (the empirical Bayes estimates) and using a second-order Taylor expansion around those modes to integrate out the random effects analytically. Two sets of optimization controls are available: `inner_kwargs` governs the per-subject random-effects optimization, while `optim_kwargs` governs the outer fixed-effects optimization. Multistart is disabled here for speed, but enabling it can help avoid local optima in models with more complex likelihood surfaces.
+After building the `DataModel`, we configure Laplace, which integrates out the random effects with a second-order expansion around each subject's empirical-Bayes mode (see [Laplace](../estimation/laplace.md)). `inner_kwargs` controls the per-subject random-effects optimization and `optim_kwargs` the outer fixed-effects optimization; multistart is off here for speed.
 
 ```julia
 dm = DataModel(model, df; primary_id=:ID, time_col=:Time)
@@ -275,7 +264,7 @@ Per-random-effect summary
 
 ## Step 4: Fit and Inspect Core Summary
 
-With the data model and estimation method in place, you can now run the fit. The Laplace algorithm alternates between two stages: an inner loop that updates the empirical Bayes estimates of the random effects for each subject, and an outer loop that optimizes the fixed-effects parameters with respect to the Laplace-approximated marginal likelihood. After convergence, the summary reports the estimated parameter values alongside the final objective function value.
+The fit alternates an inner loop (empirical-Bayes random effects per subject) with an outer loop (fixed effects against the Laplace-approximated marginal likelihood). The summary reports the estimates and the final objective:
 
 ```julia
 res = fit_model(
@@ -330,7 +319,7 @@ Empirical Bayes random effects summary (across RE levels)
 
 ## Step 5: Fitted Trajectories (First 2 Individuals)
 
-In this step, you will overlay the model's fitted trajectories on the observed data for a visual check of model adequacy. For subjects with censored observations, pay attention to the predicted curve near the detection limit: a well-fitting model should produce predicted values at or near 1.7 at censored time points, reflecting the fact that the true viral load lies somewhere below this threshold rather than at a precisely known value.
+Overlaying fitted trajectories on the data checks model adequacy. Near the detection limit, a good fit predicts values at or near 1.7 at censored time points, reflecting that the true value lies below the threshold.
 
 ```julia
 p_fit = plot_fits(
@@ -350,7 +339,7 @@ p_fit
 
 ## Step 6: Observation Distribution Diagnostic (First Individual)
 
-This diagnostic reveals the full predictive distribution at selected time points for a single subject. For uncensored observations, you will see a Normal density centered on the predicted log10 viral load. For censored observations, the distribution is truncated at the detection limit, with the probability mass below 1.7 collapsed into a point mass. Examining these distributions is a useful way to verify that the censored likelihood is behaving as intended and that the model assigns appropriate probability to the below-limit region.
+The predicted distribution at selected time points: a Normal density for uncensored observations, and for censored ones the mass below 1.7 collapsed into a point mass at the limit — a check that the censored likelihood behaves as intended.
 
 ```julia
 p_obs = plot_observation_distributions(
@@ -368,7 +357,7 @@ p_obs
 
 ## Step 7: Wald Uncertainty Quantification
 
-In this final step, you will assess the precision of the estimated fixed effects by computing Wald-based confidence intervals. The Wald method constructs approximate 95% intervals from the observed Fisher information matrix - that is, the curvature of the log-likelihood at the optimum. This is computationally inexpensive and provides a practical first assessment of parameter identifiability: wide intervals may signal that the data contain insufficient information to pin down a particular parameter.
+Wald 95% intervals come from the observed Fisher information (the log-likelihood curvature at the optimum) — cheap, and a first read on identifiability: wide intervals flag parameters the data barely constrain (see [Wald UQ](../uncertainty-quantification/wald.md)).
 
 ```julia
 uq = compute_uq(
@@ -409,7 +398,7 @@ Parameter uncertainty summary
   sigma            0.6915        0.0077        0.6754        0.7063
 ```
 
-For a consolidated report combining point estimates and their uncertainty, pass both the fit result and the uncertainty object to `summarize`. This tabular format is convenient for inclusion in manuscripts and supplementary materials.
+Passing both the fit and the UQ object to `summarize` gives a consolidated estimate-plus-uncertainty table:
 
 ```julia
 NoLimits.summarize(res, uq)
@@ -456,7 +445,7 @@ Empirical Bayes random effects summary (across RE levels)
   k2_i               50        0.0026     3.523e-11        0.0026        0.0026        0.0026
 ```
 
-Finally, you can visualize the implied sampling distributions of the fixed-effects parameters on the natural (untransformed) scale. Parameters estimated on the log scale (the `omega` and `sigma` parameters) are back-transformed before plotting, so the density plots reflect the scale on which these quantities are scientifically interpretable.
+On the natural scale, the log-scale parameters (`omega`, `sigma`) are back-transformed before plotting, so the densities are on the interpretable scale:
 
 ```julia
 plot_uq_distributions(uq; scale=:natural, plot_type=:density, show_legend=false)
@@ -467,7 +456,7 @@ plot_uq_distributions(uq; scale=:natural, plot_type=:density, show_legend=false)
 
 ## Interpretation Notes
 
-- **Nonlinearity and the Laplace approximation.** The model is nonlinear in its random effects because subject-level `LogNormal` parameters (`A_i`, `B_i`, `k1_i`, `k2_i`) appear inside a bi-exponential trajectory. This nonlinearity is precisely what necessitates the Laplace approximation rather than a simpler linear mixed-effects approach.
-- **Why the censored likelihood matters.** Left-censored rows contribute through the cumulative Normal probability of falling below 1.7, not through a standard density evaluated at the pinned recorded value. This distinction is critical for unbiased estimation whenever detection limits are present.
-- **The slow phase is only weakly identified here.** With a large fraction of observations censored at the detection limit, the data carry little information about the slow second exponential, so its amplitude estimate collapses toward zero and the fitted trajectory is effectively dominated by the fast phase. This is the data speaking rather than a defect: the observable dynamics are a single decline to the detection limit. Datasets with longer follow-up or a higher detection limit would identify both phases more sharply.
-- **A reusable template.** The workflow demonstrated here - model definition, data binding, Laplace estimation, diagnostics, and uncertainty quantification - serves as a baseline template for censored nonlinear mixed-effects analyses in NoLimits. For datasets with higher censoring fractions or more complex censoring patterns (e.g., interval censoring), the same `censored(...)` syntax generalizes naturally.
+- **Why Laplace.** The `LogNormal` parameters sit inside a bi-exponential trajectory, so the model is nonlinear in the random effects — the case the Laplace approximation is built for.
+- **Why the censored likelihood matters.** Censored rows contribute the cumulative probability of falling below 1.7, not a density at the pinned value — essential for unbiased estimation under detection limits.
+- **The slow phase is only weakly identified here.** With so many censored observations, the data say little about the slow exponential, so its amplitude collapses toward zero and the fast phase dominates. This is the data speaking: the observable dynamics are a single decline to the limit. Longer follow-up or a higher limit would identify both phases.
+- **Reusable template.** The same `censored(...)` syntax generalizes to higher censoring fractions and other patterns (e.g. interval censoring).

--- a/docs/src/tutorials/mixed-effects-multiple-methods.md
+++ b/docs/src/tutorials/mixed-effects-multiple-methods.md
@@ -1,23 +1,17 @@
 # Mixed-Effects Tutorial 1: Nonlinear Random-Effects Model Across Multiple Estimation Methods
 
-Nonlinear mixed-effects (NLME) models are a cornerstone of longitudinal data analysis in the biological sciences. They describe how individual trajectories vary around a shared population-level trend - capturing, for example, how different organisms grow at different rates toward different asymptotes, even when the underlying biological mechanism is the same. A natural question arises in practice: **how sensitive are my conclusions to the estimation algorithm I choose?** This tutorial addresses that question directly. You will fit a single nonlinear growth model to a classic biological dataset using four distinct estimation strategies, then compare the results in terms of fitted trajectories, observation-level predictions, and parameter uncertainty. By the end, you will have a practical template for multi-method comparison and a clear intuition for when each approach is most appropriate.
+Nonlinear mixed-effects (NLME) models describe how individual trajectories vary around a shared population trend. A practical question follows: how sensitive are the conclusions to the estimation algorithm? This tutorial fits one nonlinear growth model to the Orange tree dataset with four estimators — Laplace, MCEM, SAEM, and full Bayesian MCMC — and compares them on fitted trajectories, observation-level predictions, and parameter uncertainty, leaving you with a reusable template for multi-method comparison.
 
 ## What You Will Learn
 
-By the end of this tutorial, you will be able to:
-
-- **Build** a nonlinear mixed-effects model with lognormal random effects on a growth asymptote.
-- **Configure** four fundamentally different estimation strategies - Laplace approximation, MCEM, SAEM, and full Bayesian MCMC - with sensible defaults.
-- **Compare** methods in predictive space using NoLimits' diagnostic and visualization tools, rather than relying solely on objective function values.
-- **Interpret** where the estimators converge, where they diverge, and what each method uniquely provides.
-
-The goal is not just to run four fits, but to build understanding of the trade-offs involved in choosing an estimation strategy for your own longitudinal analyses.
+- Build a nonlinear mixed-effects model with a lognormal random effect on a growth asymptote.
+- Configure four estimators — Laplace, MCEM, SAEM, MCMC — with sensible defaults.
+- Compare methods in predictive space, not just by objective values.
+- See where the estimators agree, where they diverge, and what each adds.
 
 ## Step 1: Data Setup
 
-In this first step, you will load the Orange tree growth dataset, a classic longitudinal dataset originally from Draper and Smith (1981) and available in R's `datasets` package. The dataset records the trunk circumference of five orange trees measured at seven time points over approximately four years. Although small, it is representative of a broad class of problems in biology: repeated measurements of a continuous outcome on a set of individuals, with growth that follows a saturating nonlinear trajectory. The between-tree variation in final size makes it a natural candidate for random-effects modeling.
-
-The code below loads the required packages and retrieves the data directly from the Rdatasets GitHub repository.
+The Orange tree dataset (Draper and Smith, 1981; R's `datasets`) records trunk circumference for five trees at seven time points over roughly four years. The between-tree variation in final size makes it a natural random-effects example.
 
 ```julia
 using NoLimits
@@ -56,11 +50,9 @@ first(df, 8)
 
 ## Step 2: Define the Nonlinear Mixed-Effects Model
 
-Next, you will specify the statistical model. The biological reasoning is straightforward: each tree's circumference follows a saturating growth curve, increasing from an initial size toward a tree-specific maximum. You will model this maximum (the asymptote) as a random effect, allowing each tree to have its own upper bound while sharing a common growth shape across the population.
+Each tree follows a saturating growth curve toward a tree-specific maximum. That maximum (the asymptote) is the random effect: every tree gets its own upper bound while sharing the population growth shape.
 
-Concretely, the model uses a logistic-style saturating function with three population-level parameters: an initial size `phi1`, a log-scale population mean for the asymptote `log_vmax`, and a midpoint parameter `phi3` that controls the timing of the growth inflection. Each tree's individual asymptote `vmax_i` is drawn from a lognormal distribution, which ensures positivity and places between-tree variability on a multiplicative scale - a natural choice when larger individuals tend to show proportionally larger variation. The observation model is also lognormal, so residual variability scales with the predicted circumference rather than being additive. To maintain numerical stability during optimization, the predicted mean is passed through a `softplus` function that enforces positivity without introducing hard discontinuities.
-
-All fixed effects are given weakly informative priors. These priors are not strictly necessary for the optimization-based methods (Laplace, MCEM, SAEM), but they are required for MCMC and serve to regularize the likelihood surface for all methods.
+The curve uses an initial size `phi1`, a log-scale population asymptote `log_vmax`, and a midpoint `phi3`. Each tree's asymptote `vmax_i` is drawn from a `LogNormal`, keeping it positive and placing variability on a multiplicative scale; the observation model is also lognormal, so residual spread grows with the prediction, and `softplus` keeps the mean positive without hard discontinuities. All fixed effects get weakly-informative priors — optional for Laplace/MCEM/SAEM, required for MCMC.
 
 ```julia
 model = @Model begin
@@ -94,7 +86,7 @@ end
 
 ### Model Summary
 
-You can inspect the model structure to verify that all blocks were parsed correctly and that the parameter dimensions, scales, and priors match what you intended.
+Inspect the assembled model to confirm blocks, dimensions, scales, and priors:
 
 ```julia
 model_summary = NoLimits.summarize(model)
@@ -164,21 +156,16 @@ Helper functions
 
 ## Step 3: Build the DataModel and Configure Estimation Methods
 
-In this step, you will wrap the model and data together into a `DataModel` - a structure that validates the data schema, groups individuals into batches for the random effects structure, and prepares internal representations for each estimation method.
+The `DataModel` validates the schema, groups individuals into random-effect batches, and prepares the internal representations. The four methods take fundamentally different approaches to the random-effects integral in the marginal likelihood:
 
-You will then configure four estimation methods. Each represents a fundamentally different strategy for handling the random effects integral that appears in the marginal likelihood:
+- **[Laplace](../estimation/laplace.md)** — analytic second-order approximation around each individual's empirical-Bayes mode; fast and deterministic.
+- **[MCEM](../estimation/mcem.md)** — Monte Carlo EM: sample the random effects in the E-step, maximize in the M-step; robust to non-Gaussian random effects.
+- **[SAEM](../estimation/saem.md)** — stochastic-approximation EM: updates running sufficient statistics, so it needs fewer samples per iteration.
+- **[MCMC](../estimation/mcmc.md)** — samples the full joint posterior, the richest uncertainty picture at the highest cost.
 
-- **Laplace** approximates the integral analytically using a second-order Taylor expansion around each individual's best estimate of the random effects (the empirical Bayes estimate). It is fast and deterministic, making it a good default for moderate-sized problems. However, the approximation can lose accuracy when the true distribution of random effects is far from Gaussian.
+The settings below favor short runtimes; production runs would raise iteration counts and sample sizes. SAEM uses pure defaults (`NoLimits.SAEM()`) on purpose — with sensible starts it reaches the same solution as the tuned estimators.
 
-- **MCEM** (Monte Carlo Expectation-Maximization) uses MCMC sampling within each iteration to approximate the expected complete-data log-likelihood, then maximizes that approximation. In plain terms, it alternates between "filling in" the missing random effects via sampling and updating the population parameters given those samples. It is more robust than Laplace to non-Gaussian random effects but requires more computation.
-
-- **SAEM** (Stochastic Approximation EM) follows a similar alternating logic but replaces the full sampling step with a stochastic approximation that updates a running average of sufficient statistics. This means it converges with fewer samples per iteration than MCEM, making it attractive for larger problems, though its stochastic nature can make convergence harder to diagnose.
-
-- **MCMC** (Markov chain Monte Carlo) samples the full joint posterior over both fixed and random effects. Rather than returning a single "best" parameter estimate, it produces a collection of plausible parameter sets that together characterize uncertainty. This provides the richest picture of parameter uncertainty - including asymmetric or multimodal posteriors - but is the most computationally expensive and requires careful convergence assessment.
-
-The configuration values below are chosen to balance runtime and stability for this tutorial; in a research setting, you would typically increase iteration counts, sample sizes, and warmup periods. SAEM is run entirely with its default settings (`NoLimits.SAEM()`), which is a deliberate point of this tutorial: with sensible starting values, the out-of-the-box configuration converges to the same solution as the carefully tuned estimators, with no method-specific tuning required.
-
-One detail deserves emphasis here, because it matters for every estimator and especially for the stochastic ones. The initial value of `log_vmax` is set to `5.0` - close to the log of a plausible asymptote for these trees (`exp(5.0) ≈ 148`). Stochastic-approximation methods like SAEM draw the random effects from the *current* parameter values at each iteration, so a starting point far from the data (for example `log_vmax = 10.0`, implying an asymptote near `22000`) can trap the sampler in a degenerate region of the likelihood and prevent convergence, even when the gradient-based methods would eventually escape it. Choosing starting values on the right order of magnitude is one of the most effective and least appreciated ways to make mixed-effects estimation robust.
+One detail matters for every estimator, especially the stochastic ones: `log_vmax` starts at `5.0` (`exp(5.0) ≈ 148`, a plausible asymptote). SAEM and the EM methods draw random effects from the *current* parameters, so a start far from the data (say `log_vmax = 10.0`, an asymptote near `22000`) can trap the sampler in a degenerate region. Starting values on the right order of magnitude are one of the most effective ways to make mixed-effects estimation robust.
 
 ```julia
 dm = DataModel(model, df; primary_id=:Tree, time_col=:age)
@@ -206,7 +193,7 @@ serialization = SciMLBase.EnsembleThreads()
 
 ### DataModel Summary
 
-Before proceeding to estimation, inspect the DataModel summary to confirm that individuals, covariates, and random effect groupings were detected correctly.
+Confirm that individuals, covariates, and random-effect groupings were detected correctly:
 
 ```julia
 dm_summary = NoLimits.summarize(dm)
@@ -283,9 +270,7 @@ Per-random-effect summary
 
 ## Step 4: Fit All Methods
 
-With the model, data, and methods configured, you will now fit the same DataModel with all four estimators. Each call to `fit_model` returns a `FitResult` object that stores the estimated parameters, convergence diagnostics, and a reference to the DataModel for downstream analysis.
-
-Each method receives a different random seed to ensure reproducibility while allowing independent stochastic behavior across methods.
+Fit the same `DataModel` with all four estimators; each `fit_model` call returns a `FitResult` holding the parameters, convergence diagnostics, and a reference to the data model. Distinct seeds keep the stochastic methods reproducible.
 
 ```julia
 res_laplace = fit_model(dm, laplace_method; serialization=serialization, rng=Random.Xoshiro(11))
@@ -296,7 +281,7 @@ res_mcmc = fit_model(dm, mcmc_method; serialization=serialization, rng=Random.Xo
 
 ### FitResult Summaries
 
-Each fit result can be summarized to display estimated parameter values, convergence status, and method-specific diagnostics. Reviewing these summaries side by side is a quick first check for whether the methods have arrived at broadly similar parameter estimates.
+Summarizing each result shows parameter values, convergence, and method-specific diagnostics — a quick first check that the methods broadly agree.
 
 ```julia
 fit_summary_laplace = NoLimits.summarize(res_laplace)
@@ -359,18 +344,16 @@ objectives
 (laplace = 140.19104904494876, mcem = -157.26026347250098, saem = -154.8177352877204)
 ```
 
-The signs and magnitudes differ because each method defines its objective differently:
+The values differ by construction:
 
-- **Laplace** reports the minimized value of the Laplace-approximated marginal likelihood (a loss function, so lower is better).
-- **MCEM** and **SAEM** report the EM auxiliary quantity `Q` at the final iterate, which is a lower bound on the log-likelihood (higher is better).
+- **Laplace** reports the minimized Laplace-approximated marginal likelihood (lower is better).
+- **MCEM** and **SAEM** report the EM auxiliary quantity `Q`, a log-likelihood lower bound (higher is better).
 
-Because these quantities differ by construction, raw values are not directly comparable across methods. Within a single method family, however, objective values can be compared meaningfully - for example, when evaluating different starting points or model specifications with the same estimator.
+So raw values are not comparable across method families, though within one family they are — e.g. across starting points or model variants.
 
 ## Step 6: Compare Parameter Estimates Side by Side
 
-While objective values are not comparable across methods, the *parameter estimates* are - and lining them up in a single table is the quickest way to see whether the four estimators agree on the population structure. NoLimits provides `compare_parameters` for exactly this purpose. It accepts any number of `FitResult` objects, matches parameters by name across models, and reports them on a common scale (`:natural` by default). Parameters present in only some models are shown as `-` in the columns where they are absent.
-
-For the optimization-based methods (Laplace, MCEM, SAEM) the reported value is the point estimate at the optimum. For MCMC, which returns a full posterior rather than a single point, the column reports the **posterior median** of each parameter (computed per component from the post-warmup draws), giving a robust central summary that lines up directly with the point estimates from the other methods.
+Parameter estimates *are* comparable across methods, and `compare_parameters` lines them up by name on a common scale (`:natural` by default); parameters absent from a model show as `-`. For Laplace/MCEM/SAEM the value is the point estimate at the optimum; for MCMC it is the posterior median (per component, post-warmup), which aligns directly with those point estimates.
 
 ```julia
 param_comparison = compare_parameters(
@@ -394,7 +377,7 @@ ParameterComparison
   sigma        0.1126    0.1125    0.1054     0.118
 ```
 
-The agreement is striking: all four methods recover the same initial size (`phi1 ≈ 31`), the same log-asymptote (`log_vmax ≈ 5.04`, i.e. an asymptotic circumference near `155`), the same growth midpoint (`phi3 ≈ 640`), and the same between-tree and residual variability (`omega ≈ 0.16`, `sigma ≈ 0.11`). The small differences between columns are well within the stochastic noise of the Monte Carlo methods. This is the multi-method comparison distilled to a single view - when the estimates line up this cleanly, you can be confident your conclusions are not an artifact of the estimation algorithm.
+The agreement is striking: all four recover the same initial size (`phi1 ≈ 31`), log-asymptote (`log_vmax ≈ 5.04`, i.e. ~155), midpoint (`phi3 ≈ 640`), and variability (`omega ≈ 0.16`, `sigma ≈ 0.11`), with differences well within Monte Carlo noise. When estimates line up this cleanly, the conclusions are not an artifact of the algorithm.
 
 As an alternative to the `labels` keyword, you can pass `label => fit` pairs directly:
 
@@ -409,7 +392,7 @@ compare_parameters(
 
 ## Step 7: Fitted Trajectories for the First Two Individuals
 
-The most informative way to compare methods is in predictive space: do the fitted trajectories agree when overlaid on the observed data? In this step, you will generate fit plots for the first two trees under each method. For MCMC, you will additionally overlay posterior predictive quantile bands (5th and 95th percentiles), which provide a visual summary of prediction uncertainty that accounts for both parameter and random-effect uncertainty.
+The clearest comparison is in predictive space: do the fitted trajectories agree on the data? Below are the first two trees under each method; for MCMC we add posterior predictive bands (5th/95th percentiles), which fold in both parameter and random-effect uncertainty.
 
 ```julia
 inds = collect(1:min(2, length(dm.individuals)))
@@ -457,7 +440,7 @@ p_fit_mcmc = plot_fits(
 
 ```
 
-When all four methods are well-calibrated, you should see broadly similar trajectories. Differences, when they appear, tend to be most visible in the tails of the growth curve where data are sparse.
+Well-calibrated, the four give broadly similar trajectories; differences show mainly in the data-sparse tails.
 
 Laplace fit plot:
 
@@ -486,7 +469,7 @@ p_fit_saem
 <!- injected:t1-pfitsaem ->
 ![SAEM (default settings) fitted trajectories for the first two trees.](figures/t1/p_fit_saem.png)
 
-With its default settings and sensible starting values, SAEM converges to the same solution as the other estimators: its fitted trajectories are visually indistinguishable from the Laplace, MCEM, and MCMC fits, tracking the saturating growth curve cleanly through the observed age range. This is the payoff of the starting-value discussion in Step 3 - once the sampler begins in a sensible region of parameter space, the out-of-the-box stochastic-approximation configuration recovers the population parameters without any method-specific tuning. The recovered estimates (`phi3 ≈ 639`, `log_vmax ≈ 5.04`, `omega ≈ 0.16`) match the gradient-based and fully Bayesian methods to within stochastic noise.
+With default settings and sensible starts, SAEM is visually indistinguishable from the others, tracking the saturating curve cleanly. This is the payoff of the starting-value discussion in Step 3: once the sampler begins in a sensible region, the out-of-the-box configuration recovers the population parameters (`phi3 ≈ 639`, `log_vmax ≈ 5.04`, `omega ≈ 0.16`) to within stochastic noise.
 
 MCMC fit plot (with posterior predictive bands):
 
@@ -499,9 +482,7 @@ p_fit_mcmc
 
 ## Step 8: Observation Distribution Diagnostics (First Individual)
 
-Beyond trajectory-level agreement, you can examine how well each method captures the observation-level distribution. The plots below compare the observed circumference value for the first observation of the first tree against the model-implied observation distribution at that data point. If the model is well-specified, the observed value should fall in a region of reasonable density under the predicted distribution.
-
-This diagnostic is particularly useful for detecting model misspecification. If the observed value consistently falls in the tail of the predicted distribution across individuals and methods, the observation model (here, lognormal) may need revision.
+Each method's observation-level distribution at the first observation of the first tree, with the observed value marked. A consistent tail position across methods would point to a misspecified observation model (here lognormal).
 
 ```julia
 p_obs_laplace = plot_observation_distributions(
@@ -575,9 +556,7 @@ p_obs_mcmc
 
 ## Step 9: Uncertainty Quantification Across Methods
 
-A key reason to compare methods is to understand how they characterize parameter uncertainty. The optimization-based methods (Laplace, MCEM, SAEM) return point estimates; you can obtain approximate uncertainty via Wald-type confidence intervals, which are derived from the curvature of the objective function at the optimum. Intuitively, a sharply peaked objective implies tight uncertainty, while a flat objective implies wide intervals. MCMC, by contrast, produces exact posterior draws enabling distribution-based uncertainty summaries.
-
-Below, you will compute uncertainty quantification (UQ) summaries for all four methods and generate density plots of the resulting parameter distributions on the natural (untransformed) scale.
+The optimization-based methods return point estimates, so uncertainty comes from Wald intervals built on the objective's curvature at the optimum — a sharp peak gives tight intervals, a flat one wide (see [Wald UQ](../uncertainty-quantification/wald.md)). MCMC instead gives exact posterior draws. Below we compute UQ for all four and plot the parameter distributions on the natural scale.
 
 ```julia
 uq_laplace = compute_uq(
@@ -626,7 +605,7 @@ p_uq_mcmc = plot_uq_distributions(uq_mcmc; scale=:natural, plot_type=:density, s
 
 ### UQ Summaries
 
-The summaries below report point estimates alongside uncertainty intervals for each parameter. Where the methods agree, you can be confident that inference is robust. Where they diverge, the discrepancy may signal sensitivity to the estimation strategy, an under-identified parameter, or simply a need for more data.
+These report point estimates with intervals per parameter. Agreement signals robust inference; divergence flags sensitivity to the estimator, an under-identified parameter, or insufficient data.
 
 ```julia
 uq_summary_laplace = NoLimits.summarize(uq_laplace)
@@ -714,12 +693,7 @@ p_uq_mcmc
 
 ## Interpretation and Practical Guidance
 
-Several principles emerge from this multi-method comparison:
-
-**Evaluate agreement in predictive space, not objective space.** Because each method optimizes a different quantity, comparing raw objective values across methods is misleading. Instead, compare fitted trajectories, observation-level distributions, and uncertainty intervals. When methods agree in predictive space, you can be more confident that your conclusions are robust to the choice of estimator.
-
-**Method agreement on central structure is the norm for well-specified models.** For a dataset like Orange, where the model is a reasonable description of the data-generating process, Laplace, MCEM, and SAEM will typically recover similar point estimates and trajectory shapes. Disagreement is a useful diagnostic signal - it may indicate model misspecification, insufficient iterations, or a challenging likelihood surface.
-
-**MCMC provides the richest uncertainty characterization.** Posterior predictive bands and marginal posterior distributions from MCMC capture asymmetry, multimodality, and correlation structure most faithfully.
-
-**Choose your method based on your inferential goal.** If you need fast point estimates with approximate standard errors for model selection or screening, Laplace is often sufficient. If you need robust estimates under flexible random-effect distributions, SAEM or MCEM may be preferable. If full posterior inference is the goal - for example, for decision-making under uncertainty or for propagating parameter uncertainty into downstream predictions - MCMC is the strongest choice.
+- **Compare in predictive space, not objective space.** Each method optimizes a different quantity, so compare trajectories, observation distributions, and intervals — not raw objective values.
+- **Agreement is the norm for well-specified models.** When Laplace, MCEM, and SAEM diverge, suspect misspecification, too few iterations, or a hard likelihood surface.
+- **MCMC gives the richest uncertainty.** Posterior bands and marginals capture asymmetry, multimodality, and correlation most faithfully.
+- **Pick by inferential goal.** Fast point estimates with approximate SEs → Laplace; flexible random-effect distributions → SAEM/MCEM; full posterior inference → MCMC.

--- a/docs/src/tutorials/mixed-effects-nn-saem.md
+++ b/docs/src/tutorials/mixed-effects-nn-saem.md
@@ -1,21 +1,17 @@
 # Mixed-Effects Tutorial 3: Neural Differential-Equation Components (SAEM)
 
-In many scientific domains - from systems biology to chemical engineering to ecology - we understand the broad structure of a dynamical system (e.g., compartments connected by transfer rates) but lack precise knowledge of every rate law or interaction term. Neural ordinary differential equations (Neural ODEs) offer a principled way to address this gap: they embed small neural networks directly inside an ODE system, allowing the data to shape the functional forms that mechanistic reasoning alone cannot specify. Crucially, this approach preserves the interpretable compartmental structure while letting learned components capture the unknown nonlinearities.
-
-In this tutorial, you will build a mixed-effects ODE model in which multiple neural-network components parameterize the ODE right-hand side, and fit it with the Stochastic Approximation Expectation-Maximization (SAEM) algorithm. By the end, you will have a working example of a hybrid mechanistic-neural model that accounts for between-subject variability through random effects on the network weights themselves.
+Often we know a dynamical system's structure — compartments and transfer pathways — but not the exact rate laws. Neural ODEs close that gap by embedding small neural networks inside the ODE right-hand side, letting the data shape the unknown functional forms while the compartmental structure stays interpretable. This tutorial builds a two-compartment Neural ODE for the Theophylline data and fits it with Stochastic Approximation Expectation-Maximization (SAEM), with subject-level random effects on the network weights so each individual gets a personalized version of the dynamics.
 
 ## Learning Goals
 
-By the end of this tutorial, you will be able to:
-
-- **Declare neural-network parameter blocks** (`NNParameters`) and wire them into an ODE system using the `@DifferentialEquation` macro.
-- **Couple network weights to subject-level random effects** via multivariate normal distributions, so that every individual in the dataset receives a personalized version of the dynamics.
-- **Fit the model using SAEM** with its default settings, which remain stable even when random-effect dimensions are high.
-- **Visualize and diagnose** the fitted trajectories and observation distributions.
+- Declare `NNParameters` blocks and wire them into `@DifferentialEquation`.
+- Couple network weights to subject-level random effects via `MvNormal`.
+- Fit with default SAEM, stable even at high random-effect dimension.
+- Diagnose the fitted trajectories and observation distributions.
 
 ## Step 1: Data Setup
 
-In this step, you will load and prepare the data. We use the classic Theophylline dataset, which records concentration-time profiles for 12 subjects after oral administration. Although this dataset originates from pharmacology, the underlying dynamics - a substance entering a depot compartment and transferring to a central compartment where it is observed and cleared - are a standard example of a two-compartment transfer system that arises across many fields, from tracer kinetics to nutrient cycling. You will reshape the data into a flat format where the initial amount `d` enters as a constant covariate.
+We use the Theophylline dataset (12 subjects, concentration over time) in a flat format where the dose `d` enters as a constant covariate — a two-compartment transfer system (depot → central → cleared).
 
 ```julia
 using NoLimits
@@ -71,14 +67,9 @@ first(df, 10)
 
 ## Step 2: Define the Neural ODE Mixed-Effects Model
 
-In this step, you will define the core model. The key idea is that instead of specifying closed-form rate functions (such as first-order kinetics), you let neural networks learn these functions directly from data. Each `NNParameters` block declares a small feedforward network whose flattened weights become part of the fixed-effects parameter vector. At evaluation time, a callable function (e.g., `NNA1`) reconstructs the network from its weight vector and evaluates it - so you can use it inside `@DifferentialEquation` just like any other function.
+Instead of closed-form rate laws, neural networks learn the rate functions from data. Each `NNParameters` block declares a small feedforward network whose flattened weights join the fixed-effects vector and expose a callable (e.g. `NNA1`) usable inside `@DifferentialEquation` (see [function approximators](../model-building/universal-function-approximators.md)). Four networks drive the two-compartment system: `fA1`/`fA2` for the depot, `fC1`/`fC2` for the central compartment.
 
-The ODE right-hand side uses four neural components arranged in a two-compartment transfer system:
-
-- `fA1(t)` and `fA2(t)` govern the dynamics of the depot (input) compartment.
-- `fC1(t)` and `fC2(t)` govern the dynamics of the central (observed) compartment.
-
-To capture between-subject variability, each network's weight vector is paired with a subject-level random-effect vector (`etaA1`, `etaA2`, `etaC1`, `etaC2`) drawn from a `MvNormal` distribution centered on the population weights. This means every individual effectively receives their own personalized network: the population learns shared structure, while the random effects allow individual departures.
+Each network's weights are paired with a subject-level random-effect vector (`etaA1`, `etaA2`, `etaC1`, `etaC2`) drawn from an `MvNormal` centered on the population weights, so every individual gets a personalized network around shared population structure.
 
 ```julia
 using NoLimits
@@ -150,9 +141,9 @@ model = set_solver_config(
 )
 ```
 
-Before moving on, inspect the model structure to verify that all blocks were assembled correctly.
-
 ### Model Summary
+
+`summarize` confirms the blocks assembled correctly:
 
 ```julia
 model_summary = NoLimits.summarize(model)
@@ -226,7 +217,7 @@ Helper functions
 
 ## Step 3: Build the `DataModel` and Configure SAEM
 
-In this step, you will pair the model with the data by constructing a `DataModel`, then configure the SAEM algorithm. SAEM alternates between sampling random effects conditional on the current parameter estimates (the E-step) and updating population parameters (the M-step). Here we use the default configuration, `NoLimits.SAEM()`. With its defaults, SAEM draws random effects with the adaptive Metropolis sampler (`SaemixMH`) in the E-step and updates the population parameters with a stochastic-approximation (Robbins-Monro) M-step. No special configuration is required even though the random-effect dimension is high here, with four separate network weight vectors per subject. Running with defaults keeps the example simple and demonstrates that the out-of-the-box configuration is sufficient for this hybrid neural-ODE model.
+After building the `DataModel`, we fit with default SAEM (`NoLimits.SAEM()`): an adaptive-Metropolis E-step samples the random effects, a stochastic-approximation (Robbins-Monro) M-step updates the population parameters (see [SAEM](../estimation/saem.md)). No tuning is needed despite the high random-effect dimension — four network-weight vectors per subject.
 
 ```julia
 dm = DataModel(model, df; primary_id=:ID, time_col=:t)
@@ -236,9 +227,9 @@ saem_method = NoLimits.SAEM()
 serialization = SciMLBase.EnsembleThreads()
 ```
 
-Before fitting, review the data model summary to confirm that individuals, covariates, and grouping structures were parsed as expected.
-
 ### DataModel Summary
+
+Confirm individuals, covariates, and grouping structures:
 
 ```julia
 dm_summary = NoLimits.summarize(dm)
@@ -323,7 +314,7 @@ Per-random-effect summary
 
 ## Step 4: Fit the Model and Inspect Results
 
-You are now ready to run SAEM. With the default settings the algorithm iterates up to 300 times, drawing the random effects with the adaptive Metropolis sampler within each E-step. After fitting, you will extract the final objective value and the number of estimated parameters as an initial sanity check.
+With defaults, SAEM runs up to 300 iterations. We extract the final objective and parameter count as a sanity check.
 
 ```julia
 res_saem = fit_model(
@@ -344,7 +335,7 @@ res_saem = fit_model(
 (objective = -565.6734432525224, n_params = 29)
 ```
 
-For a more detailed summary of the fit - including parameter estimates and convergence diagnostics - call the `summarize` function.
+`summarize` gives parameter estimates and convergence diagnostics:
 
 ```julia
 fit_summary_saem = NoLimits.summarize(res_saem)
@@ -409,7 +400,7 @@ Empirical Bayes random effects summary (across RE levels)
 
 ## Step 5: Visualize Fitted Trajectories
 
-In this step, you will overlay the model predictions on the raw observations for the first two subjects. Plotting fitted trajectories against observed data provides an immediate visual assessment of model adequacy - you should see the neural ODE tracking the characteristic rise-and-decay pattern of the two-compartment transfer system, with subject-specific variation captured by the random effects.
+Overlaying predictions on the data for the first two subjects shows the neural ODE tracking the two-compartment rise-and-decay, with subject variation from the random effects.
 
 ```julia
 p_fit_saem = plot_fits(
@@ -429,7 +420,7 @@ p_fit_saem
 
 ## Step 6: Inspect the Observation Distribution
 
-As a final diagnostic, you will examine the implied observation distribution at a single data point for the first individual. This plot shows the full predictive distribution (not just the point estimate), which helps you assess whether the residual variance is well-calibrated and whether the model's uncertainty is reasonable.
+The predicted observation distribution at one data point for the first individual shows whether the residual variance is well-calibrated.
 
 ```julia
 p_obs_saem = plot_observation_distributions(
@@ -447,6 +438,6 @@ p_obs_saem
 
 ## Interpretation Notes
 
-- This modeling pattern combines mechanistic compartmental states with learned nonlinear rate functions inside a single mixed-effects ODE. The compartmental structure encodes known domain knowledge (e.g., mass conservation, transfer between compartments), while the neural networks fill in the unknown functional forms. This hybrid strategy is broadly applicable to any system where the topology is known but the governing laws are not fully specified.
-- Default SAEM (`NoLimits.SAEM()`) is sufficient here: the adaptive Metropolis E-step and stochastic-approximation M-step remain stable even though the random-effect dimension is large, as is typical with neural-network weight vectors. When defaults are not enough, SAEM also exposes closed-form Gaussian block updates through `builtin_stats=:closed_form` together with the `re_mean_params` mapping.
-- The structural settings used here (network width, ODE solver tolerances) are intentionally modest to keep the tutorial fast. For production analyses, consider widening the networks, increasing `maxiters` and the number of MCMC samples to ensure thorough convergence, and tightening the ODE solver tolerances.
+- **Hybrid mechanistic-neural ODE.** The compartments encode known structure (mass conservation, transfer); the networks fill in the unknown rate functions. This applies wherever the topology is known but the governing laws are not.
+- **Default SAEM suffices** even at high random-effect dimension. For finer control, SAEM also exposes closed-form Gaussian block updates via `builtin_stats=:closed_form` with the `re_mean_params` mapping.
+- **Settings are modest for speed.** For production, widen the networks, raise `maxiters` and sample counts, and tighten the ODE solver tolerances.

--- a/docs/src/tutorials/mixed-effects-ode-mcem.md
+++ b/docs/src/tutorials/mixed-effects-ode-mcem.md
@@ -1,28 +1,24 @@
 # Mixed-Effects Tutorial 2: ODE Model with Input Events (MCEM)
 
-Many longitudinal studies involve systems whose dynamics are governed by ordinary differential equations (ODEs) with discrete input events - a bolus injection, a nutrient pulse, or a stimulus onset. When individuals differ in their dynamic parameters, nonlinear mixed-effects models provide a principled way to separate population-level trends from subject-level variability. In this tutorial, you will build such a model from scratch and fit it using the Monte Carlo Expectation-Maximization (MCEM) algorithm, a method well-suited to problems where random effects enter the model nonlinearly.
-
-Starting from a publicly available concentration-time dataset (Theophylline), you will learn how to prepare event-aware data, define a two-compartment ODE model with subject-level random effects, run the full estimation workflow, and generate publication-quality diagnostics. The structural model describes a two-compartment transfer system (`depot`, `center`) in which material moves from a depot compartment into a central compartment and is subsequently eliminated. Subject-level random effects on the transfer rate (`ka`), elimination rate (`cl`), and distribution volume (`v`) capture between-individual variability. Although this tutorial uses concentration-time data, the workflow generalizes to any domain where compartmental ODE dynamics with discrete input events arise - tracer kinetics in imaging, nutrient uptake in ecology, or substrate processing in bioprocess engineering.
+Many longitudinal systems follow ODE dynamics driven by discrete input events — a bolus injection, a nutrient pulse, a stimulus onset. This tutorial builds a two-compartment ODE model (`depot` → `center` → elimination) for the Theophylline concentration-time data, with subject-level random effects on the transfer rate `ka`, elimination rate `cl`, and volume `v`, and fits it with Monte Carlo Expectation-Maximization (MCEM) — well suited to models where random effects enter nonlinearly. The same workflow applies to any compartmental system with discrete inputs, from tracer kinetics to bioprocess engineering.
 
 ## What You Will Learn
 
-By the end of this tutorial, you will be able to:
-
-- **Prepare event-aware data** - convert a raw longitudinal table into the event format NoLimits.jl expects for ODE models with discrete inputs (bolus injections, perturbations, or similar events).
-- **Define a nonlinear mixed-effects ODE model** - use the `@preDifferentialEquation` and `@DifferentialEquation` blocks to specify a model whose random effects enter nonlinearly, a setting where MCEM is especially useful.
-- **Fit the model with MCEM** - run the estimation and inspect core diagnostics including the objective value and estimated parameters.
-- **Visualize and assess results** - generate fitted trajectory plots, observation-distribution diagnostics, and Wald-based uncertainty quantification summaries.
+- Prepare an event table for an ODE model with discrete inputs (`EVID`/`AMT`/`CMT`/`RATE`).
+- Define a nonlinear mixed-effects ODE with `@preDifferentialEquation` and `@DifferentialEquation`.
+- Fit it with MCEM and read the core diagnostics.
+- Visualize fits, observation distributions, and Wald uncertainty.
 
 ## Step 1: Prepare the Event-Table
 
-In this step, you will convert raw longitudinal data into the event-table format that NoLimits.jl uses for ODE models with discrete inputs. An event table interleaves input events (such as a bolus entering a compartment) with observation rows, so that the ODE solver knows when and where to apply external perturbations. The key columns are:
+ODE models with discrete inputs use an *event table* that interleaves input events with observations, so the solver knows when and where to apply perturbations (see [Data Model Construction](../data-model-construction.md)). The key columns:
 
-- `EVID` - an integer flag distinguishing input events (`1`) from observation rows (`0`).
-- `AMT` - the magnitude of the input event (e.g., total amount delivered).
-- `CMT` - the name of the ODE compartment that receives the input.
-- `RATE` - the infusion rate; `0.0` indicates an instantaneous bolus.
+- `EVID` - input events (`1`) vs observation rows (`0`).
+- `AMT` - magnitude of the input.
+- `CMT` - the compartment that receives it.
+- `RATE` - infusion rate; `0.0` is an instantaneous bolus.
 
-The code below loads the Theophylline dataset - a widely used concentration-time dataset recording twelve individuals over time - and reshapes it into this event-table format. Each individual receives a single bolus input at time zero, followed by a series of concentration observations.
+We load Theophylline (twelve subjects) and reshape it so each subject receives one bolus into `depot` at time zero, followed by concentration observations.
 
 ```julia
 using NoLimits
@@ -96,19 +92,13 @@ first(df, 12)
 
 ## Step 2: Define the ODE Mixed-Effects Model
 
-In this step, you will specify the mechanistic model. The goal is twofold: describe the ODE dynamics of the two-compartment system, and account for inter-individual variability through random effects.
-
-The model has three system parameters - a transfer rate `ka`, an elimination rate `cl`, and a distribution volume `v` - each of which varies across individuals. To ensure positivity, each parameter is expressed as an exponential transform of a population-level fixed effect plus a subject-specific random deviation:
+Each subject has three positive parameters — transfer rate `ka`, elimination rate `cl`, volume `v` — written as exponentials of a population fixed effect plus a subject deviation:
 
 - `ka = exp(tka + eta[1])`
 - `cl = exp(tcl + eta[2])`
 - `v = exp(tv + eta[3])`
 
-Because the parameters enter the ODE nonlinearly (through the exponential transform of the random effects), standard linear mixed-effects approximations do not apply. This is precisely the setting where Monte Carlo EM methods such as MCEM offer a robust estimation strategy.
-
-The random effects vector `eta` follows a multivariate normal distribution with a diagonal covariance matrix whose entries (`omega1`, `omega2`, `omega3`) are estimated alongside the other fixed effects. Observations are modeled as normally distributed around the predicted concentration in the central compartment, with residual standard deviation `sigma_eps`.
-
-After defining the model, you will configure the ODE solver. `Tsit5()` is an efficient explicit Runge-Kutta method well-suited to non-stiff systems, and the tolerances below balance numerical accuracy with computational cost.
+The deviations `eta` follow a multivariate normal with diagonal covariance (`omega1`, `omega2`, `omega3`), and observations are Normal around the central-compartment concentration with residual SD `sigma_eps`. Because `eta` enters through the exponential, the model is nonlinear in the random effects — the setting MCEM handles well. `set_solver_config` then selects `Tsit5()` (a non-stiff explicit Runge-Kutta) with the tolerances below.
 
 ```julia
 using NoLimits
@@ -171,7 +161,7 @@ model = set_solver_config(
 
 ### Model Summary
 
-Before moving on, it is good practice to inspect the model structure with `NoLimits.summarize`. This confirms that all blocks - fixed effects, random effects, covariates, ODE states, and formulas - have been parsed correctly.
+`summarize` confirms the parsed blocks — fixed effects, random effects, covariates, ODE states, and formulas:
 
 ```julia
 model_summary = NoLimits.summarize(model)
@@ -243,7 +233,7 @@ Helper functions
 
 ## Step 3: Build the DataModel
 
-In this step, you will connect the model to the data by constructing a `DataModel`. This constructor validates the dataset against the model's requirements - checking that all declared covariates are present, that constant covariates are indeed constant within each group, and that event columns are well-formed. You must explicitly specify the event-related column names so that NoLimits.jl can correctly distinguish input events from observation rows during ODE integration.
+Constructing the `DataModel` validates the data and, for event-aware models, requires the event column names so the solver can tell input events from observations.
 
 ```julia
 dm = DataModel(
@@ -261,7 +251,7 @@ dm = DataModel(
 
 ### DataModel Summary
 
-Summarizing the `DataModel` gives you an overview of the number of individuals, batches (groups of individuals linked by shared random-effect levels), observation counts, and event structure. This is a useful checkpoint before launching a potentially expensive estimation run.
+The summary reports individuals, observation counts, and event structure — a useful checkpoint before an expensive fit:
 
 ```julia
 dm_summary = NoLimits.summarize(dm)
@@ -338,15 +328,7 @@ Per-random-effect summary
 
 ## Step 4: Configure MCEM
 
-In this step, you will set up the MCEM algorithm. MCEM alternates between two stages: (1) an E-step that samples random effects from their conditional posterior given the current fixed-effect estimates, and (2) an M-step that maximizes the expected complete-data log-likelihood with respect to the fixed effects. The number of Monte Carlo samples in the E-step can grow across iterations, improving the approximation as the algorithm converges.
-
-The configuration below is tuned for a tutorial setting - moderate iteration counts and sample sizes that keep runtime reasonable. For production analyses, you would typically increase `maxiters`, raise the ceiling of the sample schedule, and draw more MCMC samples per E-step to reduce Monte Carlo noise in the gradient estimates.
-
-A few notes on the specific settings:
-
-- `sample_schedule` controls how the number of Monte Carlo samples grows with each EM iteration, starting at 60 and increasing by 20 per iteration up to a maximum of 260.
-- `progress=false` suppresses progress bars to keep documentation output clean.
-- `EnsembleThreads()` enables multithreaded ODE solving across individuals for faster execution.
+MCEM alternates an E-step (sample random effects from their conditional posterior) with an M-step (maximize the expected complete-data log-likelihood); growing the E-step sample count across iterations sharpens the approximation as it converges (see [MCEM](../estimation/mcem.md)). The settings below keep runtime short — production runs would raise `maxiters`, the `sample_schedule` ceiling, and the per-E-step sample count. Here `sample_schedule` grows from 60 by 20 per iteration up to 260, and `EnsembleThreads()` solves the ODE across individuals in parallel.
 
 ```julia
 mcem_method = NoLimits.MCEM(;
@@ -362,9 +344,7 @@ serialization = SciMLBase.EnsembleThreads()
 
 ## Step 5: Fit the Model and Inspect Core Outputs
 
-With everything in place, you can now run the fit. The call to `fit_model` performs the full MCEM optimization loop and returns a result object containing parameter estimates, diagnostics, and metadata.
-
-After fitting, you will extract the final objective value - the marginal log-likelihood approximation at convergence. This number is useful for comparing models or monitoring optimization progress, but model adequacy is best judged through the predictive diagnostics covered in the next steps.
+Running the fit performs the full MCEM loop. The final objective is the marginal log-likelihood approximation at convergence — useful for monitoring, but model adequacy is best judged by the predictive diagnostics below.
 
 ```julia
 res_mcem = fit_model(
@@ -388,7 +368,7 @@ fit_summary
 
 ### FitResult Summary
 
-The structured summary provides a convenient overview of convergence status, iteration counts, and method-specific diagnostics.
+The summary gives convergence, iteration counts, and method-specific diagnostics:
 
 ```julia
 fit_result_summary = NoLimits.summarize(res_mcem)
@@ -432,7 +412,7 @@ Empirical Bayes random effects summary (across RE levels)
   eta            eta_3          12       -0.0048        0.1182       -0.1011        0.0051        0.0658
 ```
 
-You can also extract the estimated fixed-effect parameters on their natural (untransformed) scale. The population-level log-scale parameters (`tka`, `tcl`, `tv`) can be exponentiated to recover typical-individual values, and `sigma_eps` represents the residual observation noise.
+On the natural scale, the population log-parameters (`tka`, `tcl`, `tv`) exponentiate to typical-individual values, and `sigma_eps` is the residual noise.
 
 ```julia
 params = NoLimits.get_params(res_mcem; scale=:untransformed)
@@ -451,7 +431,7 @@ params = NoLimits.get_params(res_mcem; scale=:untransformed)
 
 ## Step 6: Visualize Fitted Trajectories
 
-A natural first diagnostic is to overlay the model's predicted trajectories on the observed data. In this step, the `plot_fits` function computes individual-level predictions (using empirical Bayes estimates of the random effects) and plots them alongside the raw observations. Showing the first two individuals provides a quick visual check that the model captures the characteristic rise-and-fall dynamics of the two-compartment system.
+Overlaying predicted trajectories (from the empirical-Bayes random effects) on the data is the first check. The first two individuals show whether the model captures the two-compartment rise-and-fall.
 
 ```julia
 p_fit_mcem = plot_fits(
@@ -471,7 +451,7 @@ p_fit_mcem
 
 ## Step 7: Assess the Observation Distribution
 
-Beyond trajectory-level checks, it is valuable to examine how well the model's predicted observation distribution matches the data at individual time points. In this step, `plot_observation_distributions` visualizes the predictive distribution for a given individual and observation row, letting you assess whether the assumed error model (here, a normal distribution with standard deviation `sigma_eps`) is well-calibrated.
+The predicted observation distribution at a single time point tests whether the error model (Normal with SD `sigma_eps`) is well-calibrated.
 
 ```julia
 p_obs_mcem = plot_observation_distributions(
@@ -489,9 +469,7 @@ p_obs_mcem
 
 ## Step 8: Quantify Parameter Uncertainty
 
-Point estimates alone are insufficient for scientific conclusions - you also need to quantify how precisely each parameter has been determined. In this step, you will use the Wald approach, which constructs approximate confidence intervals from the curvature of the log-likelihood at the optimum (the observed information matrix). For MCEM fits, computing this curvature requires an auxiliary random-effects integration step; the Laplace approximation (`re_approx=:laplace`) serves this purpose here.
-
-The resulting uncertainty estimates are visualized as density plots on the natural parameter scale, providing an intuitive picture of estimation precision given the available data.
+Wald intervals come from the curvature of the log-likelihood at the optimum (see [Wald UQ](../uncertainty-quantification/wald.md)); for MCEM the curvature needs an auxiliary random-effects integration, here via `re_approx=:laplace`. The densities below show the estimation precision on the natural scale.
 
 ```julia
 uq_mcem = compute_uq(
@@ -520,7 +498,7 @@ p_uq_mcem
 
 ### UQ Summaries
 
-Finally, the numerical summaries consolidate point estimates and confidence intervals into a single table - a format suitable for reporting results in publications or for systematic comparison across candidate models.
+The combined table consolidates point estimates and intervals for reporting:
 
 ```julia
 uq_summary_mcem = NoLimits.summarize(uq_mcem)
@@ -569,6 +547,5 @@ Empirical Bayes random effects summary (across RE levels)
 
 ## Practical Guidance
 
-- **Objective values are optimization diagnostics, not model quality scores.** A lower objective indicates better optimization convergence, but model adequacy should be judged through predictive checks - trajectory plots and observation-distribution diagnostics provide complementary views of fit quality.
-- **Inspect trajectory and distributional diagnostics together.** `plot_fits` reveals whether the model captures the overall shape of the response, while `plot_observation_distributions` tests whether the local predictive distribution is well-calibrated. Discrepancies in either diagnostic suggest different kinds of model misspecification.
-- **Scale up before changing model structure.** If the fit appears unstable or the objective has not plateaued, first try increasing `maxiters` and the sample schedule ceiling. MCEM convergence can be slow when Monte Carlo noise dominates the gradient signal, and increasing sample sizes is often more productive than modifying the structural model.
+- **Objective is an optimization diagnostic, not a quality score.** Judge model adequacy through predictive checks: `plot_fits` for overall shape, `plot_observation_distributions` for local calibration — discrepancies in each point to different misspecifications.
+- **Scale up before changing structure.** If the fit looks unstable or the objective hasn't plateaued, first raise `maxiters` and the sample-schedule ceiling; MCEM converges slowly when Monte Carlo noise dominates the gradient.

--- a/docs/src/tutorials/mixed-effects-seizure-counts-poisson-nb-mcem.md
+++ b/docs/src/tutorials/mixed-effects-seizure-counts-poisson-nb-mcem.md
@@ -1,24 +1,17 @@
 # Mixed-Effects Tutorial 5: Modeling Seizure Counts with Poisson and Negative Binomial Outcomes
 
-Counting events over time - seizures, infections, adverse reactions - is one of the most common tasks in longitudinal clinical research. Yet count data behave very differently from continuous measurements. Counts are non-negative integers, their variance typically grows with their mean, and they are often right-skewed. Applying a Normal likelihood to such data can produce negative predicted counts, biased standard errors, and misleading inferences. The Poisson and Negative Binomial distributions are the natural statistical models for these outcomes because they respect the discrete, non-negative nature of counts and link the variance directly to the mean.
-
-In this tutorial, you will build and compare two nonlinear mixed-effects models for repeated seizure counts, using data from the Thall and Vail (1990) epilepsy trial. This trial is one of the most widely analyzed longitudinal count datasets in biostatistics: 59 epilepsy patients were randomized to either progabide or placebo, and seizure counts were recorded across four consecutive two-week periods following a baseline observation window. The dataset has become a benchmark for count regression methods because it exhibits substantial between-subject variability and overdispersion - features that push simple Poisson models to their limits and motivate the Negative Binomial alternative.
-
-Both models share the same fixed-effects covariates and subject-level random-effects structure; they differ only in the outcome distribution. The Poisson assumes the variance equals the mean, while the Negative Binomial introduces a dispersion parameter to accommodate extra-Poisson variation. Because the subject-specific random effect enters inside an exponential rate function, both models are nonlinear in the random effects. This nonlinearity means the marginal likelihood integral over random effects has no closed-form solution, making Monte Carlo Expectation-Maximization (MCEM) a natural estimation strategy.
+Count outcomes — seizures, infections, adverse events — are non-negative integers whose variance grows with the mean, so a Normal likelihood can predict negative counts and biased errors. The Poisson and Negative Binomial distributions respect this structure. This tutorial fits and compares both as nonlinear mixed-effects models on the Thall and Vail (1990) epilepsy trial (59 patients, progabide vs placebo, four two-week periods). The two share the same predictor and random intercept and differ only in the outcome: Poisson fixes the variance to the mean, while Negative Binomial adds a dispersion parameter for overdispersion. The random effect enters through an exponential rate, so both are nonlinear in the random effects — a natural fit for Monte Carlo Expectation-Maximization (MCEM).
 
 ## Learning Goals
 
-By the end of this tutorial, you will be able to:
-
-- **Prepare longitudinal count data** - reshape the classic MASS `epil` dataset into the long format NoLimits expects, deriving subject-level covariates (baseline seizure rate, age, treatment) and time-varying design variables (period, treatment-by-period interaction).
-- **Specify count regression models** - define both a Poisson and a Negative Binomial mixed-effects model in NoLimits, each with a log-link linear predictor and a subject-level random intercept.
-- **Estimate with MCEM** - fit both models using Monte Carlo Expectation-Maximization, an algorithm that alternates between sampling random effects from their conditional distribution and optimizing the fixed-effects parameters.
-- **Visualize model fit** - generate fitted-trajectory plots and observation-level predictive distributions using `plot_fits` and `plot_observation_distributions`.
-- **Quantify uncertainty** - compute Wald-based confidence intervals with `compute_uq` and produce publication-ready summary tables with `NoLimits.summarize`.
+- Reshape the MASS `epil` dataset into NoLimits' long format with subject- and time-level covariates.
+- Specify Poisson and Negative Binomial mixed-effects models with a log-link and random intercept.
+- Fit both with MCEM.
+- Diagnose with fit and observation-distribution plots, and quantify uncertainty with Wald intervals.
 
 ## Step 1: Data Setup
 
-In this step, you will load the MASS epilepsy dataset (`MASS::epil`, mirrored in Rdatasets) and reshape it into the long format that NoLimits expects, where each row represents one subject-period combination. Along the way, you will derive several analysis variables: a binary treatment indicator, log-transformed baseline seizure count and age (to stabilize the scale of the linear predictor), and a centered period variable that improves interpretability of the intercept. The treatment-by-period interaction term will allow you to test whether the treatment effect changes over the course of the trial.
+We load the MASS `epil` dataset (one row per subject-period) and derive the analysis variables: a binary treatment indicator, log baseline count and age (to stabilize the predictor scale), a centered period, and a treatment-by-period interaction.
 
 ```julia
 using NoLimits
@@ -80,9 +73,7 @@ first(df, 10)
 
 ## Step 2: Poisson Mixed-Effects Model
 
-In this step, you will define the Poisson mixed-effects model. The core idea is a log-linear predictor: the log of the expected seizure rate is modeled as a linear combination of covariates plus a subject-level random intercept. The random effect `eta` captures unmeasured between-subject heterogeneity in baseline seizure propensity. Because `eta` appears inside the exponential that maps the log-rate to the Poisson intensity parameter `lambda`, the model is nonlinear in the random effects - a key reason MCEM is preferred over simpler estimation methods such as the Laplace approximation.
-
-Note the two helper functions defined in the `@helpers` block: `linpred` computes the dot product of the covariate vector with the coefficient vector (keeping the model specification clean), and `safe_exp` guards against numerical overflow in the exponential.
+The Poisson model uses a log-linear predictor: the log seizure rate is a linear combination of covariates plus a subject random intercept `eta`, which captures unmeasured heterogeneity in baseline propensity. Because `eta` sits inside the exponential mapping to the rate `lambda`, the model is nonlinear in the random effects. The `@helpers` block defines `linpred` (covariate·coefficient dot product) and `safe_exp` (overflow-guarded exponential).
 
 ```julia
 model_poisson = @Model begin
@@ -181,9 +172,7 @@ Helper functions
 
 ### Build `DataModel` and Configure `MCEM`
 
-Next, you will bind the model to the data by constructing a `DataModel`. This step validates that all required columns are present and correctly typed, groups observations by subject, and prepares the internal data structures for estimation.
-
-You will then configure the MCEM algorithm. The `sample_schedule` controls how many MCMC samples are drawn from the conditional distribution of the random effects at each EM iteration - starting with fewer samples and increasing over iterations improves computational efficiency. The settings here are intentionally compact for documentation purposes; in practice, you would use more iterations and larger sample sizes for production analyses.
+The `DataModel` validates the data and groups observations by subject. MCEM's `sample_schedule` grows the E-step sample count across iterations (see [MCEM](../estimation/mcem.md)); the compact settings here keep runtime short — production runs would use more iterations and larger samples.
 
 ```julia
 dm_poisson = DataModel(model_poisson, df; primary_id=:Subject, time_col=:period_f)
@@ -277,7 +266,7 @@ Per-random-effect summary
 
 ### Fit, Summarize, Plot, and UQ (Poisson)
 
-You are now ready to fit the Poisson model. The `fit_model` call runs the full MCEM loop: at each iteration, it samples random effects conditional on the current fixed-effects estimates, then updates the fixed effects by maximizing the Monte Carlo approximation to the marginal likelihood. After fitting, you will inspect a summary of the estimated parameters.
+Fitting runs the full MCEM loop; the summary shows the estimated parameters:
 
 ```julia
 res_poisson = fit_model(
@@ -325,7 +314,7 @@ Empirical Bayes random effects summary (across RE levels)
   eta                59        0.3579        0.6502        0.0455        0.2804        0.6631
 ```
 
-To assess how well the model captures individual seizure trajectories, you will now plot fitted values against observed data for the first two subjects. The observation-distribution diagnostic reveals the full predictive distribution at selected time points - a particularly informative view for count data, where the shape of the distribution (not just its mean) carries clinical significance.
+Fitted values vs observed data for the first two subjects, plus the predicted distribution at selected points — especially informative for counts, where distribution shape matters, not just the mean.
 
 ```julia
 p_fit_poisson = plot_fits(
@@ -350,7 +339,7 @@ p_fit_poisson
 <!- injected:t5-pfitp ->
 ![Fitted Poisson seizure-rate trajectories for the first two subjects.](figures/t5/p_fit_poisson.png)
 
-Display the observation-distribution plot to examine the predicted probability mass function at individual time points.
+The observation-distribution plot shows the predicted probability mass at individual time points.
 
 ```julia
 p_obs_poisson
@@ -359,7 +348,7 @@ p_obs_poisson
 <!- injected:t5-pobsp ->
 ![Predicted Poisson probability mass at the first two observations of the first subject.](figures/t5/p_obs_poisson.png)
 
-Next, you will compute Wald-based confidence intervals for the fixed-effects parameters. The Wald method uses the curvature of the log-likelihood at the optimum to approximate the sampling distribution of each parameter estimate, yielding standard errors and 95% confidence intervals without requiring additional model fits.
+Wald intervals use the log-likelihood curvature at the optimum to give standard errors and 95% CIs without extra fits (see [Wald UQ](../uncertainty-quantification/wald.md)).
 
 ```julia
 uq_poisson = compute_uq(
@@ -398,7 +387,7 @@ Parameter uncertainty summary
   omega            0.7901        0.4303        0.3728        1.9309
 ```
 
-For a consolidated view, combine the parameter estimates and their uncertainty into a single summary table - the format most convenient for reporting in manuscripts and presentations.
+Combine estimates and uncertainty into one table for reporting:
 
 ```julia
 NoLimits.summarize(res_poisson, uq_poisson)
@@ -440,7 +429,7 @@ Empirical Bayes random effects summary (across RE levels)
   eta                59        0.3579        0.6502        0.0455        0.2804        0.6631
 ```
 
-Finally, visualize the approximate sampling distributions of the fixed-effects parameters implied by the Wald approximation.
+Visualize the Wald sampling distributions of the parameters:
 
 ```julia
 plot_uq_distributions(uq_poisson)
@@ -451,9 +440,9 @@ plot_uq_distributions(uq_poisson)
 
 ## Step 3: Negative Binomial Mixed-Effects Model
 
-The Poisson model assumes that the conditional variance of seizure counts equals the conditional mean. In practice, count data from clinical trials frequently exhibit *overdispersion* - more variability than the Poisson predicts - due to unmeasured heterogeneity beyond what the random intercept alone can capture. The Negative Binomial distribution addresses this limitation by introducing an additional dispersion parameter `r` (sometimes called the "size" or "shape" parameter). As `r` grows large, the Negative Binomial converges to the Poisson; smaller values of `r` indicate greater overdispersion. This makes the Negative Binomial a strict generalization of the Poisson, and comparing the two reveals whether overdispersion is a meaningful feature of the data.
+The Poisson fixes the variance to the mean, but trial counts are often *overdispersed* — more variable than Poisson allows. The Negative Binomial adds a dispersion parameter `r`: large `r` recovers the Poisson, small `r` means strong overdispersion, so comparing the two reveals whether overdispersion matters.
 
-In this step, you will define the Negative Binomial model. It retains the same structural predictor and random-effects hierarchy as the Poisson model above. The only additions are the dispersion parameter `log_r` (estimated on the log scale to ensure positivity) and the formula lines that convert the mean-scale rate `lambda` and size `r` into the `(r, p)` parameterization expected by `Distributions.NegativeBinomial`.
+The model keeps the Poisson predictor and random intercept, adding `log_r` (log scale for positivity) and the lines that convert `lambda` and `r` into the `(r, p)` form `Distributions.NegativeBinomial` expects.
 
 ```julia
 model_nb = @Model begin
@@ -556,7 +545,7 @@ Helper functions
 
 ### Build `DataModel`, Fit, Summarize, Plot, and UQ (Negative Binomial)
 
-You will now follow the same workflow as for the Poisson model: construct the `DataModel`, fit with identical MCEM settings, and inspect the results. Using the same algorithm configuration for both models ensures that any differences in fit quality reflect genuine differences in model adequacy rather than tuning artifacts.
+Same workflow as the Poisson, with identical MCEM settings — so differences reflect model adequacy, not tuning:
 
 ```julia
 dm_nb = DataModel(model_nb, df; primary_id=:Subject, time_col=:period_f)
@@ -608,7 +597,7 @@ Empirical Bayes random effects summary (across RE levels)
   eta                59        0.2344        0.5379       -0.0228        0.2442          0.43
 ```
 
-Generate the same fitted-trajectory and observation-distribution diagnostics as before. Comparing these plots side-by-side with the Poisson versions will reveal whether the Negative Binomial's wider predictive intervals better capture the observed variability in seizure counts.
+The same diagnostics as before; comparing with the Poisson shows whether the Negative Binomial's wider intervals better capture the observed variability.
 
 ```julia
 p_fit_nb = plot_fits(
@@ -633,7 +622,7 @@ p_fit_nb
 <!- injected:t5-pfitnb ->
 ![Fitted Negative Binomial seizure-rate trajectories for the first two subjects.](figures/t5/p_fit_nb.png)
 
-Display the Negative Binomial observation-distribution plot for direct comparison with the Poisson version above. Pay attention to the width of the predicted probability mass - the Negative Binomial should assign more probability to extreme counts.
+Compare the predicted probability mass with the Poisson version — the Negative Binomial should give more weight to extreme counts.
 
 ```julia
 p_obs_nb
@@ -642,7 +631,7 @@ p_obs_nb
 <!- injected:t5-pobsnb ->
 ![Predicted Negative Binomial probability mass at the first two observations of the first subject.](figures/t5/p_obs_nb.png)
 
-Compute Wald-based uncertainty for the Negative Binomial model and produce both standalone and combined summary tables, following the same procedure as for the Poisson fit.
+Wald uncertainty for the Negative Binomial, with standalone and combined tables:
 
 ```julia
 uq_nb = compute_uq(
@@ -694,7 +683,7 @@ Empirical Bayes random effects summary (across RE levels)
   eta                59        0.2344        0.5379       -0.0228        0.2442          0.43
 ```
 
-The uncertainty distribution plots for the Negative Binomial model now include the dispersion parameter `log_r` - a parameter with no counterpart in the Poisson model, whose magnitude directly quantifies the degree of overdispersion in the data.
+These distributions now include `log_r`, whose magnitude quantifies the overdispersion absent from the Poisson.
 
 ```julia
 plot_uq_distributions(uq_nb)
@@ -705,7 +694,7 @@ plot_uq_distributions(uq_nb)
 
 ## Step 4: Comparing Poisson and Negative Binomial Objectives
 
-As a final diagnostic, you will compare the objective function values (negative log-likelihoods) from the two fits. A word of caution: because the Poisson is a limiting case of the Negative Binomial (as `r` tends to infinity) rather than a strict parameter restriction, these values are not directly comparable via a standard likelihood ratio test. Nevertheless, a substantially lower objective for the Negative Binomial strongly suggests that the data exhibit overdispersion the Poisson cannot accommodate. Formal model comparison for this class of count models would require information criteria (AIC, BIC) or cross-validation, which are beyond the scope of this tutorial.
+Comparing the two objectives (negative log-likelihoods) needs care: the Poisson is a limiting case of the Negative Binomial (`r → ∞`), not a strict parameter restriction, so a standard likelihood-ratio test does not apply. Still, a substantially lower Negative Binomial objective points to overdispersion the Poisson cannot capture; formal selection would use information criteria (AIC, BIC) or cross-validation.
 
 ```julia
 (
@@ -719,4 +708,4 @@ As a final diagnostic, you will compare the objective function values (negative 
 (poisson_objective = -676.3985855275587, nb_objective = -645.9052503662361)
 ```
 
-Keep in mind that these two objective values arise from different likelihood families. They provide a useful heuristic comparison, but definitive model selection requires the formal tools mentioned above.
+The two objectives come from different likelihood families — a useful heuristic, but definitive selection needs the formal tools above.

--- a/docs/src/tutorials/mixed-effects-softtree-saem.md
+++ b/docs/src/tutorials/mixed-effects-softtree-saem.md
@@ -1,22 +1,17 @@
 # Mixed-Effects Tutorial 4: SoftTree Differential-Equation Components (SAEM)
 
-When building mechanistic models of longitudinal data, you often know the broad structure of the system - compartments, conservation laws, transfer pathways - but not the precise functional forms that govern how material moves between states. Neural networks are one way to learn those unknown rate functions from data, as shown in Tutorial 3. Soft decision trees offer an appealing alternative. They can approximate arbitrary nonlinear mappings, yet their branching structure provides built-in feature selection and piecewise-smooth approximation that is often easier to interpret. For the low-dimensional inputs typical of scientific rate functions (a single state variable, or time itself), soft trees can match neural network flexibility with substantially fewer parameters.
-
-In this tutorial, you will build a mixed-effects ODE model in which soft decision trees parameterize the ODE right-hand side, then estimate the model with the Stochastic Approximation Expectation-Maximization (SAEM) algorithm. The model is structurally parallel to Tutorial 3, so you can directly compare the two function-approximation strategies on the same data and compartmental structure.
+This tutorial mirrors the [Neural ODE tutorial](mixed-effects-nn-saem.md) but swaps the neural networks for soft decision trees as the rate-function approximators. Soft trees approximate arbitrary nonlinear mappings, and for the low-dimensional inputs typical of scientific rate functions (a single state, or time) they can match neural-network flexibility with fewer parameters and a more inspectable, piecewise-smooth structure. We build the same two-compartment ODE for the Theophylline data and fit it with Stochastic Approximation Expectation-Maximization (SAEM), with subject-level random effects on each tree's parameters.
 
 ## Learning Goals
 
-By the end of this tutorial, you will be able to:
-
-- Declare `SoftTreeParameters` blocks that create differentiable decision trees whose flattened parameters join the fixed-effects vector, exposing callable functions (e.g., `STA1`) for use inside `@DifferentialEquation`.
-- Wire multiple soft trees into a two-compartment transfer ODE, letting the trees learn unknown rate functions from data.
-- Couple each tree's parameter vector to subject-level random effects via `MvNormal` distributions, giving every individual a personalized version of the dynamics.
-- Fit the model with SAEM using its default settings, which remain stable even when the random-effect vectors are high-dimensional.
-- Visualize individual-level trajectories and observation distributions to assess model adequacy.
+- Declare `SoftTreeParameters` blocks and wire their callables (e.g. `STA1`) into `@DifferentialEquation`.
+- Couple each tree's parameters to subject-level random effects via `MvNormal`.
+- Fit with default SAEM, stable at high random-effect dimension.
+- Diagnose the fitted trajectories and observation distributions.
 
 ## Step 1: Data Setup
 
-In this step, you will load the Theophylline dataset used throughout these tutorials. The dataset records time-series measurements for 12 subjects and provides a clean example of two-compartment transfer dynamics: a substance enters a depot (input) compartment and moves to a central (observed) compartment, where it is measured and gradually cleared. You will reshape the data so that the initial amount `d` appears as a constant covariate for each subject.
+We use the Theophylline dataset (12 subjects) in a flat format where the dose `d` enters as a constant covariate — a two-compartment transfer system (depot → central → cleared).
 
 ```julia
 using NoLimits
@@ -71,14 +66,9 @@ first(df, 10)
 
 ## Step 2: Define SoftTree-Driven ODE Mixed-Effects Model
 
-In this step, you will construct the full mixed-effects model. The guiding idea is the same as in the neural ODE tutorial: rather than specifying closed-form rate laws, you let data-driven function approximators learn the rate functions directly from observations. The difference is the choice of approximator. Each `SoftTreeParameters` block declares a soft decision tree with a specified input dimension and depth. The `depth_st` parameter controls expressiveness - a tree of depth `d` has `2^d` leaf nodes, each contributing a smooth local approximation. The block's flattened parameters become part of the fixed-effects vector, and the associated callable function (e.g., `STA1`) evaluates the tree at any input.
+As in the Neural ODE tutorial, data-driven approximators learn the rate functions — here soft decision trees. Each `SoftTreeParameters` block declares a tree of given input dimension and depth (`depth_st`: a depth-`d` tree has `2^d` leaves); its flattened parameters join the fixed-effects vector and expose a callable (e.g. `STA1`) (see [function approximators](../model-building/universal-function-approximators.md)). Four trees drive the two-compartment system: `fA1`/`fA2` for the depot, `fC1`/`fC2` for the central compartment.
 
-The ODE system wires four soft trees into a two-compartment transfer model:
-
-- `fA1(t)` and `fA2(t)` govern the dynamics of the depot (input) compartment.
-- `fC1(t)` and `fC2(t)` govern the dynamics of the central (observed) compartment.
-
-To capture between-subject variability, each tree's parameter vector is paired with a subject-level random-effect vector drawn from an `MvNormal` distribution centered on the population parameters. This gives every individual a personalized version of the transfer dynamics while sharing structure across the population.
+Each tree's parameters are paired with a subject-level random-effect vector drawn from an `MvNormal` centered on the population parameters, giving every individual a personalized version of the dynamics.
 
 ```julia
 using NoLimits
@@ -145,9 +135,9 @@ model = set_solver_config(
 )
 ```
 
-Before moving on, inspect the assembled model to verify that all blocks - covariates, fixed effects, random effects, ODE, and formulas - are correctly wired together.
-
 ### Model Summary
+
+`summarize` confirms the blocks are wired correctly:
 
 ```julia
 model_summary = NoLimits.summarize(model)
@@ -221,7 +211,7 @@ Helper functions
 
 ## Step 3: Build `DataModel` and Configure SAEM
 
-In this step, you will pair the model with the observed data by constructing a `DataModel`, then configure the SAEM fitting algorithm. SAEM alternates between two phases: an E-step that samples subject-level random effects conditional on the current population parameters, and an M-step that updates those population parameters using stochastic sufficient statistics. Here we use the default configuration, `NoLimits.SAEM()`. With its defaults, SAEM draws the random effects with the adaptive Metropolis sampler (`SaemixMH`) in the E-step and updates the population parameters with a stochastic-approximation (Robbins-Monro) M-step. No special configuration is required even though each tree's full parameter vector is individualized, so the random-effect dimension is high. Running with defaults keeps the example simple and parallel to the neural-ODE tutorial, making the two function-approximation strategies directly comparable.
+After building the `DataModel`, we fit with default SAEM (`NoLimits.SAEM()`): an adaptive-Metropolis E-step samples the random effects, a stochastic-approximation (Robbins-Monro) M-step updates the population parameters (see [SAEM](../estimation/saem.md)). No tuning is needed despite the high random-effect dimension — a full tree-parameter vector per subject.
 
 ```julia
 dm = DataModel(model, df; primary_id=:ID, time_col=:t)
@@ -231,9 +221,9 @@ saem_method = NoLimits.SAEM()
 serialization = SciMLBase.EnsembleThreads()
 ```
 
-Before fitting, review the data model summary to confirm that individuals, covariates, and grouping structures were parsed as expected.
-
 ### DataModel Summary
+
+Confirm individuals, covariates, and grouping structures:
 
 ```julia
 dm_summary = NoLimits.summarize(dm)
@@ -318,7 +308,7 @@ Per-random-effect summary
 
 ## Step 4: Fit and Inspect Core Result Summary
 
-In this step, you will run the SAEM algorithm and examine the results. With the default settings the algorithm iterates up to 300 times, drawing the random effects with the adaptive Metropolis sampler within each E-step. After fitting completes, you will extract the final objective value and parameter count as a quick sanity check before looking at more detailed diagnostics.
+With defaults, SAEM runs up to 300 iterations. We extract the final objective and parameter count as a sanity check.
 
 ```julia
 res_saem = fit_model(
@@ -339,7 +329,7 @@ res_saem = fit_model(
 (objective = -644.2180056833639, n_params = 41)
 ```
 
-For a more detailed view - including parameter estimates and convergence diagnostics - call the `summarize` function on the fit result.
+`summarize` gives parameter estimates and convergence diagnostics:
 
 ```julia
 fit_summary_saem = NoLimits.summarize(res_saem)
@@ -417,7 +407,7 @@ Empirical Bayes random effects summary (across RE levels)
 
 ## Step 5: Fitted Trajectories (First 2 Individuals)
 
-In this step, you will overlay the model's predicted trajectories on the raw observations for the first two subjects. Plotting fitted curves against data provides an immediate visual assessment of model adequacy: do the predicted dynamics capture the timing and magnitude of the observed response?
+Overlaying predictions on the data for the first two subjects checks whether the trees capture the timing and magnitude of the response.
 
 ```julia
 p_fit_saem = plot_fits(
@@ -437,7 +427,7 @@ p_fit_saem
 
 ## Step 6: Observation Distribution Diagnostic
 
-As a final check, you will examine the implied observation distribution at a single data point for the first individual. Rather than showing only a point prediction, this plot displays the full predictive distribution, letting you assess whether the residual variance is well-calibrated and the model's uncertainty envelope is reasonable.
+The predicted observation distribution at one data point for the first individual shows whether the residual variance is well-calibrated.
 
 ```julia
 p_obs_saem = plot_observation_distributions(
@@ -455,7 +445,7 @@ p_obs_saem
 
 ## Interpretation Notes
 
-- This modeling pattern combines mechanistic compartmental structure with soft decision tree function approximators inside a single mixed-effects ODE. The compartments encode known domain knowledge (mass conservation, transfer pathways), while the trees learn the unknown rate functions from data. This separation means you retain interpretable system structure without needing to specify rate-law functional forms in advance.
-- Compared to neural networks, soft trees can be more parameter-efficient for the low-dimensional inputs common in scientific rate functions, and their piecewise-smooth approximation may be easier to inspect post hoc. The choice between the two is problem-dependent; both can be embedded in the same NoLimits framework with minimal code changes (compare this tutorial with Tutorial 3).
-- Default SAEM (`NoLimits.SAEM()`) is sufficient here: the adaptive Metropolis E-step and stochastic-approximation M-step remain stable even when the individualized parameter vectors are high-dimensional. When defaults are not enough, SAEM also exposes closed-form Gaussian block updates through `builtin_stats=:closed_form` together with the `re_mean_params` mapping.
-- The structural settings in this tutorial (tree depth, ODE solver tolerances) are intentionally modest to keep runtime short. For production analyses, consider deeper trees, increasing `maxiters` and the number of MCMC samples to ensure thorough convergence, and tightening the ODE solver tolerances.
+- **Hybrid mechanistic-tree ODE.** The compartments encode known structure; the trees learn the unknown rate functions, so you keep interpretable structure without specifying rate-law forms.
+- **Trees vs networks.** Soft trees can be more parameter-efficient for the low-dimensional inputs common in rate functions, and their piecewise-smooth form is easier to inspect; both embed in the same framework with minimal code change (compare the [Neural ODE tutorial](mixed-effects-nn-saem.md)).
+- **Default SAEM suffices** even at high random-effect dimension. For finer control, use closed-form Gaussian block updates via `builtin_stats=:closed_form` with `re_mean_params`.
+- **Settings are modest for speed.** For production, use deeper trees, raise `maxiters` and sample counts, and tighten the ODE solver tolerances.

--- a/src/data_model/DataModel.jl
+++ b/src/data_model/DataModel.jl
@@ -22,7 +22,7 @@ using Random
 """
     DataModelConfig{S}
 
-Configuration struct for a [`DataModel`](@ref), storing column names, serialisation
+Configuration struct for a [`DataModel`](@ref), storing column names, serialization
 algorithm, and save-time mode.
 
 # Fields
@@ -778,7 +778,7 @@ end
 
 # Materialise a covariate-vector value from a NamedTuple of its per-column entries.
 # When every entry is `Real`, return a `ComponentArray` so the value behaves both as a
-# labelled record (`x.Age`, `x.weight`) AND as a numeric vector (`x' * β`, `dot(x, β)`,
+# labeled record (`x.Age`, `x.weight`) AND as a numeric vector (`x' * β`, `dot(x, β)`,
 # `sum(x)`, indexing). Non-numeric (e.g. categorical) covariate vectors stay NamedTuples:
 # field access still works and vector arithmetic is undefined for them anyway. The branch
 # is decided at compile time from the NamedTuple type, so the hot per-row path stays

--- a/src/distributions/outcomes/CoarsedObservedStatesMarkoModel.jl
+++ b/src/distributions/outcomes/CoarsedObservedStatesMarkoModel.jl
@@ -76,6 +76,34 @@ function posterior_hidden_states(dist::CoarsedObservedStatesMarkovModel, y)
         eltype(probabilities_hidden_states(dist.base_dist)), dist.base_dist.n_states)
 end
 
+# Combined accessor sharing the single base-distribution propagation between logpdf
+# and posterior; reuses the EXACT ops of the methods above (bit-identical). Shares
+# the matrix-exponential when the base is a continuous-time model.
+function _hmm_logpdf_and_posterior(
+        dist::CoarsedObservedStatesMarkovModel, y::AbstractVector)
+    idxs = _omm_coarsed_observation_indices(dist.base_dist.state_labels, y)
+    p = probabilities_hidden_states(dist.base_dist)
+    T = eltype(p)
+    post = zeros(T, dist.base_dist.n_states)
+    isempty(idxs) && return (-Inf, post)
+    mass = zero(T)
+    for idx in idxs
+        mass += p[idx]
+    end
+    (isfinite(mass) && mass > zero(T)) || return (-Inf, post)
+    inv_mass = inv(mass)
+    for idx in idxs
+        post[idx] = p[idx] * inv_mass
+    end
+    return (log(mass), post)
+end
+
+function _hmm_logpdf_and_posterior(dist::CoarsedObservedStatesMarkovModel, y)
+    _omm_coarsed_observation_indices(dist.base_dist.state_labels, y)
+    return (-Inf,
+        zeros(eltype(probabilities_hidden_states(dist.base_dist)), dist.base_dist.n_states))
+end
+
 function Distributions.logpdf(dist::CoarsedObservedStatesMarkovModel, y::AbstractVector)
     idxs = _omm_coarsed_observation_indices(dist.base_dist.state_labels, y)
     isempty(idxs) && return -Inf

--- a/src/distributions/outcomes/ContinuousTimeHMM.jl
+++ b/src/distributions/outcomes/ContinuousTimeHMM.jl
@@ -352,7 +352,7 @@ Returns a vector of probabilities `p` where `p[s]` is `P(State = s | Y = y)`.
 Uses Bayes' rule: `P(S | Y) ∝ P(Y | S) * P(S)`
 """
 function posterior_hidden_states(hmm::ContinuousTimeDiscreteStatesHMM, y::Real)
-    # Per-state weighting/normalisation fused into tuples (bit-identical op
+    # Per-state weighting/normalization fused into tuples (bit-identical op
     # order); the matrix-exponential propagation inside
     # `probabilities_hidden_states` remains the dominant cost.
     p_hidden = probabilities_hidden_states(hmm)
@@ -376,6 +376,20 @@ function Distributions.logpdf(hmm::ContinuousTimeDiscreteStatesHMM, y::Real)
     pt = _hmm_probs_tuple(p_hidden, dists)
     xs = map((pi, d) -> log(pi) + logpdf(d, y), pt, dists)
     return _hmm_logsumexp(xs)
+end
+
+# Combined accessor sharing the single `exp(QΔt)` propagation (the dominant per-row
+# cost) between the likelihood and the posterior. Reuses the EXACT per-state ops of
+# `logpdf` and `posterior_hidden_states` above, so the returned pair is bit-identical
+# to calling them separately.
+function _hmm_logpdf_and_posterior(hmm::ContinuousTimeDiscreteStatesHMM, y::Real)
+    p_hidden = probabilities_hidden_states(hmm)
+    dists = hmm.emission_dists
+    pt = _hmm_probs_tuple(p_hidden, dists)
+    lp = _hmm_logsumexp(map((pi, d) -> log(pi) + logpdf(d, y), pt, dists))
+    u = map((pi, d) -> pi * pdf(d, y), pt, dists)
+    su = sum(u)
+    return lp, [ui / su for ui in u]
 end
 
 function Distributions.rand(rng::AbstractRNG, hmm::ContinuousTimeDiscreteStatesHMM)

--- a/src/distributions/outcomes/ContinuousTimeObservedStatesMarkovModel.jl
+++ b/src/distributions/outcomes/ContinuousTimeObservedStatesMarkovModel.jl
@@ -117,6 +117,24 @@ function posterior_hidden_states(
     return zeros(eltype(probabilities_hidden_states(dist)), dist.n_states)
 end
 
+# Combined accessor sharing the single `exp(QΔt)` propagation between logpdf and
+# posterior; reuses the EXACT ops of the methods above (bit-identical).
+function _hmm_logpdf_and_posterior(dist::ContinuousTimeObservedStatesMarkovModel, y)
+    idx = _omm_scalar_observation_index(dist.state_labels, y)
+    p = probabilities_hidden_states(dist)
+    T = eltype(p)
+    post = zeros(T, dist.n_states)
+    idx === nothing && return (-Inf, post)
+    post[idx] = one(T)
+    return (log(p[idx]), post)
+end
+
+function _hmm_logpdf_and_posterior(
+        dist::ContinuousTimeObservedStatesMarkovModel, y::AbstractVector)
+    _omm_scalar_observation_index(dist.state_labels, y)
+    return (-Inf, zeros(eltype(probabilities_hidden_states(dist)), dist.n_states))
+end
+
 # --- Distributions.jl interface ---
 
 function Distributions.logpdf(dist::ContinuousTimeObservedStatesMarkovModel, y)
@@ -141,7 +159,7 @@ Distributions.pdf(dist::ContinuousTimeObservedStatesMarkovModel, y) = exp(logpdf
 # and `pdf(::UnivariateDistribution, ::Real)`. Real scalars and 1-d vectors
 # already dispatch to the methods above; these forward the remaining array
 # shapes to the untyped handler (via `invoke`, to avoid self-recursion) so
-# behaviour is identical — the observation pipeline never constructs them.
+# behavior is identical — the observation pipeline never constructs them.
 function Distributions.logpdf(dist::ContinuousTimeObservedStatesMarkovModel,
         y::AbstractArray{<:Real, 0})
     invoke(

--- a/src/distributions/outcomes/DiscreteTimeHMM.jl
+++ b/src/distributions/outcomes/DiscreteTimeHMM.jl
@@ -52,7 +52,7 @@ end
 Compute the marginal prior probabilities of the hidden states at the current observation
 time, propagated from `hmm.initial_dist` through the transition dynamics.
 
-Returns a normalised probability vector of length `n_states`.
+Returns a normalized probability vector of length `n_states`.
 """
 function probabilities_hidden_states(hmm::DiscreteTimeDiscreteStatesHMM)
     # Propagate one discrete step from the provided prior state probabilities.
@@ -66,8 +66,8 @@ end
 Compute posterior probabilities of hidden states given observation `y`.
 """
 function posterior_hidden_states(hmm::DiscreteTimeDiscreteStatesHMM, y::Real)
-    # Same op order as the former vector pipeline (propagate, normalise by the
-    # same sum, weight by the emission pdf, normalise) with the per-state steps
+    # Same op order as the former vector pipeline (propagate, normalize by the
+    # same sum, weight by the emission pdf, normalize) with the per-state steps
     # fused into tuples — bit-identical values, one matvec + the output vector
     # instead of four intermediate vectors per call (this runs once per row in
     # the HMM forward filter).

--- a/src/distributions/outcomes/DiscreteTimeObservedStatesMarkovModel.jl
+++ b/src/distributions/outcomes/DiscreteTimeObservedStatesMarkovModel.jl
@@ -25,7 +25,7 @@ Used as an observation distribution in `@formulas` blocks.
 # Missing data
 When the observation is `missing`, the predicted state distribution (after one transition step)
 is propagated forward without a likelihood contribution — identical to the HMM missing-data
-behaviour.
+behavior.
 """
 struct DiscreteTimeObservedStatesMarkovModel{
     M <: AbstractMatrix{<:Real},
@@ -130,7 +130,7 @@ Distributions.pdf(dist::DiscreteTimeObservedStatesMarkovModel, y) = exp(logpdf(d
 # and `pdf(::UnivariateDistribution, ::Real)`. Real scalars and 1-d vectors
 # already dispatch to the methods above; these forward the remaining array
 # shapes to the untyped handler (via `invoke`, to avoid self-recursion) so
-# behaviour is identical — the observation pipeline never constructs them.
+# behavior is identical — the observation pipeline never constructs them.
 function Distributions.logpdf(dist::DiscreteTimeObservedStatesMarkovModel,
         y::AbstractArray{<:Real, 0})
     invoke(

--- a/src/distributions/outcomes/MVContinuousTimeHMM.jl
+++ b/src/distributions/outcomes/MVContinuousTimeHMM.jl
@@ -102,7 +102,7 @@ Posterior probabilities of hidden states given the length-M observation vector
 `y` (which may contain `missing` entries). Uses all non-missing outcomes jointly.
 """
 function posterior_hidden_states(hmm::MVContinuousTimeDiscreteStatesHMM, y::AbstractVector)
-    # Tuple-fused per-state weighting/normalisation (bit-identical op order);
+    # Tuple-fused per-state weighting/normalization (bit-identical op order);
     # the matrix-exponential propagation remains the dominant cost.
     p_hidden = probabilities_hidden_states(hmm)
     dists = hmm.emission_dists
@@ -110,6 +110,19 @@ function posterior_hidden_states(hmm::MVContinuousTimeDiscreteStatesHMM, y::Abst
     u = map((pi, d) -> pi * exp(_mv_emission_logpdf(d, y)), pt, dists)
     su = sum(u)
     return [ui / su for ui in u]
+end
+
+# Combined accessor sharing the single matrix-exponential propagation between the
+# likelihood and posterior; reuses the EXACT per-state ops above (bit-identical).
+function _hmm_logpdf_and_posterior(hmm::MVContinuousTimeDiscreteStatesHMM,
+        y::AbstractVector)
+    p_hidden = probabilities_hidden_states(hmm)
+    dists = hmm.emission_dists
+    pt = _hmm_probs_tuple(p_hidden, dists)
+    lp = _hmm_logsumexp(map((pi, d) -> log(pi) + _mv_emission_logpdf(d, y), pt, dists))
+    u = map((pi, d) -> pi * exp(_mv_emission_logpdf(d, y)), pt, dists)
+    su = sum(u)
+    return lp, [ui / su for ui in u]
 end
 
 # ---------------------------------------------------------------------------

--- a/src/distributions/outcomes/_HMMUtils.jl
+++ b/src/distributions/outcomes/_HMMUtils.jl
@@ -26,3 +26,16 @@ end
 # work into tuple operations without allocating intermediate vectors.
 @inline _hmm_probs_tuple(p::AbstractVector, ::NTuple{N, Any}) where {N} = ntuple(
     i -> @inbounds(p[i]), Val(N))
+
+# Combined per-row HMM accessor: returns (logpdf(d, y), posterior_hidden_states(d, y)).
+# The forward-filter loop in `_loglikelihood_individual` (and cv) needs BOTH every
+# observed row. The continuous-time families recompute the state-probability
+# propagation `exp(QΔt)` (the dominant per-row cost) once in `logpdf` and again in
+# `posterior_hidden_states`; they specialise this accessor to propagate ONCE and
+# reuse it for both, using the EXACT per-state ops of the two methods (bit-identical
+# values). The generic fallback below just calls both — correct for every family;
+# the discrete-time families inline `transpose(M)*p` and so share nothing, gaining
+# nothing from a specialisation but losing nothing from the fallback. Specialisations
+# live in the CT family files (ContinuousTimeHMM / MVContinuousTimeHMM /
+# ContinuousTimeObservedStatesMarkovModel / CoarsedObservedStatesMarkoModel).
+@inline _hmm_logpdf_and_posterior(d, y) = (logpdf(d, y), posterior_hidden_states(d, y))

--- a/src/distributions/random_effects/NormalizingPlanarFlows.jl
+++ b/src/distributions/random_effects/NormalizingPlanarFlows.jl
@@ -208,7 +208,7 @@ end
 # Use the underlying transformed distribution's bijector for HMC/NUTS.
 Bijectors.bijector(d::NormalizingPlanarFlow) = Bijectors.bijector(d.base)
 
-# DynamicPPL >=0.41 vectorises a variable's link via `Bijectors.VectorBijectors.to_linked_vec(dist)`
+# DynamicPPL >=0.41 vectorizes a variable's link via `Bijectors.VectorBijectors.to_linked_vec(dist)`
 # on the tilde path. Delegate to the underlying transformed distribution (consistent with the
 # bijector delegation above). Guarded so the package still loads on Bijectors < 0.16, which has
 # no `VectorBijectors` submodule (and whose DynamicPPL never calls this).
@@ -228,7 +228,7 @@ Bijectors.bijector(d::NormalizingPlanarFlow) = Bijectors.bijector(d.base)
     end
 end
 
-# Estimate covariance via sampling — used only for MH step-size initialisation,
+# Estimate covariance via sampling — used only for MH step-size initialization,
 # so an empirical approximation is sufficient.
 function Statistics.cov(d::NormalizingPlanarFlow; n_samples::Int = 2000)
     Statistics.cov(rand(default_rng(), d, n_samples)')

--- a/src/estimation/Multistart.jl
+++ b/src/estimation/Multistart.jl
@@ -24,13 +24,13 @@ parameter vectors and returns the best result.
 
 Starting points are drawn either from the fixed-effect priors or from user-supplied
 `dists`; the top-`n_draws_used` candidates (by a cheap objective evaluation) are then
-fully optimised.
+fully optimized.
 
 # Keyword Arguments
 - `dists::NamedTuple = NamedTuple()`: per-parameter sampling distributions, keyed by
   fixed-effect name. Parameters without an entry use their prior, if available.
 - `n_draws_requested::Int = 100`: number of candidate starting points to sample.
-- `n_draws_used::Int = 50`: number of candidates to fully optimise after screening.
+- `n_draws_used::Int = 50`: number of candidates to fully optimize after screening.
 - `sampling::Symbol = :random`: sampling strategy for starting points: `:random` or `:lhs`
   (Latin hypercube sampling).
 - `serialization::SciMLBase.EnsembleAlgorithm = EnsembleThreads()`: parallelisation
@@ -41,9 +41,9 @@ fully optimised.
   - `:prior_mean` — evaluates the observation log-likelihood with random effects fixed at
     their prior means under each candidate θ. Fast but ignores RE adaptability.
   - `:ebe` — for each candidate θ, first computes per-individual Empirical Bayes Estimates
-    (EBEs) by maximising the joint log-density (observation ll + RE prior), then uses the
+    (EBEs) by maximizing the joint log-density (observation ll + RE prior), then uses the
     resulting joint log-density as the screening score. More accurate but slower.
-- `ebe_maxiters::Int = 30`: maximum inner-optimisation iterations per individual when
+- `ebe_maxiters::Int = 30`: maximum inner-optimization iterations per individual when
   `screening = :ebe`. Lower values trade accuracy for speed.
 """
 struct Multistart{D, S, R}
@@ -351,7 +351,7 @@ function _build_mean_eta(dm::DataModel, θu::ComponentArray)
     return etas
 end
 
-# Compute per-individual EBEs by maximising the joint log-density (obs ll + RE prior)
+# Compute per-individual EBEs by maximizing the joint log-density (obs ll + RE prior)
 # for each candidate θu.  Returns (etas, joint_score) where joint_score is the total
 # joint log-density at the EBEs (used as the screening score).
 function _build_ebe_eta(dm::DataModel, θu::ComponentArray, ll_cache; maxiters::Int = 30)
@@ -403,7 +403,7 @@ function _build_ebe_eta(dm::DataModel, θu::ComponentArray, ll_cache; maxiters::
             etas[i] = η0_i
             continue
         end
-        # Closure: negative joint log-density to minimise
+        # Closure: negative joint log-density to minimize
         neg_logf = let dm = dm, i = i, θu = θu, ll_cache = ll_cache,
             axs = axs, dists = dists, re_logpdf_fn = re_logpdf_fn,
             re_names = re_names, re_names_tuple = re_names_tuple
@@ -446,7 +446,7 @@ function _multistart_screen(dm::DataModel,
         screening::Symbol,
         ebe_maxiters::Int;
         progress::Bool = true)
-    # EBE inner optimisation is serial per individual; use EnsembleSerial for that path.
+    # EBE inner optimization is serial per individual; use EnsembleSerial for that path.
     cache_serialization = screening == :ebe ? EnsembleSerial() : serialization
     cache = build_ll_cache(dm; ode_args = ode_args, ode_kwargs = ode_kwargs,
         serialization = cache_serialization, force_saveat = true)
@@ -466,7 +466,7 @@ function _multistart_screen(dm::DataModel,
         progress && next!(screen_p)
     end
     idxs = partialsortperm(scores, 1:min(n_used, length(candidates)))
-    # Return selected candidates and their scores (sign-flipped back from minimisation scores)
+    # Return selected candidates and their scores (sign-flipped back from minimization scores)
     selected_scores = [-scores[j] for j in idxs]
     return candidates[idxs], selected_scores
 end

--- a/src/estimation/adaptive_mh.jl
+++ b/src/estimation/adaptive_mh.jl
@@ -45,7 +45,7 @@ implicit rejection (proposals outside the support yield `logpdf = -Inf`).
 - `adapt_start::Int = 50`: pooled sample count before Haario updates begin.
 - `init_scale::Float64 = 1.0`: multiplier on the prior-based initial proposal
   covariance.
-- `eps_reg::Float64 = 1e-6`: regularisation added to the diagonal of the
+- `eps_reg::Float64 = 1e-6`: regularization added to the diagonal of the
   proposal covariance to ensure positive-definiteness.
 
 # Usage
@@ -205,7 +205,7 @@ end
 # at runtime), forcing dynamic dispatch and an allocation on every call — these wrappers
 # sit in the per-coordinate MH proposal inner loop. Branching over the finite set of known
 # RE-type symbols lets each branch dispatch to a `Val`-*literal* method (a compile-time
-# constant), eliminating the dynamic `Val(s)` construction. Behaviour is identical: the
+# constant), eliminating the dynamic `Val(s)` construction. Behavior is identical: the
 # branch set is exactly the set of specialised `Val{:X}` methods, and any other symbol
 # falls through to the generic `::Val` identity method.
 @inline function _amh_bij_forward(s::Symbol, η)
@@ -288,7 +288,24 @@ end
 
 # Fallback: identity bijection, Jacobian = 1
 @inline _bij_log_jac_forward(::Val, z) = 0.0
-@inline _bij_log_jac_forward(s::Symbol, z) = _bij_log_jac_forward(Val(s), z)
+# Symbol entrypoint: branch over the known RE-type symbols so each dispatches to a
+# `Val`-literal method (compile-time constant) instead of materialising `Val(s)` from
+# a runtime Symbol (non-inferrable type → dynamic dispatch + boxing per IS sample).
+# Mirrors `_amh_bij_forward`/`_amh_bij_inverse`/`_amh_bij_log_jac`; behavior is
+# identical (the branch set is exactly the specialised `Val{:X}` methods; any other
+# symbol falls through to the generic `::Val` identity method via `Val(s)`).
+@inline function _bij_log_jac_forward(s::Symbol, z)
+    s === :Normal && return _bij_log_jac_forward(Val(:Normal), z)
+    s === :LogNormal && return _bij_log_jac_forward(Val(:LogNormal), z)
+    s === :Exponential && return _bij_log_jac_forward(Val(:Exponential), z)
+    s === :Beta && return _bij_log_jac_forward(Val(:Beta), z)
+    s === :MvNormal && return _bij_log_jac_forward(Val(:MvNormal), z)
+    s === :MvLogNormal && return _bij_log_jac_forward(Val(:MvLogNormal), z)
+    s === :MvLogitNormal && return _bij_log_jac_forward(Val(:MvLogitNormal), z)
+    s === :NormalizingPlanarFlow &&
+        return _bij_log_jac_forward(Val(:NormalizingPlanarFlow), z)
+    return _bij_log_jac_forward(Val(s), z)
+end
 
 # ---------------------------------------------------------------------------
 # Initial proposal covariance from prior distribution
@@ -422,7 +439,7 @@ function _amh_haario_update!(block::_REAdaptBlock, z::AbstractVector{<:Real},
     end
     if n >= max(adapt_start + 1, 2)
         λ = 2.38^2 / d
-        # Scale into C, then add the regulariser to the diagonal only — the
+        # Scale into C, then add the regularizer to the diagonal only — the
         # previous `eps_reg * Id` materialised a dense d×d identity per MH step.
         @. block.C = λ * block.S_run / (n - 1)
         for j in 1:d
@@ -453,7 +470,7 @@ function _amh_build_level_inds(info::_LaplaceBatchInfo, ri::Int,
 end
 
 # ---------------------------------------------------------------------------
-# State initialisation
+# State initialization
 # ---------------------------------------------------------------------------
 
 function _amh_init_state(dm::DataModel, info::_LaplaceBatchInfo,
@@ -478,7 +495,7 @@ function _amh_init_state(dm::DataModel, info::_LaplaceBatchInfo,
         dim = re_info.dim
         n_levels == 0 && continue
 
-        # Sample from prior to initialise b
+        # Sample from prior to initialize b
         for (li, _) in enumerate(levels)
             const_cov = dm.individuals[re_info.reps[li]].const_cov
             dists = dists_builder(θ_re, const_cov, model_funs, helpers)
@@ -517,7 +534,7 @@ function _amh_init_state(dm::DataModel, info::_LaplaceBatchInfo,
         lp_offset += n_levels
     end
 
-    # Initialise per-individual and per-level caches
+    # Initialize per-individual and per-level caches
     ind_ll, re_lp, logp = _amh_compute_full_ll(dm, info, θ_re, b_current,
         const_cache, cache, blocks,
         dists_builder, model_funs, helpers)
@@ -565,10 +582,9 @@ end
 # Recompute caches in-place after an M-step (θ changed, b_current unchanged).
 function _amh_recompute_ll_cache!(state::_AdaptiveMHState,
         dm::DataModel, info::_LaplaceBatchInfo,
-        θ::ComponentArray,
+        θ_re::ComponentArray,   # pre-symmetrized by the caller
         const_cache::LaplaceConstantsCache,
         cache::_LLCache)
-    θ_re = _symmetrize_psd_params(θ, dm.model.fixed.fixed)
     dists_builder = get_create_random_effect_distribution(dm.model.random.random)
     model_funs = cache.model_funs
     helpers = cache.helpers
@@ -603,12 +619,13 @@ end
 # ---------------------------------------------------------------------------
 
 function _amh_step!(state::_AdaptiveMHState, dm::DataModel,
-        info::_LaplaceBatchInfo, θ::ComponentArray,
+        info::_LaplaceBatchInfo, θ_re::ComponentArray,
         const_cache::LaplaceConstantsCache, cache::_LLCache,
         sampler::AdaptiveNoLimitsMH, rng::AbstractRNG;
         anneal_sds::NamedTuple = NamedTuple())
+    # θ_re is pre-symmetrized once per E-step by the caller (this used to re-copy the
+    # PSD blocks of θ on every one of the ~n_samples steps per E-step).
     b = state.b_current
-    θ_re = _symmetrize_psd_params(θ, dm.model.fixed.fixed)
     dists_builder = get_create_random_effect_distribution(dm.model.random.random)
     model_funs = cache.model_funs
     helpers = cache.helpers
@@ -767,10 +784,14 @@ function _mcem_sample_batch(dm::DataModel, info::_LaplaceBatchInfo,
     end
     n_samples = get(turing_kwargs, :n_samples, 100)
 
-    # Restore adaptation state or initialise from prior
+    # θ is constant across the whole E-step — symmetrize the PSD blocks ONCE here and
+    # thread θ_re into the per-step kernel and the resync (each re-copied θ otherwise).
+    θ_re = _symmetrize_psd_params(θ, dm.model.fixed.fixed)
+
+    # Restore adaptation state or initialize from prior
     state = if warm_start && last_params isa _AdaptiveMHState
         # θ has changed since last iteration — recompute ind_ll and re_lp in-place.
-        _amh_recompute_ll_cache!(last_params, dm, info, θ, const_cache, cache)
+        _amh_recompute_ll_cache!(last_params, dm, info, θ_re, const_cache, cache)
         last_params
     else
         _amh_init_state(dm, info, θ, re_names, const_cache, cache, sampler, rng)
@@ -779,7 +800,7 @@ function _mcem_sample_batch(dm::DataModel, info::_LaplaceBatchInfo,
     # Run the chain
     samples = Matrix{Float64}(undef, nb, n_samples)
     for i in 1:n_samples
-        _amh_step!(state, dm, info, θ, const_cache, cache, sampler, rng;
+        _amh_step!(state, dm, info, θ_re, const_cache, cache, sampler, rng;
             anneal_sds = anneal_sds)
         samples[:, i] .= state.b_current
     end

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -57,7 +57,7 @@ abstract type FittingMethod end
 
 Lightweight stub that records which fitting method was used when a [`FitResult`](@ref)
 is loaded from disk via [`load_fit`](@ref). Replaces the full method struct (which
-contains optimiser closures that cannot be serialised) on save.
+contains optimizer closures that cannot be serialized) on save.
 
 `get_method(res).kind` returns a Symbol such as `:mle`, `:map`, `:laplace`, etc.
 """
@@ -68,7 +68,7 @@ end
 
 function Base.show(io::IO, m::_SavedFittingMethod)
     print(io,
-        "_SavedFittingMethod(:$(m.kind)) [loaded from disk; original optimiser not stored]")
+        "_SavedFittingMethod(:$(m.kind)) [loaded from disk; original optimizer not stored]")
 end
 
 """
@@ -184,11 +184,11 @@ end
 """
     FitParameters{T, U}
 
-Stores parameter estimates on both the transformed (optimisation) and untransformed
+Stores parameter estimates on both the transformed (optimization) and untransformed
 (natural) scales as `ComponentArray`s.
 
 # Fields
-- `transformed::T`: parameter vector on the optimisation scale.
+- `transformed::T`: parameter vector on the optimization scale.
 - `untransformed::U`: parameter vector on the natural scale.
 """
 struct FitParameters{T, U}
@@ -358,7 +358,7 @@ Return the estimated parameter vector.
 # Keyword Arguments
 - `scale::Symbol = :both`: which scale to return.
   - `:both` — a [`FitParameters`](@ref) struct with both scales.
-  - `:transformed` — the optimisation-scale `ComponentArray`.
+  - `:transformed` — the optimization-scale `ComponentArray`.
   - `:untransformed` — the natural-scale `ComponentArray`.
 """
 function get_params(res::FitResult; scale::Symbol = :both)
@@ -383,7 +383,7 @@ get_chain(::MethodResult) = error("Chain access not supported for this method.")
 """
     get_iterations(res::FitResult) -> Int
 
-Return the number of optimiser iterations. Valid for optimisation-based methods
+Return the number of optimizer iterations. Valid for optimization-based methods
 (MLE, MAP, Laplace, MCEM, SAEM).
 """
 get_iterations(res::FitResult) = get_iterations(res.result)
@@ -1137,7 +1137,7 @@ The sampling mechanism matches the one the fitting method itself uses for the
 conditional distribution, so the draws are consistent with the E-step:
 
 - `Laplace`, `GHQuadrature`: Gaussian Laplace
-  approximation centred at the EBE mode ``b^\\star`` with covariance
+  approximation centered at the EBE mode ``b^\\star`` with covariance
   ``(-H)^{-1}``, where ``H`` is the Hessian of the joint log-density at ``b^\\star``.
 - `MCEM`, `SAEM`: MCMC samples drawn from the exact conditional with the same
   sampler used in the E-step (Turing sampler for MCEM, `SaemixMH` or Turing
@@ -1157,7 +1157,7 @@ jointly and split per individual.
 - `warm_start::Bool = true`: seed the MCMC chain at the EB mode (MCMC path only).
 - `sampler = nothing`: override the MCMC sampler used for MCEM/SAEM. Defaults to
   the sampler stored on the fit method, or to `SaemixMH()` when the result was
-  loaded from disk (where the original sampler is not serialised).
+  loaded from disk (where the original sampler is not serialized).
 - `turing_kwargs::NamedTuple = NamedTuple()`: extra kwargs passed through to the
   MCMC sampler. Merged on top of the method's stored `turing_kwargs` when those
   are available.
@@ -1247,18 +1247,18 @@ end
 
 Re-estimate empirical Bayes estimates (EBEs) from a fitted model, ignoring any EBEs
 stored in the result. Returns a new `FitResult` with `eb_modes` replaced by the
-freshly-optimised modes. Use `get_random_effects` on the returned result to obtain the
+freshly-optimized modes. Use `get_random_effects` on the returned result to obtain the
 corresponding `NamedTuple` of `DataFrame`s.
 
 Supported methods: `Laplace`, `MCEM`, `SAEM`.
 
 # Keyword Arguments
-- `ebe_optimizer`: inner optimiser for EBE mode-finding (default: `LBFGS` with backtracking).
+- `ebe_optimizer`: inner optimizer for EBE mode-finding (default: `LBFGS` with backtracking).
 - `ebe_optim_kwargs::NamedTuple`: extra kwargs forwarded to `Optimization.solve`.
 - `ebe_adtype`: automatic differentiation type (default: `AutoForwardDiff()`).
 - `ebe_grad_tol`: gradient convergence tolerance (default: `:auto`).
 - `ebe_multistart_n::Int`: number of multistart candidates (default: `50`).
-- `ebe_multistart_k::Int`: k-means clusters for multistart initialisation (default: `1`).
+- `ebe_multistart_k::Int`: k-means clusters for multistart initialization (default: `1`).
 - `ebe_multistart_max_rounds::Int`: maximum multistart refinement rounds (default: `5`).
 - `ebe_multistart_sampling::Symbol`: candidate sampling strategy — `:lhs`, `:random`, or `:mcmc`
   (default: `:lhs`). With `:mcmc`, `ebe_multistart_n` conditional posterior samples are drawn
@@ -1277,8 +1277,8 @@ Supported methods: `Laplace`, `MCEM`, `SAEM`.
 - `ebe_rescue_multistart_sampling::Symbol`: sampling for rescue (default: `:lhs`).
 - `constants_re::NamedTuple`: fix specific RE levels at given values (natural scale).
 - `individuals`: `nothing` (all) or a vector of primary IDs. When provided, only batches
-  containing at least one listed individual are re-optimised; the remaining batches retain
-  the `eb_modes` already stored in `res`. Co-batch individuals are always re-optimised.
+  containing at least one listed individual are re-optimized; the remaining batches retain
+  the `eb_modes` already stored in `res`. Co-batch individuals are always re-optimized.
 - `ode_args::Tuple`, `ode_kwargs::NamedTuple`: forwarded to the ODE solver.
 - `rng::AbstractRNG`: random number generator.
 - `progress::Bool`: show progress bar (default: `false`).
@@ -1501,7 +1501,7 @@ Laplace, SAEM, MCEM, GHQuadrature.
 - `mc_integrator::Union{Nothing, MCIntegrator}`: if not `nothing`, use Monte Carlo
   sampling for **all** batches instead of AGHQ. See [`MCIntegrator`](@ref).
 - `fallback::Union{Nothing, MCIntegrator}`: what to do when the Cholesky of `-H` fails
-  for a batch. `nothing` raises an error (old behaviour). An `MCIntegrator` falls back to
+  for a batch. `nothing` raises an error (old behavior). An `MCIntegrator` falls back to
   sampling for that batch and issues a warning. Default: `MCIntegrator()` (Turing-based sampling,
   1000 samples).
 """
@@ -1659,7 +1659,7 @@ Fit a model to data using the specified estimation method.
 
 # Keyword Arguments
 - `constants::NamedTuple = NamedTuple()`: fix named parameters at given values on the
-  natural scale. Fixed parameters are removed from the optimiser state.
+  natural scale. Fixed parameters are removed from the optimizer state.
 - `penalty::NamedTuple = NamedTuple()`: add per-parameter quadratic penalties on the
   natural scale (not available for MCMC).
 - `ode_args::Tuple = ()`: extra positional arguments forwarded to the ODE solver.
@@ -2021,24 +2021,46 @@ function _loglikelihood_individual_rowwise(dm::DataModel, idx::Int, θ, η_ind,
     model = dm.model
     ind = dm.individuals[idx]
     obs_rows = dm.row_groups.obs_rows[idx]
+    T_el = promote_type(eltype(θ), eltype(η_ind))
+    isempty(obs_rows) && return zero(T_el)
     const_cov = ind.const_cov
     obs_series = ind.series.obs
+    obs_cols = dm.config.obs_cols
     vary_cache = cache.vary_cache === nothing ? nothing : cache.vary_cache[idx]
     t_obs = vary_cache === nothing ? _get_col(dm.df, dm.config.time_col)[obs_rows] : nothing
-    T_el = promote_type(eltype(θ), eltype(η_ind))
-    ll = zero(T_el)
-    obs_cols = dm.config.obs_cols
-    isempty(obs_rows) && return ll
+    # `_row_re_template` derives its axes from the deliberately-boxing
+    # `_row_random_effects_at`, so `row_tmpl` is statically `_RowREFill{Any}`.
+    # Pass it into the row loop behind a function barrier (`tmpl::TM` type
+    # parameter) so the axes become concrete there: `_row_random_effects_fill`
+    # then returns a concrete ComponentVector and the formulas/logpdf calls
+    # dispatch statically — mirroring the `_ll_rows_obs` fast path. (Without the
+    # barrier every per-row `calculate_formulas_obs`/`getproperty`/`logpdf` boxed
+    # through `Any`.)
     row_tmpl = _row_re_template(dm, idx, 1, η_ind; obs_only = true)
+    return _ll_rows_obs_rowwise(dm, idx, model, θ, η_ind, cache, sol_accessors,
+        const_cov, obs_series, obs_cols, vary_cache, ind, t_obs, row_tmpl, T_el)
+end
+
+# Row loop of `_loglikelihood_individual_rowwise` behind a function barrier: with
+# `tmpl::TM` arriving as a concrete type parameter the per-row η ComponentVector is
+# concrete, so the formulas RGF call, observation field accesses, and logpdf
+# evaluations dispatch statically (same role as `_ll_rows_obs`, but with per-row η
+# re-selection retained). HMM-free fast path; the first HMM-producing row hands the
+# remainder to `_loglikelihood_rows_hmm`.
+function _ll_rows_obs_rowwise(dm::DataModel, idx::Int, model::M, θ, η_ind,
+        cache::_LLCache, sol_accessors, const_cov::CC, obs_series::OS, obs_cols,
+        vary_cache, ind, t_obs, tmpl::TM, ::Type{T}) where {M, CC, OS, TM, T}
+    obs_rows = dm.row_groups.obs_rows[idx]
+    ll = zero(T)
     for i in eachindex(obs_rows)
         vary = vary_cache === nothing ? _varying_at(dm, ind, i, t_obs) : vary_cache[i]
-        η_row = _row_random_effects_fill(dm, idx, i, η_ind, row_tmpl; obs_only = true)
+        η_row = _row_random_effects_fill(dm, idx, i, η_ind, tmpl; obs_only = true)
         obs = sol_accessors === nothing ?
               calculate_formulas_obs(model, θ, η_row, const_cov, vary) :
               calculate_formulas_obs(model, θ, η_row, const_cov, vary, sol_accessors)
         if _row_has_hmm_dist(obs, obs_cols)
             ll_hmm = _loglikelihood_rows_hmm(dm, idx, θ, η_ind, cache, sol_accessors, i)
-            isfinite(ll_hmm) || return -Inf
+            isfinite(ll_hmm) || return T(-Inf)
             return ll + ll_hmm
         end
         for col in obs_cols
@@ -2048,7 +2070,7 @@ function _loglikelihood_individual_rowwise(dm::DataModel, idx::Int, θ, η_ind,
             v = _fast_logpdf(dist, y)
             v === nothing && (v = logpdf(dist, y))
             if !isfinite(v)
-                return -Inf
+                return T(-Inf)
             end
             ll += v
         end
@@ -2182,25 +2204,23 @@ function _loglikelihood_rows_hmm(dm::DataModel, idx::Int, θ, η_ind, cache::_LL
                     hmm_has_prior[j] = true
                     continue
                 end
-                v = try
-                    logpdf(dist_use, y)
+                # Combined accessor: continuous-time families propagate the hidden
+                # state once and reuse it for both the likelihood and the posterior
+                # (was two independent `exp(QΔt)` propagations per observed row). The
+                # returned pair is bit-identical to separate logpdf/posterior calls.
+                lp_post = try
+                    _hmm_logpdf_and_posterior(dist_use, y)
                 catch err
                     if err isa DomainError || err isa ArgumentError
                         return -Inf
                     end
                     rethrow(err)
                 end
+                v = lp_post[1]
                 if !isfinite(v)
                     return -Inf
                 end
-                hmm_priors[j] = try
-                    posterior_hidden_states(dist_use, y)
-                catch err
-                    if err isa DomainError || err isa ArgumentError
-                        return -Inf
-                    end
-                    rethrow(err)
-                end
+                hmm_priors[j] = lp_post[2]
                 hmm_has_prior[j] = true
             else
                 y === missing && continue

--- a/src/estimation/cv.jl
+++ b/src/estimation/cv.jl
@@ -38,7 +38,7 @@ end
     CVResult
 
 Aggregate cross-validation results. `obs_scores` combines all folds with a
-`:fold` column. `mean_test_loglikelihood` and `std_test_loglikelihood` summarise
+`:fold` column. `mean_test_loglikelihood` and `std_test_loglikelihood` summarize
 predictive performance across folds.
 """
 struct CVResult
@@ -376,7 +376,7 @@ end
 # Prior-mean RE value for an unseen test individual, shaped to match `ref` (a
 # scalar or vector component of a reference η). Tries the distribution mean, then
 # the median, then zero — mirroring `_re_start_value`, so non-zero-mean RE priors
-# (Beta, Gumbel, LogNormal, …) are honoured rather than collapsed to zero.
+# (Beta, Gumbel, LogNormal, …) are honored rather than collapsed to zero.
 function _re_prior_mean_or_zero(dist, ref)
     v = try
         Distributions.mean(dist)
@@ -444,7 +444,7 @@ function _cv_evaluate_ebe(dm_train, dm_test, res_train, θu, ll_cache_test, loss
     return _cv_collect_obs(dm_test, θu, η_test, ll_cache_test, loss)
 end
 
-# MC path: marginalise over the conditional (seen) or prior (unseen) using S MC draws.
+# MC path: marginalize over the conditional (seen) or prior (unseen) using S MC draws.
 # Aggregates per-obs log-likelihoods via logsumexp and predicted means via arithmetic mean.
 function _cv_evaluate_mc(dm_train, dm_test, res_train, θu, ll_cache_test, loss,
         seen_re_mode, unseen_re_mode, n_mc_samples, rng, re_names,

--- a/src/estimation/focei.jl
+++ b/src/estimation/focei.jl
@@ -25,7 +25,7 @@ using SpecialFunctions: trigamma
 #                    formula evaluation (and the ODE solve, if any),
 #   * ℐ(φ)          is the closed-form Fisher information of the outcome family
 #                    (the "expected information"), evaluated in Distributions.jl's
-#                    native parameterisation, and
+#                    native parameterization, and
 #   * −∇²_η log π   is the exact curvature of the random-effects prior (= Ω⁻¹ for
 #                    Normal/MvNormal random effects).
 #
@@ -35,7 +35,7 @@ using SpecialFunctions: trigamma
 # Hessian from second-order to first-order AD.
 #
 # FOCE (no interaction) freezes the dispersion-type parameters at the random-effects
-# prior mean mᵢ = mean(πᵢ) (= 0 for centred Normal random effects, the classical case)
+# prior mean mᵢ = mean(πᵢ) (= 0 for centered Normal random effects, the classical case)
 # and drops their η-sensitivity, while the location/structural parameters and their
 # Jacobian stay at the conditional mode η̂.
 # =====================================================================================
@@ -50,7 +50,7 @@ using SpecialFunctions: trigamma
 #   _focei_is_supported(d)          -> Bool
 #
 # The Jacobian carries every link / transform / ODE dependence, so ℐ is stored purely in
-# the native parameterisation.  Distributions without a registered ℐ are rejected up
+# the native parameterization.  Distributions without a registered ℐ are rejected up
 # front (no numeric fallback by design).
 # -------------------------------------------------------------------------------------
 
@@ -388,8 +388,8 @@ end
 # -------------------------------------------------------------------------------------
 
 # Robustness wrapper: distribution construction can throw on a numerically
-# degenerate θ the outer optimiser steps into (e.g. a singular Ω) — fall back to
-# the zero vector so the subsequent evaluations return -Inf and the optimiser
+# degenerate θ the outer optimizer steps into (e.g. a singular Ω) — fall back to
+# the zero vector so the subsequent evaluations return -Inf and the optimizer
 # backtracks instead of crashing the fit (mirrors `_laplace_logf_batch`).
 function _focei_prior_mean_b(
         dm::DataModel, batch_info::_LaplaceBatchInfo, θ_re::ComponentArray,
@@ -551,10 +551,10 @@ function _focei_data_term_obs!(
 end
 
 # Robustness wrapper (mirrors `_laplace_logf_batch`): an ODE solve or distribution
-# construction that throws on an unstable parameter region the optimiser steps into
+# construction that throws on an unstable parameter region the optimizer steps into
 # (e.g. a negative state driving a fractional power, or a negative scale) is turned into
 # a NaN Hessian. That makes the Cholesky/log-det fail and the marginal -Inf, so the outer
-# optimiser backtracks instead of crashing the whole fit — matching Laplace's behaviour.
+# optimizer backtracks instead of crashing the whole fit — matching Laplace's behavior.
 function _focei_negH_batch(dm::DataModel, batch_info::_LaplaceBatchInfo, θ, b,
         const_cache::LaplaceConstantsCache, cache::_LLCache;
         interaction::Bool, tctx = nothing)
@@ -588,7 +588,7 @@ function _focei_negH_batch_impl(dm::DataModel, batch_info::_LaplaceBatchInfo, θ
         J = ForwardDiff.jacobian(Φ, b)
         # Guard against an ODE solve that succeeds at the base point but reports failure
         # under the AD seed (length mismatch): signal a non-finite Hessian so the marginal
-        # becomes -Inf and the outer optimiser backtracks out of the unstable region.
+        # becomes -Inf and the outer optimizer backtracks out of the unstable region.
         D_expected = sum(_focei_paramcount, dists_b; init = 0)
         size(J, 1) == D_expected || return fill(convert(T, NaN), nb, nb)
         dists_m = nothing
@@ -615,7 +615,7 @@ end
 # -------------------------------------------------------------------------------------
 # 5. Hessian-builder plug-in for the shared Laplace objective/gradient machinery.
 #
-# FOCEI reuses Laplace's optimised marginal objective and trace-estimator gradient
+# FOCEI reuses Laplace's optimized marginal objective and trace-estimator gradient
 # (config/buffer caching, the implicit db*/dθ term, batching, threading) verbatim,
 # swapping only the inner Hessian via `_build_hess_b`.  The builder returns H = ∇²_b log f
 # so that the downstream `negH = -H`; FOCEI's negH IS 𝓗 = Σ Jᵀ ℐ(φ) J − ∇²log π, hence it

--- a/src/estimation/ghquadrature.jl
+++ b/src/estimation/ghquadrature.jl
@@ -30,7 +30,7 @@ Approximates the batch marginal likelihood via
     log L_batch ≈ signed_logsumexp_r [ log|W_r| + Σᵢ ℓᵢ(μ + Lzᵣ, θ) ]
 
 where `{(zᵣ, Wᵣ)}` are Smolyak–Gauss-Hermite quadrature nodes/weights at the
-requested `level`.  Unlike `Laplace`, there is no inner optimisation during the
+requested `level`.  Unlike `Laplace`, there is no inner optimization during the
 forward pass: the objective is fully differentiable by `AutoForwardDiff`.
 
 # Keyword Arguments
@@ -41,14 +41,14 @@ forward pass: the objective is fully differentiable by `AutoForwardDiff`.
     level 1.  The batch grid is the tensor product of per-group Smolyak grids.
   Levels 1–3 are numerically stable; higher levels may exhibit cancellation
   in signed logsumexp.
-- `optimizer`: outer Optimization.jl-compatible optimiser.  Defaults to LBFGS
+- `optimizer`: outer Optimization.jl-compatible optimizer.  Defaults to LBFGS
   with backtracking line search.
 - `optim_kwargs::NamedTuple = NamedTuple()`: forwarded to `Optimization.solve`
   (e.g. `maxiters`, `reltol`).
 - `adtype`: AD backend for the outer gradient.  Defaults to
   `AutoForwardDiff()`.
 - `inner_options / inner_optimizer / inner_kwargs / inner_adtype / inner_grad_tol`:
-  configure the Laplace-style inner optimiser used **only post-hoc** to compute
+  configure the Laplace-style inner optimizer used **only post-hoc** to compute
   empirical-Bayes mode estimates for `get_random_effects`.
 - `multistart_options / multistart_n / multistart_k / multistart_grad_tol /
   multistart_max_rounds / multistart_sampling`: multistart settings for the

--- a/src/estimation/kernel.jl
+++ b/src/estimation/kernel.jl
@@ -13,7 +13,7 @@ Numerically stable computation of log|Σ_r s_r exp(a_r)| where s_r ∈ {+1, -1}.
 
 Returns `(log|result|, sign(result))` as `(Float64, Int8)`.
 
-The sum is split into positive and negative contributions, each stabilised by
+The sum is split into positive and negative contributions, each stabilized by
 the maximum over all `logvals`:
 
     pos = Σ_{s_r=+1} exp(a_r - amax)
@@ -220,7 +220,7 @@ Estimate the batch marginal log-likelihood via MCMC-guided Gaussian importance s
 **Algorithm:**
 1. Run Turing MCMC with `n_warmup` adaptation (warmup) steps followed by `max(n_warmup, 50)`
    kept steps to draw approximate posterior samples `b_r ~ p(b | y, θ)`.
-2. Fit a Gaussian proposal `q = N(μ, Σ)` to those posterior samples (mean + regularised
+2. Fit a Gaussian proposal `q = N(μ, Σ)` to those posterior samples (mean + regularized
    covariance). This captures the location and scale of the posterior without assuming
    anything about its shape at the mode.
 3. Draw `n_samples` **fresh** IID samples from `q`. These are the IS points.

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -528,7 +528,18 @@ function _build_laplace_batch_infos(dm::DataModel, constants_re::NamedTuple)
             map = _LaplaceREMap(levels, level_to_index)
             re_info[ri] = _LaplaceREInfo(map, ranges, reps, dim, is_scalar)
         end
-        batch_infos[bi] = _LaplaceBatchInfo(inds, re_info, total_dim)
+        # Narrow `re_info` to a concrete eltype before storing it. The `undef`
+        # scratch buffer above has the abstract `_LaplaceREInfo` eltype, which makes
+        # `_LaplaceBatchInfo.re_info` abstract — so every `batch_info.re_info[ri]`
+        # field access on the per-row EBE hot path (`_build_eta_ind_fast`,
+        # `_laplace_logf_batch`, the grad/Hessian assembly) boxes and dynamic-
+        # dispatches. All entries share one concrete type, so `identity.` narrows
+        # the eltype with no data copy (same element objects); it auto-falls back to
+        # an abstract eltype if a future config ever mixes element types. The outer
+        # `batch_infos::Vector{_LaplaceBatchInfo}` stays abstract on purpose (the
+        # per-batch dispatch is amortized once per batch, and ~25 signatures across
+        # the estimators annotate `::Vector{_LaplaceBatchInfo}`).
+        batch_infos[bi] = _LaplaceBatchInfo(inds, identity.(re_info), total_dim)
     end
     return pairing, batch_infos, const_cache
 end
@@ -658,9 +669,9 @@ function _laplace_lhs_draws_mvnormal(dist, n::Int, rng::AbstractRNG, dim::Int)
 end
 
 # Robustness wrapper: RE-distribution construction can throw on a numerically
-# degenerate θ the outer optimiser steps into (e.g. a singular Ω, even on the
+# degenerate θ the outer optimizer steps into (e.g. a singular Ω, even on the
 # cholesky scale via exp-underflow). Fall back to a zero start — the subsequent
-# logf evaluation returns -Inf and the optimiser backtracks instead of the whole
+# logf evaluation returns -Inf and the optimizer backtracks instead of the whole
 # fit crashing (mirrors the `_laplace_logf_batch` exception policy).
 function _laplace_default_b0(dm::DataModel,
         batch_info::_LaplaceBatchInfo,
@@ -1089,7 +1100,7 @@ function _const_re_prior_logf(dm::DataModel,
 end
 
 # Wrapper around the batch log-density. An invalid RE covariance — e.g. a degenerate
-# matrix-exp (`:expm`) draw the optimiser/UQ steps into — makes distribution construction
+# matrix-exp (`:expm`) draw the optimizer/UQ steps into — makes distribution construction
 # throw (`PosDefException` etc.) rather than return a finite density. Treat such numeric
 # failures as a -Inf log-density so callers backtrack instead of crashing. The try/catch is
 # free on the non-throwing path, so the hot-path performance of the impl is preserved.
@@ -2298,17 +2309,17 @@ end
               lb, ub) <: FittingMethod
 
 Laplace approximation with Empirical Bayes Estimates (EBE) for random-effects models.
-The outer optimiser maximises the Laplace-approximated marginal likelihood over the
-fixed effects, while the inner optimiser computes per-individual MAP estimates of the
+The outer optimizer maximizes the Laplace-approximated marginal likelihood over the
+fixed effects, while the inner optimizer computes per-individual MAP estimates of the
 random effects.
 
 # Keyword Arguments
-- `optimizer`: outer Optimization.jl optimiser. Defaults to `LBFGS` with backtracking.
+- `optimizer`: outer Optimization.jl optimizer. Defaults to `LBFGS` with backtracking.
 - `optim_kwargs::NamedTuple = NamedTuple()`: keyword arguments for the outer `solve` call.
-- `adtype`: AD backend for the outer optimiser. Defaults to `AutoForwardDiff()`.
-- `inner_optimizer`: inner optimiser for computing EBE modes. Defaults to `LBFGS`.
+- `adtype`: AD backend for the outer optimizer. Defaults to `AutoForwardDiff()`.
+- `inner_optimizer`: inner optimizer for computing EBE modes. Defaults to `LBFGS`.
 - `inner_kwargs::NamedTuple = NamedTuple()`: keyword arguments for the inner `solve` call.
-- `inner_adtype`: AD backend for the inner optimiser. Defaults to `AutoForwardDiff()`.
+- `inner_adtype`: AD backend for the inner optimizer. Defaults to `AutoForwardDiff()`.
 - `inner_grad_tol`: gradient tolerance for inner convergence (`:auto` chooses automatically).
 - `multistart_n::Int = 50`: number of random starts for the inner EBE multistart.
 - `multistart_k::Int = 10`: number of best starts to refine in the inner multistart.
@@ -2316,7 +2327,7 @@ random effects.
 - `multistart_max_rounds::Int = 1`: maximum multistart refinement rounds.
 - `multistart_sampling::Symbol = :lhs`: inner multistart sampling strategy (`:lhs` or `:random`).
 - `jitter::Float64 = 1e-6`: initial diagonal jitter added to ensure Hessian PD.
-- `max_tries::Int = 6`: maximum attempts to regularise the Hessian.
+- `max_tries::Int = 6`: maximum attempts to regularize the Hessian.
 - `jitter_growth::Float64 = 10.0`: multiplicative growth factor for jitter on each retry.
 - `adaptive_jitter::Bool = true`: whether to adapt jitter magnitude based on scale.
 - `jitter_scale::Float64 = 1e-6`: scale for the adaptive jitter.

--- a/src/estimation/map.jl
+++ b/src/estimation/map.jl
@@ -15,7 +15,7 @@ Maximum A Posteriori estimation for models without random effects.
 Requires prior distributions on at least one free fixed effect.
 
 # Keyword Arguments
-- `optimizer`: Optimization.jl-compatible optimiser. Defaults to `LBFGS` with backtracking
+- `optimizer`: Optimization.jl-compatible optimizer. Defaults to `LBFGS` with backtracking
   line search.
 - `optim_kwargs::NamedTuple = NamedTuple()`: keyword arguments forwarded to `Optimization.solve`
   (e.g. `maxiters`, `reltol`).

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -71,7 +71,7 @@ MCMC-based E-step for [`MCEM`](@ref). Wraps a Turing.jl-compatible sampler.
 - `sampler`: Turing-compatible sampler. Defaults to `NUTS(0.75)`.
 - `turing_kwargs::NamedTuple`: forwarded to `Turing.sample`.
 - `sample_schedule`: samples per E-step — `Int`, `Vector{Int}`, or `Function(iter)->Int`.
-- `warm_start::Bool = true`: initialise sampler from previous iteration's modes.
+- `warm_start::Bool = true`: initialize sampler from previous iteration's modes.
 """
 struct MCEM_MCMC{S, K, SS} <: AbstractMCEMEStep
     sampler::S
@@ -93,7 +93,7 @@ end
 Importance Sampling E-step for [`MCEM`](@ref).
 
 Draws `n_samples` random-effect vectors from a proposal distribution `q(b)` and
-reweights them by `log p(y, b | θ_k) - log q(b)` to form a self-normalised
+reweights them by `log p(y, b | θ_k) - log q(b)` to form a self-normalized
 Monte Carlo approximation of the Q-function.
 
 # Keyword Arguments
@@ -162,12 +162,12 @@ end
            ebe_rescue_multistart_k, ebe_rescue_max_rounds, ebe_rescue_grad_tol,
            ebe_rescue_multistart_sampling, lb, ub) <: FittingMethod
 
-Monte Carlo Expectation-Maximisation for random-effects models. At each EM iteration the
-E-step draws random effects; the M-step maximises the Monte Carlo Q-function over the
+Monte Carlo Expectation-Maximization for random-effects models. At each EM iteration the
+E-step draws random effects; the M-step maximizes the Monte Carlo Q-function over the
 fixed effects.
 
 # Keyword Arguments
-- `optimizer`: M-step Optimization.jl optimiser. Defaults to `LBFGS` with backtracking.
+- `optimizer`: M-step Optimization.jl optimizer. Defaults to `LBFGS` with backtracking.
 - `optim_kwargs::NamedTuple = (; iterations=50, g_abstol=1e-4, f_reltol=1e-6)`: keyword arguments for the M-step `solve`.
 - `adtype`: AD backend for the M-step. Defaults to `AutoForwardDiff()`.
 - `e_step`: E-step strategy. Either [`MCEM_MCMC`](@ref) or [`MCEM_IS`](@ref). When
@@ -175,7 +175,7 @@ fixed effects.
 - `sampler`: (legacy) Turing sampler; used when `e_step` is not provided.
 - `turing_kwargs::NamedTuple`: (legacy) forwarded to `Turing.sample`.
 - `sample_schedule::Int = 250`: (legacy) MCMC samples per E-step iteration.
-- `warm_start::Bool = true`: (legacy) initialise sampler from previous iteration's modes.
+- `warm_start::Bool = true`: (legacy) initialize sampler from previous iteration's modes.
 - `verbose::Bool = false`: print per-iteration diagnostics.
 - `progress::Bool = true`: show a progress bar.
 - `store_diagnostics::Bool = false`: store per-iteration parameter trajectories
@@ -186,7 +186,7 @@ fixed effects.
 - `rtol_theta`, `atol_theta`: relative/absolute convergence tolerance on fixed effects.
 - `rtol_Q`, `atol_Q`: relative/absolute convergence tolerance on the Q-function.
 - `consecutive_params::Int = 3`: consecutive iterations satisfying tolerance to converge.
-- `ebe_optimizer`, `ebe_optim_kwargs`, `ebe_adtype`, `ebe_grad_tol`: EBE inner optimiser.
+- `ebe_optimizer`, `ebe_optim_kwargs`, `ebe_adtype`, `ebe_grad_tol`: EBE inner optimizer.
 - `ebe_multistart_n`, `ebe_multistart_k` (default 1), `ebe_multistart_max_rounds`,
   `ebe_multistart_sampling`: multistart settings for EBE mode computation.
 - `ebe_rescue_on_high_grad` (default `false`), `ebe_rescue_multistart_n`,
@@ -823,11 +823,11 @@ function _is_gaussian_sample_batch(dm::DataModel,
     if nb == 0
         return (zeros(Float64, 0, n_samples), zeros(Float64, n_samples))
     end
-    # Memoise the per-block proposal densities across the sample loop — μ/C are
+    # Memoize the per-block proposal densities across the sample loop — μ/C are
     # invariant over the n_samples draws, but the scalar Normal (with its sqrt)
     # and the MvNormal (dense covariance copy + Cholesky inside the constructor)
     # were rebuilt once per draw per level. Built lazily on first use so the
-    # construction conditions (and any covariance-degeneracy behaviour) match the
+    # construction conditions (and any covariance-degeneracy behavior) match the
     # historical per-draw code exactly.
     q_scalar = Vector{Union{Nothing, Normal{Float64}}}(nothing, length(blocks))
     q_mv = Vector{Union{Nothing, MvNormal}}(nothing, length(blocks))
@@ -1486,7 +1486,7 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
         θu_new = nothing
         Q_new = T0(Inf)
 
-        # Q2 sub-step: optimise parameters that appear only in RE distribution
+        # Q2 sub-step: optimize parameters that appear only in RE distribution
         # expressions (no ODE needed).  Results are folded into mstep_constants so the
         # Q1 optimizer below sees them as fixed.
         mstep_constants = constants

--- a/src/estimation/mle.jl
+++ b/src/estimation/mle.jl
@@ -16,7 +16,7 @@ using OptimizationBBO
 Maximum Likelihood Estimation for models without random effects.
 
 # Keyword Arguments
-- `optimizer`: Optimization.jl-compatible optimiser. Defaults to `LBFGS` with backtracking
+- `optimizer`: Optimization.jl-compatible optimizer. Defaults to `LBFGS` with backtracking
   line search.
 - `optim_kwargs::NamedTuple = NamedTuple()`: keyword arguments forwarded to `Optimization.solve`
   (e.g. `maxiters`, `reltol`).
@@ -234,7 +234,7 @@ end
 """
     default_bounds_from_start(dm::DataModel; margin=1.0) -> (lower, upper)
 
-Generate symmetric box bounds on the transformed parameter scale centred at the
+Generate symmetric box bounds on the transformed parameter scale centered at the
 initial parameter values, with half-width `margin`.
 
 Useful for passing to `MLE(lb=lower, ub=upper)` when the model-declared bounds are

--- a/src/estimation/pooled.jl
+++ b/src/estimation/pooled.jl
@@ -20,7 +20,7 @@ using Statistics
 Pooled estimation for models with random effects. Each individual's random effects are
 set to the **plug-in value of their RE distribution** (mean, falling back to median; a
 fixed-draw Monte-Carlo mean for normalizing flows), then the data log-likelihood alone is
-optimised over the free fixed effects. The plug-in is a function of the fixed effects and
+optimized over the free fixed effects. The plug-in is a function of the fixed effects and
 is recomputed at every objective evaluation, so parameters that shift the plug-in (e.g. a
 population mean inside the RE distribution) are estimated.
 
@@ -36,7 +36,7 @@ The freeze classification is reported in `get_notes(res)`. The RE prior is never
 evaluated.
 
 # Keyword Arguments
-- `optimizer`: Optimization.jl-compatible optimiser. Defaults to `LBFGS` with backtracking.
+- `optimizer`: Optimization.jl-compatible optimizer. Defaults to `LBFGS` with backtracking.
 - `optim_kwargs::NamedTuple = NamedTuple()`: forwarded to `Optimization.solve`.
 - `adtype`: AD backend. Defaults to `AutoForwardDiff()`.
 - `lb`/`ub`: bounds on the transformed scale, or `nothing` to use model-declared bounds.
@@ -44,7 +44,7 @@ evaluated.
 - `force_free::Vector{Symbol} = Symbol[]`: parameter names exempt from auto-freezing.
 - `refreeze_check::Symbol = :warn`: post-fit sensitivity re-check at the optimum;
   `:warn` records violations in the notes, `:refit` unfreezes violators and continues
-  optimisation warm-started from the current optimum.
+  optimization warm-started from the current optimum.
 - `identifiable_only::Bool = true`: freeze plug-in-collinear parameters (pivoted
   redundancy elimination); `false` keeps all contributing parameters free.
 - `n_probes::Int = 3`: number of probe points (start + jittered) for the sensitivity
@@ -133,7 +133,7 @@ end
     PooledResult{S, O, I, R, N, E} <: MethodResult
 
 Method-specific result from a [`Pooled`](@ref) or [`PooledMap`](@ref) fit. Stores the
-optimisation solution plus the per-individual plug-in random effects evaluated at the
+optimization solution plus the per-individual plug-in random effects evaluated at the
 fitted fixed effects. The `notes` field records the plug-in strategy per random effect
 and the freeze classification (`frozen_dispersion`, `frozen_collinear`, `frozen_inert`,
 `frozen_unverified`, `weakly_identified`, `unfrozen_by_invariance`, `unfrozen_postfit`,
@@ -229,6 +229,25 @@ function _pooled_eta_value(dist, dim::Int, strategy, ::Type{T}) where {T}
     return Vector{T}(v)
 end
 
+# Per-individual plug-in η fill for the `_compute_pooled_etas` fast path, behind a
+# function barrier so `axs` / `ηlen` / `T` arrive as positional arguments (concrete)
+# rather than locals captured by the comprehension closure. Previously `axs`/`ηlen`
+# were assigned in BOTH the fast and the heterogeneous branch and captured by the
+# fast-path comprehension, which boxed them (`Core.Box`) and inferred the whole
+# per-individual body as `Any` (a runtime dispatch per individual per objective eval).
+@inline function _pooled_fill_ind_eta(dists_builder::DB, θs::TH, const_cov,
+        model_funs, helpers, re_names, dims, strategies, ::Type{T}, axs::AX,
+        ηlen::Int) where {DB, TH, T, AX}
+    dists = dists_builder(θs, const_cov, model_funs, helpers)
+    vals = Vector{T}(undef, ηlen)
+    pos = 1
+    for (ri, re) in enumerate(re_names)
+        val = _pooled_eta_value(getproperty(dists, re), dims[ri], strategies[ri], T)
+        pos = _pooled_fill_eta!(vals, pos, val)
+    end
+    return ComponentArray(vals, axs)
+end
+
 function _compute_pooled_etas(dm::DataModel, θ::ComponentArray, strategies)
     model = get_model(dm)
     lp_cache = dm.re_group_info.laplace_cache
@@ -251,32 +270,17 @@ function _compute_pooled_etas(dm::DataModel, θ::ComponentArray, strategies)
                           all(
         ri -> (lp_cache.dims[ri] == 1) == lp_cache.is_scalar[ri], eachindex(re_names))
     if template_compatible
-        # Fast path (one RE level per group per individual): fill a flat vector
-        # and wrap it with the precomputed axes — same trick as
-        # `_build_eta_ind_fast`, and the comprehension keeps η_vec's eltype
-        # concrete. This runs once per objective evaluation, per individual.
+        # Fast path (one RE level per group per individual): fill a flat vector and
+        # wrap it with the precomputed axes — same trick as `_build_eta_ind_fast`.
+        # The per-individual fill is hoisted into `_pooled_fill_ind_eta` (axs / ηlen /
+        # T passed positionally) so the comprehension closure does not capture them;
+        # see that helper for the Core.Box this avoids. Runs once per objective
+        # evaluation, per individual.
         axs = getaxes(template)
         ηlen = length(template)
-        return [begin
-                    ind = individuals[i]
-                    dists = dists_builder(θs, ind.const_cov, model_funs, helpers)
-                    vals = Vector{T}(undef, ηlen)
-                    pos = 1
-                    for (ri, re) in enumerate(re_names)
-                        dist = getproperty(dists, re)
-                        val = _pooled_eta_value(dist, lp_cache.dims[ri], strategies[ri], T)
-                        if val isa Number
-                            vals[pos] = val
-                            pos += 1
-                        else
-                            for k in eachindex(val)
-                                vals[pos + k - 1] = val[k]
-                            end
-                            pos += length(val)
-                        end
-                    end
-                    ComponentArray(vals, axs)
-                end
+        dims = lp_cache.dims
+        return [_pooled_fill_ind_eta(dists_builder, θs, individuals[i].const_cov,
+                    model_funs, helpers, re_names, dims, strategies, T, axs, ηlen)
                 for i in 1:n]
     end
     # Heterogeneous-shape path (e.g. a dim-1 NPF RE kept as a 1-vector): probe the
@@ -940,7 +944,7 @@ function _fit_pooled(dm::DataModel, method;
             error("Parameter $(name) cannot be both in constants and force_free.")
     end
     all(name in keys(constants) for name in fixed_names) &&
-        error("Pooled() has no free fixed effects to optimise.")
+        error("Pooled() has no free fixed effects to optimize.")
 
     θ0_u = get_θ0_untransformed(fe)
     if theta_0_untransformed !== nothing
@@ -994,7 +998,7 @@ function _fit_pooled(dm::DataModel, method;
     frozen_unverified = [n for n in part.frozen_unverified if n in frozen_dispersion]
     frozen_collinear = copy(part.frozen_collinear)
 
-    # ── optimisation (with optional post-fit unfreeze-and-continue rounds) ──
+    # ── optimization (with optional post-fit unfreeze-and-continue rounds) ──
     max_rounds = method.refreeze_check === :refit ? 3 : 1
     θ_round_u = θ0_u
     unfrozen_postfit = Symbol[]
@@ -1005,7 +1009,7 @@ function _fit_pooled(dm::DataModel, method;
         for n in vcat(frozen_dispersion, frozen_collinear))
         merged_constants = merge(auto_constants, constants)  # user constants win
         all(name in keys(merged_constants) for name in fixed_names) &&
-            error("Pooled() has no free fixed effects to optimise (all are RE " *
+            error("Pooled() has no free fixed effects to optimize (all are RE " *
                   "distribution parameters with no likelihood contribution). Add at " *
                   "least one fixed effect in @formulas or @DifferentialEquation.")
         sol, θ_hat_t, θ_hat_u = _pooled_solve(dm, method, θ_round_u, merged_constants,
@@ -1071,7 +1075,7 @@ function _fit_pooled(dm::DataModel, method;
         store_data_model ? dm : nothing, fit_args, fit_kwargs)
 end
 
-# One optimisation pass over the free fixed effects, with η either recomputed from θ
+# One optimization pass over the free fixed effects, with η either recomputed from θ
 # at every objective evaluation (when a free parameter feeds an RE distribution) or
 # precomputed once (fast path — plug-ins cannot move).
 function _pooled_solve(dm::DataModel, method, θ_start_u::ComponentArray,

--- a/src/estimation/remeasure.jl
+++ b/src/estimation/remeasure.jl
@@ -641,7 +641,7 @@ function build_re_measure_from_batch(
 end
 
 # ---------------------------------------------------------------------------
-# CenteredREMeasure: AGHQ measure centred at EBE mode b* with local curvature
+# CenteredREMeasure: AGHQ measure centered at EBE mode b* with local curvature
 # ---------------------------------------------------------------------------
 
 """
@@ -649,8 +649,8 @@ end
 
 Adaptive Gauss-Hermite Quadrature (AGHQ) measure for a batch of random effects.
 
-Unlike `GaussianRE` (which centres nodes at the prior mean μ), this measure
-centres nodes at the empirical-Bayes mode **b***, scaled by
+Unlike `GaussianRE` (which centers nodes at the prior mean μ), this measure
+centers nodes at the empirical-Bayes mode **b***, scaled by
 **S = chol(-H)^{-1}** where H is the Hessian of log p(b | y, θ) at b*.
 
 The change-of-variables correction is

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -94,7 +94,7 @@ end
 # next_idx: 1-based next-write position (= head when buffer is full).
 # Invariant: active slots in age order are head, head+1, ..., head+len-1 (all mod capacity,
 # 1-based). After each push, entries whose SA weight falls below q_epsilon are pruned from
-# the oldest end (subject to the q_min floor). Retained weights are normalised in _saem_Q.
+# the oldest end (subject to the q_min floor). Retained weights are normalized in _saem_Q.
 mutable struct _SAEMSampleStore
     weights::Vector{Float64}                          # [slot] weight, preallocated
     snaps::Vector{Vector{Vector{Float64}}}            # [slot][batch] re-values, preallocated
@@ -326,13 +326,13 @@ end
            ebe_rescue_max_rounds, ebe_rescue_grad_tol, ebe_rescue_multistart_sampling,
            lb, ub) <: FittingMethod
 
-Stochastic Approximation Expectation-Maximisation for random-effects models. SAEM
+Stochastic Approximation Expectation-Maximization for random-effects models. SAEM
 maintains a stochastic approximation of the sufficient statistics using a decreasing
-step-size sequence; the M-step updates the fixed effects via gradient-based optimisation
+step-size sequence; the M-step updates the fixed effects via gradient-based optimization
 or closed-form updates (when `builtin_stats` is enabled).
 
 # Keyword Arguments
-- `optimizer`: M-step Optimization.jl optimiser. Defaults to `LBFGS` with backtracking.
+- `optimizer`: M-step Optimization.jl optimizer. Defaults to `LBFGS` with backtracking.
 - `optim_kwargs::NamedTuple = (; iterations=10, g_abstol=1e-4, f_reltol=1e-6)`: keyword
   arguments for the M-step `solve`. The defaults cap the inner LBFGS at 10 iterations
   and convergence tolerances (max-norm gradient < 1e-4, relative function improvement
@@ -350,7 +350,7 @@ or closed-form updates (when `builtin_stats` is enabled).
     the indices of batches to update. Can be a plain function or a callable struct (a
     mutable struct with a matching `call` method, useful for stateful schedules).
     Example: a struct that cycles through all batches in successive windows of 100.
-- `warm_start::Bool = true`: initialise the sampler from the previous iteration's modes.
+- `warm_start::Bool = true`: initialize the sampler from the previous iteration's modes.
 - `verbose::Bool = false`: print per-iteration diagnostics.
 - `progress::Bool = true`: show a progress bar.
 - `mcmc_steps`: number of MCMC sweeps per E-step. Defaults to `1` for `SaemixMH` (one
@@ -361,8 +361,8 @@ or closed-form updates (when `builtin_stats` is enabled).
 - `q_store_epsilon::Float64 = 1e-10`: weight threshold for the adaptive memory policy.
   After each push, snapshots whose SA weight falls below this value are pruned from the
   oldest end of the buffer (subject to `q_store_min`). The retained weights are
-  renormalised to sum to 1 before evaluating Q, so Q is scale-invariant to pruning.
-  During the γ=1 stabilisation phase all previous snapshots are immediately pruned,
+  renormalized to sum to 1 before evaluating Q, so Q is scale-invariant to pruning.
+  During the γ=1 stabilization phase all previous snapshots are immediately pruned,
   keeping only the current iteration's sample. Only applies to the numeric Q path;
   if `suffstats` is provided this parameter has no effect (a warning is emitted if set
   to a non-default value).
@@ -380,11 +380,11 @@ or closed-form updates (when `builtin_stats` is enabled).
 - `q_from_stats`: custom Q-function from sufficient statistics, or `nothing`.
 - `mstep_closed_form`: custom closed-form M-step function, or `nothing`.
 - `builtin_stats`: `:auto`, `:on`, or `:off`; controls use of built-in Gaussian statistics.
-- `builtin_mean`: `:none`, `:additive`, or `:all`; controls built-in mean parameterisation.
+- `builtin_mean`: `:none`, `:additive`, or `:all`; controls built-in mean parameterization.
 - `resid_var_param::Symbol = :σ`: fixed-effect name for the residual standard deviation.
 - `re_cov_params::NamedTuple = NamedTuple()`: mapping of RE name to covariance parameter.
 - `re_mean_params::NamedTuple = NamedTuple()`: mapping of RE name to mean parameter.
-- `ebe_optimizer`, `ebe_optim_kwargs`, `ebe_adtype`, `ebe_grad_tol`: EBE inner optimiser.
+- `ebe_optimizer`, `ebe_optim_kwargs`, `ebe_adtype`, `ebe_grad_tol`: EBE inner optimizer.
 - `ebe_multistart_n`, `ebe_multistart_k` (default 1), `ebe_multistart_max_rounds`,
   `ebe_multistart_sampling`: multistart settings for EBE mode computation.
 - `ebe_rescue_on_high_grad` (default `false`), `ebe_rescue_*`: rescue multistart settings
@@ -401,7 +401,7 @@ or closed-form updates (when `builtin_stats` is enabled).
   log-likelihood at the current RE sample. Each retry re-runs the MCMC sampler for
   the offending batches only (using `retry_mcmc_steps` steps), then overwrites the
   capacity-1 ring buffer slot. If all retries are exhausted the M-step is skipped for
-  that iteration (existing behaviour). Has no effect when `mstep_sa_on_params=false`.
+  that iteration (existing behavior). Has no effect when `mstep_sa_on_params=false`.
 - `retry_mcmc_steps::Int = 1`: number of MCMC steps per retry attempt. Kept small
   (default 1) since the goal is merely to escape the bad RE value, not to fully mix.
 """
@@ -2378,7 +2378,7 @@ function _saem_batches(update_schedule, nbatches::Int, iter::Int, rng::AbstractR
     return _saem_batches!(Vector{Int}(), update_schedule, nbatches, iter, rng)
 end
 
-# Sum of active snapshot weights (always Float64; used for renormalisation in _saem_Q).
+# Sum of active snapshot weights (always Float64; used for renormalization in _saem_Q).
 function _saem_store_weight_sum(store::_SAEMSampleStore)
     s = 0.0
     h = store.head
@@ -2400,7 +2400,7 @@ function _saem_Q(dm::DataModel,
         anneal_sds::NamedTuple = NamedTuple())
     total = zero(eltype(θ))
     store.len == 0 && return total
-    # Compute weight sum once (Float64) for renormalisation; guard against degenerate store.
+    # Compute weight sum once (Float64) for renormalization; guard against degenerate store.
     weight_sum = _saem_store_weight_sum(store)
     weight_sum < 1e-300 && return total
     # Capture head/len as locals — they must not change during Q evaluation.
@@ -2930,7 +2930,7 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
     has_custom_closed_form = method.saem.suffstats !== nothing &&
                              method.saem.mstep_closed_form !== nothing
     # Detect Q2-only free parameters (appear only in RE distributions, never in obs-side blocks).
-    # These are optimised in a cheap separate M-step that skips ODE evaluation entirely.
+    # These are optimized in a cheap separate M-step that skips ODE evaluation entirely.
     q2_base_free_names = let p = _partition_q1_q2_names(dm.model, base_free_names)
         p.q2
     end
@@ -3041,7 +3041,7 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
 
     # O2+O4+O5: preallocated ring buffer for SA sample history
     # When mstep_sa_on_params=true the M-step reads only b_current, so the ring buffer is
-    # never used for optimization — capacity=1 minimises memory while keeping Q_new valid.
+    # never used for optimization — capacity=1 minimizes memory while keeping Q_new valid.
     _store_capacity = method.saem.mstep_sa_on_params ? 1 : method.saem.q_store_max
     sample_store = _init_saem_sample_store(_store_capacity, method.saem.q_store_epsilon,
         min(method.saem.q_store_min, _store_capacity), batch_infos)
@@ -3279,7 +3279,7 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
         axs_full = axs_full_iter
 
         # ── Q2 numerical M-step ──────────────────────────────────────────────
-        # Optimise parameters that appear only in RE distribution expressions.
+        # Optimize parameters that appear only in RE distribution expressions.
         # No ODE calls needed — objective is purely log p(η | θ_Q2).
         let q2_free_now = [n for n in q2_base_free_names if n ∉ keys(iter_constants)]
             if !isempty(q2_free_now)

--- a/src/estimation/saemix_mh.jl
+++ b/src/estimation/saemix_mh.jl
@@ -155,11 +155,10 @@ end
 function _saemixmh_init_indiv_ll!(indiv_ll::Vector{Float64},
         dm::DataModel,
         batch_info::_LaplaceBatchInfo,
-        θ::ComponentArray,
+        θ_re::ComponentArray,   # pre-symmetrized by the caller
         const_cache::LaplaceConstantsCache,
         cache::_LLCache,
         b::Vector{Float64})
-    θ_re = _symmetrize_psd_params(θ, dm.model.fixed.fixed)
     for (pos, i) in enumerate(batch_info.inds)
         η_ind = _build_eta_ind(dm, i, batch_info, b, const_cache, θ_re)
         indiv_ll[pos] = _loglikelihood_individual(dm, i, θ_re, η_ind, cache)
@@ -170,12 +169,11 @@ end
 function _saemixmh_level_plp!(level_plp::Vector{Float64},
         levels::Vector{_SaemixMHLevel},
         dm::DataModel,
-        θ::ComponentArray,
+        θ_re::ComponentArray,   # pre-symmetrized by the caller
         const_cache::LaplaceConstantsCache,
         cache::_LLCache,
         b::Vector{Float64};
         anneal_sds::NamedTuple = NamedTuple())
-    θ_re = _symmetrize_psd_params(θ, dm.model.fixed.fixed)
     dists_builder = get_create_random_effect_distribution(dm.model.random.random)
     model_funs = cache.model_funs
     helpers = cache.helpers
@@ -234,7 +232,7 @@ function _saemixmh_build_levels(dm::DataModel,
 end
 
 # Return the standard deviation in the bijected (z) space for a scalar RE level.
-# Used to initialise domega2 in the correct units — the bijection is what kernels
+# Used to initialize domega2 in the correct units — the bijection is what kernels
 # 2 and 3 now propose in, so the initial step size should live in that space.
 function _saemixmh_zspace_std(dist, re_type::Symbol)::Float64
     if re_type == :LogNormal
@@ -327,13 +325,14 @@ function _saemixmh_init_state(dm::DataModel,
         rw_init::Float64)
     nb = batch_info.n_b
     n_inds = length(batch_info.inds)
+    θ_re = _symmetrize_psd_params(θ, dm.model.fixed.fixed)
     levels = _saemixmh_build_levels(dm, batch_info, re_names)
     b = zeros(Float64, nb)
     _saemixmh_init_b!(b, levels, dm, θ, const_cache, cache, rng, re_names)
     indiv_ll = Vector{Float64}(undef, n_inds)
-    _saemixmh_init_indiv_ll!(indiv_ll, dm, batch_info, θ, const_cache, cache, b)
+    _saemixmh_init_indiv_ll!(indiv_ll, dm, batch_info, θ_re, const_cache, cache, b)
     level_plp = Vector{Float64}(undef, length(levels))
-    _saemixmh_level_plp!(level_plp, levels, dm, θ, const_cache, cache, b)
+    _saemixmh_level_plp!(level_plp, levels, dm, θ_re, const_cache, cache, b)
     domega2 = _saemixmh_init_domega2(levels, dm, θ, const_cache, cache, re_names, rw_init)
     # Scratch for multi-individual levels: sized to the largest level group so the
     # accept/reject step never allocates (was one Vector per proposal per step).
@@ -349,7 +348,7 @@ end
 function _saemixmh_kern1!(state::_SaemixMHState,
         dm::DataModel,
         batch_info::_LaplaceBatchInfo,
-        θ::ComponentArray,
+        θ_re::ComponentArray,   # pre-symmetrized once per E-step by the caller
         const_cache::LaplaceConstantsCache,
         cache::_LLCache,
         rng::AbstractRNG,
@@ -357,7 +356,6 @@ function _saemixmh_kern1!(state::_SaemixMHState,
         n_steps::Int,
         anneal_sds::NamedTuple)
     n_steps == 0 && return
-    θ_re = _symmetrize_psd_params(θ, dm.model.fixed.fixed)
     dists_builder = get_create_random_effect_distribution(dm.model.random.random)
     model_funs = cache.model_funs
     helpers = cache.helpers
@@ -441,7 +439,7 @@ end
 function _saemixmh_kern2!(state::_SaemixMHState,
         dm::DataModel,
         batch_info::_LaplaceBatchInfo,
-        θ::ComponentArray,
+        θ_re::ComponentArray,   # pre-symmetrized once per E-step by the caller
         const_cache::LaplaceConstantsCache,
         cache::_LLCache,
         rng::AbstractRNG,
@@ -451,7 +449,6 @@ function _saemixmh_kern2!(state::_SaemixMHState,
         stepsize_rw::Float64,
         anneal_sds::NamedTuple)
     n_steps == 0 && return
-    θ_re = _symmetrize_psd_params(θ, dm.model.fixed.fixed)
     dists_builder = get_create_random_effect_distribution(dm.model.random.random)
     model_funs = cache.model_funs
     helpers = cache.helpers
@@ -547,7 +544,7 @@ end
 function _saemixmh_kern3!(state::_SaemixMHState,
         dm::DataModel,
         batch_info::_LaplaceBatchInfo,
-        θ::ComponentArray,
+        θ_re::ComponentArray,   # pre-symmetrized once per E-step by the caller
         const_cache::LaplaceConstantsCache,
         cache::_LLCache,
         rng::AbstractRNG,
@@ -558,7 +555,6 @@ function _saemixmh_kern3!(state::_SaemixMHState,
         stepsize_rw::Float64,
         anneal_sds::NamedTuple)
     n_steps == 0 && return
-    θ_re = _symmetrize_psd_params(θ, dm.model.fixed.fixed)
     dists_builder = get_create_random_effect_distribution(dm.model.random.random)
     model_funs = cache.model_funs
     helpers = cache.helpers
@@ -682,7 +678,12 @@ function _mcem_sample_batch(dm::DataModel,
         return (zeros(eltype(θ), 0, 0), nothing, eltype(θ)[])
     end
 
-    # Initialise or warm-start state
+    # θ is constant across the whole E-step, so symmetrize the PSD blocks ONCE here
+    # and thread the result through the resync helpers and the per-sweep kernels
+    # (each used to recompute it; for PSD-Ω models that was a flat θ copy per call).
+    θ_re = _symmetrize_psd_params(θ, dm.model.fixed.fixed)
+
+    # Initialize or warm-start state
     state = if warm_start && last_params isa _SaemixMHState
         last_params
     else
@@ -692,19 +693,19 @@ function _mcem_sample_batch(dm::DataModel,
 
     # Re-sync indiv_ll and level_plp when θ has changed (e.g. M-step update).
     # We check by recomputing — cheap compared to MCMC itself.
-    _saemixmh_init_indiv_ll!(state.indiv_ll, dm, info, θ, const_cache, cache, state.b)
-    _saemixmh_level_plp!(state.level_plp, state.levels, dm, θ, const_cache, cache,
+    _saemixmh_init_indiv_ll!(state.indiv_ll, dm, info, θ_re, const_cache, cache, state.b)
+    _saemixmh_level_plp!(state.level_plp, state.levels, dm, θ_re, const_cache, cache,
         state.b; anneal_sds = anneal_sds)
 
     # Run n_samples sweeps: each sweep = n_kern1 kernel-1 steps + n_kern2 kernel-2 steps
     n_sweeps = max(1, get(turing_kwargs, :n_samples, 1))
     for _ in 1:n_sweeps
-        _saemixmh_kern1!(state, dm, info, θ, const_cache, cache, rng, re_names,
+        _saemixmh_kern1!(state, dm, info, θ_re, const_cache, cache, rng, re_names,
             sampler.n_kern1, anneal_sds)
-        _saemixmh_kern2!(state, dm, info, θ, const_cache, cache, rng, re_names,
+        _saemixmh_kern2!(state, dm, info, θ_re, const_cache, cache, rng, re_names,
             sampler.n_kern2, sampler.proba_mcmc, sampler.stepsize_rw,
             anneal_sds)
-        _saemixmh_kern3!(state, dm, info, θ, const_cache, cache, rng, re_names,
+        _saemixmh_kern3!(state, dm, info, θ_re, const_cache, cache, rng, re_names,
             sampler.n_kern3, outer_iter, sampler.proba_mcmc,
             sampler.stepsize_rw, anneal_sds)
     end

--- a/src/estimation/serialization.jl
+++ b/src/estimation/serialization.jl
@@ -137,7 +137,7 @@ end
 
 # ─── Method stripping ─────────────────────────────────────────────────────────
 # FittingMethod structs contain optimizer/sampler objects with bare Function fields
-# that JLD2 cannot serialise cleanly.  Replace them with a lightweight stub.
+# that JLD2 cannot serialize cleanly.  Replace them with a lightweight stub.
 
 _strip_fitting_method(::MLE) = _SavedFittingMethod(:mle)
 _strip_fitting_method(::MAP) = _SavedFittingMethod(:map)

--- a/src/estimation/vi_turing.jl
+++ b/src/estimation/vi_turing.jl
@@ -282,7 +282,7 @@ function _fit_model(dm::DataModel, method::VI, args...;
     # third argument — a function `(rng, ldf) -> q` (e.g. `q_meanfield_gaussian`). `vi` builds
     # a correctly linked `LogDensityFunction` internally and calls the family on it; the old
     # API of pre-constructing `q` from the model was removed. Pass the family function (a
-    # user-supplied `q_init` is honoured as-is).
+    # user-supplied `q_init` is honored as-is).
     if q_init === nothing
         q_init = family == :meanfield ? Turing.q_meanfield_gaussian :
                  Turing.q_fullrank_gaussian

--- a/src/model/Covariates.jl
+++ b/src/model/Covariates.jl
@@ -63,7 +63,7 @@ end
 ```
 Inside model blocks the value supports both named-field access (`x.Age`, `x.BMI`) and
 numeric-vector operations in column order (`x' * β`, `dot(x, β)`, `sum(x)`, `x[1]`). The
-vector behaviour requires every column to be numeric; mixed/categorical vectors keep
+vector behavior requires every column to be numeric; mixed/categorical vectors keep
 field access only.
 
 # Keyword Arguments
@@ -86,7 +86,7 @@ end
 ```
 Inside model blocks the per-row value supports both named-field access (`z.z1`, `z.z2`)
 and numeric-vector operations in column order (`z' * β`, `dot(z, β)`, `sum(z)`, `z[1]`).
-The vector behaviour requires every column to be numeric; mixed/categorical vectors keep
+The vector behavior requires every column to be numeric; mixed/categorical vectors keep
 field access only.
 
 # Arguments
@@ -196,7 +196,7 @@ end
     Covariates
 
 Compiled representation of a `@covariates` block. Stores the covariate names
-categorised as constant, varying, or dynamic, along with interpolation types
+categorized as constant, varying, or dynamic, along with interpolation types
 and the raw covariate parameter structs.
 
 Use the `model.covariates.covariates` field (or the `CovariatesBundle`) to inspect

--- a/src/model/DifferentialEquation.jl
+++ b/src/model/DifferentialEquation.jl
@@ -43,10 +43,17 @@ function DifferentialEquationMeta(state_names::Vector{Symbol},
     DifferentialEquationMeta(state_names, signal_names, var_syms, fun_syms, Expr[])
 end
 
-struct DifferentialEquationBuilders
-    compile::Function
-    f!::Function
-    f::Function
+# Parameterized on the (concrete RuntimeGeneratedFunction) field types so the
+# RGF types propagate through `DEBundle{D,...}` (D = typeof(de)) into the Model /
+# DataModel type. Without the parameters these fields are abstract `::Function`,
+# so `get_de_compiler(de)(pc)` / `get_de_f!(de)` / `get_de_accessors_builder(de)`
+# return `Any` and every per-individual ODE solve dynamic-dispatches through them
+# (the whole `_ll_solve_de` body inferred `Any`). Construction (below) is
+# positional, so the parameters are inferred with no call-site change.
+struct DifferentialEquationBuilders{C, FB, F}
+    compile::C
+    f!::FB
+    f::F
 end
 
 """
@@ -56,10 +63,10 @@ Compiled representation of a `@DifferentialEquation` block. Stores state and sig
 names, in-place/out-of-place ODE functions, a parameter compiler, and an accessor
 builder for retrieving state/signal values from a solution object.
 """
-struct DifferentialEquation
+struct DifferentialEquation{B, A}
     meta::DifferentialEquationMeta
-    builders::DifferentialEquationBuilders
-    accessors_builder::Function
+    builders::B
+    accessors_builder::A
 end
 
 """

--- a/src/model/FixedEffects.jl
+++ b/src/model/FixedEffects.jl
@@ -133,7 +133,7 @@ get_θ0_untransformed(fe::FixedEffects) = fe.values.θ0_untransformed
 """
     get_θ0_transformed(fe::FixedEffects) -> ComponentArray
 
-Return the initial parameter vector on the transformed (optimisation) scale.
+Return the initial parameter vector on the transformed (optimization) scale.
 """
 get_θ0_transformed(fe::FixedEffects) = fe.values.θ0_transformed
 
@@ -155,14 +155,14 @@ get_bounds_transformed(fe::FixedEffects) = fe.bounds.transformed
     get_transform(fe::FixedEffects) -> ForwardTransform
 
 Return the callable `ForwardTransform` that maps a natural-scale `ComponentArray`
-to the optimisation scale.
+to the optimization scale.
 """
 get_transform(fe::FixedEffects) = fe.transforms.forward
 
 """
     get_inverse_transform(fe::FixedEffects) -> InverseTransform
 
-Return the callable `InverseTransform` that maps an optimisation-scale `ComponentArray`
+Return the callable `InverseTransform` that maps an optimization-scale `ComponentArray`
 back to the natural scale.
 """
 get_inverse_transform(fe::FixedEffects) = fe.transforms.inverse
@@ -783,7 +783,7 @@ function _collect_model_fun!(p::NPFParameter, model_fun_pairs, ::Type{T}) where 
 end
 
 # Adapt base distribution element type for ForwardDiff compatibility.
-# MvNormal is re-parameterised with typed mean/cov; other distributions are used as-is.
+# MvNormal is re-parameterized with typed mean/cov; other distributions are used as-is.
 # The covariance STRUCTURE is preserved: densifying a ScalMat/PDiagMat to a full
 # PDMat would route logpdf through a LAPACK triangular solve (`trtrs`), which
 # Enzyme forward mode cannot handle under runtime activity ("Runtime Activity not

--- a/src/model/Formulas.jl
+++ b/src/model/Formulas.jl
@@ -399,7 +399,7 @@ function _formulas_build_formulas_expr(ir::FormulasIR,
         end
     end
 
-    # Also recognise S(vc) as a state-time call when vc is a varying covariate.
+    # Also recognize S(vc) as a state-time call when vc is a varying covariate.
     vc_time_args = Set{Symbol}()
     let all_state_syms = Set(vcat(state_names, signal_names)),
         vc_syms_early = Set(varying_cov_names)

--- a/src/model/Parameters.jl
+++ b/src/model/Parameters.jl
@@ -46,7 +46,7 @@ A scalar real-valued fixed-effect parameter block.
 
 # Keyword Arguments
 - `name::Symbol = :unnamed`: parameter name (injected automatically by `@fixedEffects`).
-- `scale::Symbol = :identity`: reparameterisation applied during optimisation.
+- `scale::Symbol = :identity`: reparameterization applied during optimization.
   Must be one of `REAL_SCALES` (`:identity`, `:log`, `:logit`).
 - `lower::Real = -Inf`: lower bound on the natural scale (defaults to `EPSILON` when `scale=:log`).
 - `upper::Real = Inf`: upper bound on the natural scale.
@@ -166,9 +166,9 @@ end
     RealPSDMatrix(value; name, scale, prior, calculate_se) -> RealPSDMatrix
 
 A symmetric positive semi-definite (PSD) matrix parameter block, typically used
-to parameterise covariance matrices of random-effect distributions.
+to parameterize covariance matrices of random-effect distributions.
 
-The matrix is reparameterised during optimisation to ensure PSD constraints are
+The matrix is reparameterized during optimization to ensure PSD constraints are
 automatically satisfied.
 
 # Arguments
@@ -176,7 +176,7 @@ automatically satisfied.
 
 # Keyword Arguments
 - `name::Symbol = :unnamed`: parameter name (injected automatically by `@fixedEffects`).
-- `scale::Symbol = :cholesky`: reparameterisation. Must be one of `PSD_SCALES`
+- `scale::Symbol = :cholesky`: reparameterization. Must be one of `PSD_SCALES`
   (`:cholesky`, `:expm`).
 - `prior = Priorless()`: a `Distributions.Distribution` (e.g. `Wishart`) or `Priorless()`.
 - `calculate_se::Bool = false`: whether to include this parameter in standard-error calculations.
@@ -213,7 +213,7 @@ end
 A diagonal positive-definite matrix parameter block, stored as a vector of the
 diagonal entries. Useful for diagonal covariance matrices.
 
-All diagonal entries must be strictly positive. They are stored and optimised on the
+All diagonal entries must be strictly positive. They are stored and optimized on the
 log scale.
 
 # Arguments
@@ -222,7 +222,7 @@ log scale.
 
 # Keyword Arguments
 - `name::Symbol = :unnamed`: parameter name (injected automatically by `@fixedEffects`).
-- `scale::Symbol = :log`: reparameterisation. Must be in `DIAGONAL_SCALES` (`:log`).
+- `scale::Symbol = :log`: reparameterization. Must be in `DIAGONAL_SCALES` (`:log`).
 - `prior = Priorless()`: a `Distributions.Distribution` or `Priorless()`.
 - `calculate_se::Bool = false`: whether to include this parameter in standard-error calculations.
 """
@@ -264,7 +264,7 @@ end
 A parameter block that wraps the flattened parameters of a neural-network chain — either a
 Lux.jl `Chain` or a SimpleChains.jl `SimpleChain`.
 
-The resulting parameter is optimised as a flat real vector. Inside model blocks
+The resulting parameter is optimized as a flat real vector. Inside model blocks
 (`@randomEffects`, `@preDifferentialEquation`, `@formulas`) the network is called
 as `function_name(input, θ_slice)`, where `θ_slice` is the corresponding slice of
 the fixed-effects `ComponentArray`.
@@ -280,7 +280,7 @@ the fixed-effects `ComponentArray`.
 # Keyword Arguments
 - `name::Symbol = :unnamed`: parameter name (injected automatically by `@fixedEffects`).
 - `function_name::Symbol`: the name used to call the network in model blocks.
-- `seed::Integer = 0`: random seed for initialising the network parameters.
+- `seed::Integer = 0`: random seed for initializing the network parameters.
 - `prior = Priorless()`: `Priorless()`, a `Vector{Distribution}` of length equal to
   the number of parameters, or a multivariate `Distribution` with matching `length`.
 - `calculate_se::Bool = false`: whether to include this parameter in standard-error calculations.
@@ -322,7 +322,7 @@ end
 SimpleChains.jl backend for [`NNParameters`](@ref). A `SimpleChains.SimpleChain` already stores
 its parameters as a flat `Vector`, so they are kept as-is (no `Optimisers.destructure`/`reconstructor`
 round-trip); at runtime the network is evaluated directly as `chain(input, θ_slice)`. Parameters
-are initialised as `Float64`. This backend is ForwardDiff-compatible.
+are initialized as `Float64`. This backend is ForwardDiff-compatible.
 """
 function NNParameters(chain::SimpleChain; name::Symbol = :unnamed,
         function_name::Symbol, seed::Integer = 0,
@@ -354,11 +354,11 @@ base distribution. Parameters are stored as a flat real vector.
 
 # Keyword Arguments
 - `name::Symbol = :unnamed`: parameter name (injected automatically by `@fixedEffects`).
-- `seed::Integer = 0`: random seed for initialisation.
-- `init::Function`: weight initialisation function; defaults to `x -> sqrt(1/n_input) .* x`.
+- `seed::Integer = 0`: random seed for initialization.
+- `init::Function`: weight initialization function; defaults to `x -> sqrt(1/n_input) .* x`.
 - `base_dist`: base distribution for the flow. Defaults to `MvNormal(zeros(n_input), I)`.
   Can be any continuous multivariate distribution (e.g. `MvTDist(3, zeros(1), ones(1,1))`).
-  For ForwardDiff compatibility, `MvNormal` base distributions are automatically re-parameterised
+  For ForwardDiff compatibility, `MvNormal` base distributions are automatically re-parameterized
   with the correct element type; other distributions are used as-is.
 - `prior = Priorless()`: `Priorless()`, a `Vector{Distribution}`, or a multivariate `Distribution`.
 - `calculate_se::Bool = false`: whether to include this parameter in standard-error calculations.
@@ -413,10 +413,10 @@ end
 """
     SplineParameters(knots; name, function_name, degree, prior, calculate_se) -> SplineParameters
 
-A parameter block for a B-spline function whose coefficients are optimised as fixed effects.
+A parameter block for a B-spline function whose coefficients are optimized as fixed effects.
 
 The number of coefficients is determined by `length(knots) - degree - 1`. All coefficients
-are initialised to zero. Inside model blocks the spline is evaluated as
+are initialized to zero. Inside model blocks the spline is evaluated as
 `function_name(x, θ_slice)`.
 
 # Arguments
@@ -462,7 +462,7 @@ end
 """
     SoftTreeParameters(input_dim, depth; name, function_name, n_output, seed, prior, calculate_se) -> SoftTreeParameters
 
-A parameter block for a soft decision tree whose parameters are optimised as fixed effects.
+A parameter block for a soft decision tree whose parameters are optimized as fixed effects.
 
 The tree takes a real-valued vector of length `input_dim` and produces a vector of
 length `n_output`. Parameters are stored as a flat real vector. Inside model blocks
@@ -476,7 +476,7 @@ the tree is called as `function_name(x, θ_slice)`.
 - `name::Symbol = :unnamed`: parameter name (injected automatically by `@fixedEffects`).
 - `function_name::Symbol`: the name used to call the tree in model blocks.
 - `n_output::Integer = 1`: number of output values.
-- `seed::Integer = 0`: random seed for initialisation.
+- `seed::Integer = 0`: random seed for initialization.
 - `prior = Priorless()`: `Priorless()`, a `Vector{Distribution}`, or a multivariate `Distribution`.
 - `calculate_se::Bool = false`: whether to include this parameter in standard-error calculations.
 """
@@ -523,17 +523,17 @@ end
     ProbabilityVector(value; name, scale, prior, calculate_se) -> ProbabilityVector
 
 A probability vector parameter block: a vector of `k ≥ 2` non-negative entries
-summing to 1. Optimised via the logistic stick-breaking reparameterisation, which
+summing to 1. Optimized via the logistic stick-breaking reparameterization, which
 maps the simplex to `k-1` unconstrained reals.
 
 # Arguments
 - `value::AbstractVector{<:Real}`: initial probability vector. All entries must be
   non-negative and sum to 1 (within tolerance); if the sum differs by less than
-  `atol=1e-6`, the vector is silently normalised.
+  `atol=1e-6`, the vector is silently normalized.
 
 # Keyword Arguments
 - `name::Symbol = :unnamed`: parameter name (injected automatically by `@fixedEffects`).
-- `scale::Symbol = :stickbreak`: reparameterisation. Must be in `PROBABILITY_SCALES`.
+- `scale::Symbol = :stickbreak`: reparameterization. Must be in `PROBABILITY_SCALES`.
 - `prior = Priorless()`: a `Distributions.Distribution` or `Priorless()`.
 - `calculate_se::Bool = true`: whether to include this parameter in standard-error calculations.
 """
@@ -564,7 +564,7 @@ function ProbabilityVector(value::AbstractVector{<:Real};
     atol = T(1e-6)
     abs(s - one(T)) <= atol ||
         error("ProbabilityVector for parameter $(name) must sum to 1 (within 1e-6); got sum=$(s).")
-    v = v ./ s   # silent normalisation
+    v = v ./ s   # silent normalization
     return ProbabilityVector{T, typeof(v)}(name, v, scale, prior, calculate_se)
 end
 
@@ -572,16 +572,16 @@ end
     DiscreteTransitionMatrix(value; name, scale, prior, calculate_se) -> DiscreteTransitionMatrix
 
 A square row-stochastic matrix parameter block of size `n×n` (`n ≥ 2`). Each row
-is a probability vector and is independently reparameterised via the logistic
+is a probability vector and is independently reparameterized via the logistic
 stick-breaking transform, yielding `n*(n-1)` unconstrained reals.
 
 # Arguments
 - `value::AbstractMatrix{<:Real}`: initial row-stochastic matrix. Each row must be
-  non-negative and sum to 1 (within tolerance); rows are silently normalised if needed.
+  non-negative and sum to 1 (within tolerance); rows are silently normalized if needed.
 
 # Keyword Arguments
 - `name::Symbol = :unnamed`: parameter name (injected automatically by `@fixedEffects`).
-- `scale::Symbol = :stickbreakrows`: reparameterisation. Must be in `TRANSITION_SCALES`.
+- `scale::Symbol = :stickbreakrows`: reparameterization. Must be in `TRANSITION_SCALES`.
 - `prior = Priorless()`: a `Distributions.Distribution` or `Priorless()`.
 - `calculate_se::Bool = true`: whether to include this parameter in standard-error calculations.
 """
@@ -615,7 +615,7 @@ function DiscreteTransitionMatrix(value::AbstractMatrix{<:Real};
     atol = T(1e-6)
     all(abs.(row_sums .- one(T)) .<= atol) ||
         error("Each row of DiscreteTransitionMatrix for parameter $(name) must sum to 1 (within 1e-6); got row sums=$(vec(row_sums)).")
-    v = v ./ row_sums   # silent row-wise normalisation
+    v = v ./ row_sums   # silent row-wise normalization
     return DiscreteTransitionMatrix{T, typeof(v)}(name, v, scale, prior, calculate_se)
 end
 
@@ -628,7 +628,7 @@ The Q-matrix has:
 - Off-diagonal entries `Q[i,j] ≥ 0` (transition rates from state `i` to state `j`, `i ≠ j`).
 - Diagonal entries `Q[i,i] = -∑_{j≠i} Q[i,j]` (rows sum to zero).
 
-The `n*(n-1)` off-diagonal rates are optimised on the log scale (`:lograterows`), mapping
+The `n*(n-1)` off-diagonal rates are optimized on the log scale (`:lograterows`), mapping
 each rate to an unconstrained real via `log`. The diagonal is recomputed from the off-diagonals
 and is not an independent free parameter.
 
@@ -639,7 +639,7 @@ and is not an independent free parameter.
 
 # Keyword Arguments
 - `name::Symbol = :unnamed`: parameter name (injected automatically by `@fixedEffects`).
-- `scale::Symbol = :lograterows`: reparameterisation. Must be in `RATE_MATRIX_SCALES`.
+- `scale::Symbol = :lograterows`: reparameterization. Must be in `RATE_MATRIX_SCALES`.
 - `prior = Priorless()`: a `Distributions.Distribution` or `Priorless()`.
 - `calculate_se::Bool = true`: whether to include this parameter in standard-error calculations.
 """

--- a/src/model/PreDE.jl
+++ b/src/model/PreDE.jl
@@ -266,13 +266,19 @@ macro preDifferentialEquation(block)
     skip_vars = Set([:Inf, :NaN, :nothing, :missing, :true, :false])
     var_syms = Set([s for s in var_syms if !(s in skip_vars)])
 
-    prop_syms_expr = Expr(:call, :Set, Expr(:vect, QuoteNode.(collect(prop_syms))...))
-    binds_vars = [quote
-                      if $(QuoteNode(sym)) in $prop_syms_expr
+    # `sym in prop_syms` is decidable at macro-expansion time — emit the chosen
+    # branch directly. (The old code carried the membership test into the generated
+    # function as `sym in Set([...])`, allocating a fresh Set on every builder
+    # invocation; `calculate_prede` runs per individual per objective evaluation.
+    # Mirrors the identical fix in RandomEffects.jl.)
+    binds_vars = [if sym in prop_syms
+                      quote
                           if hasproperty(constant_features_i, $(QuoteNode(sym)))
                               $(sym) = getproperty(constant_features_i, $(QuoteNode(sym)))
                           end
-                      else
+                      end
+                  else
+                      quote
                           if hasproperty(constant_features_i, $(QuoteNode(sym)))
                               $(sym) = getproperty(constant_features_i, $(QuoteNode(sym)))
                           elseif hasproperty(random_effects, $(QuoteNode(sym)))

--- a/src/plotting/plots.jl
+++ b/src/plotting/plots.jl
@@ -1748,7 +1748,7 @@ Plot predictions from one or more fitted models side-by-side for visual comparis
 
 When called with a single `FitResult` or `MultistartFitResult`, behaves like
 [`plot_fits`](@ref). When called with a collection, overlays predictions from each
-model on the same panel, labelled by vector index, `NamedTuple` key, or `Dict` key.
+model on the same panel, labeled by vector index, `NamedTuple` key, or `Dict` key.
 
 All keyword arguments are forwarded to the underlying `plot_fits` implementation.
 """
@@ -2175,7 +2175,7 @@ end
 Horizontal bar chart of eta shrinkage for all scalar random effects, with a
 vertical reference line at `threshold` (default 30 %).
 
-Bars are coloured by severity: below `threshold` (green), between `threshold`
+Bars are colored by severity: below `threshold` (green), between `threshold`
 and 50 % (orange), above 50 % (red). Shrinkage is computed via
 [`compute_shrinkage`](@ref).
 

--- a/src/plotting/plotting.jl
+++ b/src/plotting/plotting.jl
@@ -38,12 +38,12 @@ All plotting functions accept a `style::PlotStyle` keyword argument. Construct a
 `PlotStyle()` with the defaults and override individual fields as needed.
 
 # Keyword Arguments
-- `color_primary::String`: main series colour (default: `"#0072B2"` — blue).
-- `color_secondary::String`: secondary series colour (default: `"#E69F00"` — orange).
-- `color_accent::String`: accent colour (default: `"#009E73"` — green).
-- `color_dark::String`: dark foreground colour (default: `"#2C3E50"`).
-- `color_density::String`: colour for density bands (default: `"#E69F00"`).
-- `color_reference::String`: reference line colour (default: `"#2C3E50"`).
+- `color_primary::String`: main series color (default: `"#0072B2"` — blue).
+- `color_secondary::String`: secondary series color (default: `"#E69F00"` — orange).
+- `color_accent::String`: accent color (default: `"#009E73"` — green).
+- `color_dark::String`: dark foreground color (default: `"#2C3E50"`).
+- `color_density::String`: color for density bands (default: `"#E69F00"`).
+- `color_reference::String`: reference line color (default: `"#2C3E50"`).
 - `font_family::String`: font family for all text (default: `"Helvetica"`).
 - `font_size_title`, `font_size_label`, `font_size_tick`, `font_size_legend`,
   `font_size_annotation`: font sizes in points, applied uniformly across all plots
@@ -599,7 +599,7 @@ parameter element (e.g. `β[1]`, `β[2]`, `Ω[1,1]`, ...).
 - `dm::Union{Nothing, DataModel} = nothing`: data model for the inverse transform when
   `scale=:untransformed`. Inferred from `res` when stored.
 - `scale::Symbol = :untransformed`: `:untransformed` (natural scale) or `:transformed`
-  (optimiser scale). Affects the plotted values; `:untransformed` requires the DataModel.
+  (optimizer scale). Affects the plotted values; `:untransformed` requires the DataModel.
 - `include_parameters`: `Symbol`, `String`, or vector thereof. If set, only the named
   top-level parameter blocks are plotted. Defaults to `nothing` (all free parameters).
 - `exclude_parameters`: `Symbol`, `String`, or vector thereof. If set, the named blocks

--- a/src/plotting/plotting_random_effects.jl
+++ b/src/plotting/plotting_random_effects.jl
@@ -465,7 +465,7 @@ end
                                 kwargs_subplot, kwargs_layout) -> Plots.Plot
 
 Pairplot (scatter matrix) of empirical-Bayes estimates across all pairs of random
-effects, useful for visualising correlations and joint structure.
+effects, useful for visualizing correlations and joint structure.
 
 # Keyword Arguments
 - `dm::Union{Nothing, DataModel} = nothing`: data model (inferred from `res` by default).
@@ -1571,7 +1571,7 @@ end
                                     mcmc_draws, flow_samples, ncols, style, save_path,
                                     kwargs_subplot, kwargs_layout) -> Plots.Plot
 
-Plot standardised (z-score) empirical-Bayes estimates for each random effect as a
+Plot standardized (z-score) empirical-Bayes estimates for each random effect as a
 histogram and/or KDE, with a standard Normal reference. Values far from zero indicate
 outliers or misspecification.
 
@@ -1684,7 +1684,7 @@ end
                                             flow_samples, ncols, style, save_path,
                                             kwargs_subplot, kwargs_layout) -> Plots.Plot
 
-Scatter plot of standardised (z-score) empirical-Bayes estimates against a covariate
+Scatter plot of standardized (z-score) empirical-Bayes estimates against a covariate
 or group level index. Useful for detecting systematic patterns in the residual structure
 of the random-effects model.
 

--- a/src/plotting/plotting_residuals.jl
+++ b/src/plotting/plotting_residuals.jl
@@ -318,7 +318,7 @@ Compute residuals for each observation and return a `DataFrame`.
 - `residuals`: residual metrics to compute. Allowed: `:pit`, `:quantile`, `:raw`,
   `:pearson`, `:logscore`.
 - `fitted_stat = mean`: statistic applied to the predictive distribution for raw residuals.
-- `randomize_discrete::Bool = true`: randomise PIT values for discrete outcomes.
+- `randomize_discrete::Bool = true`: randomize PIT values for discrete outcomes.
 - `cdf_fallback_mc::Int = 0`: MC samples for CDF approximation with non-analytic distributions.
 - `ode_args::Tuple = ()`, `ode_kwargs::NamedTuple = NamedTuple()`: forwarded to ODE solver.
 - `mcmc_draws::Int = 1000`, `mcmc_warmup`: MCMC draw settings.

--- a/src/soft_trees/SoftTrees.jl
+++ b/src/soft_trees/SoftTrees.jl
@@ -67,7 +67,7 @@ end
     init_params(tree::SoftTree, rng::AbstractRNG; init_weight_std=0.1,
                 init_bias_std=0.0, init_leaf_std=0.1) -> SoftTreeParams
 
-Initialise parameters for a [`SoftTree`](@ref).
+Initialize parameters for a [`SoftTree`](@ref).
 
 The no-`rng` overload fills all parameters with the given constant values.
 The `rng` overload draws parameters from zero-mean Normal distributions with the
@@ -77,12 +77,12 @@ specified standard deviations.
 - `tree::SoftTree`: the soft tree architecture.
 - `rng::AbstractRNG`: random-number generator (second overload only).
 
-# Keyword Arguments (constant initialisation)
+# Keyword Arguments (constant initialization)
 - `init_weight::Real = 0.0`: node weight initial value.
 - `init_bias::Real = 0.0`: node bias initial value.
 - `init_leaf::Real = 0.0`: leaf value initial value.
 
-# Keyword Arguments (random initialisation)
+# Keyword Arguments (random initialization)
 - `init_weight_std::Real = 0.1`: standard deviation for node weights.
 - `init_bias_std::Real = 0.0`: standard deviation for node biases.
 - `init_leaf_std::Real = 0.1`: standard deviation for leaf values.

--- a/src/uq/accessors.jl
+++ b/src/uq/accessors.jl
@@ -62,7 +62,7 @@ Return point estimates from a [`UQResult`](@ref).
 
 # Keyword Arguments
 - `scale::Symbol = :natural`: `:natural` for the untransformed scale, `:transformed`
-  for the optimisation scale.
+  for the optimization scale.
 - `as_component::Bool = true`: if `true`, return a `ComponentArray` keyed by parameter
   name; otherwise return a plain `Vector{Float64}`.
 """

--- a/src/utils/ParameterTranformations.jl
+++ b/src/utils/ParameterTranformations.jl
@@ -479,7 +479,7 @@ end
 
 # ForwardDiff-aware matrix exponential of a symmetric matrix (single-level Dual).
 # The generic eigen-based `exp(Symmetric)` has NaN / asymmetric ForwardDiff derivatives at
-# repeated eigenvalues (e.g. Ω = I, the typical optimisation/UQ point — the derivative of an
+# repeated eigenvalues (e.g. Ω = I, the typical optimization/UQ point — the derivative of an
 # eigen-based matrix function divides by eigenvalue gaps), and the Padé `exp(::Matrix)` has no
 # `Dual` method. So compute the value with the eigen-exp of the (Float64) symmetric value, and
 # each partial direction with the AD-safe block-2×2 Padé Fréchet derivative (`_expm_frechet`,

--- a/test/estimation_focei_tests.jl
+++ b/test/estimation_focei_tests.jl
@@ -13,7 +13,7 @@ using SpecialFunctions: trigamma
 const NL = NoLimits
 
 @testset "FOCEI Fisher-information registry" begin
-    # Closed-form values (Distributions.jl native parameterisation).
+    # Closed-form values (Distributions.jl native parameterization).
     @test NL._focei_expected_information(Normal(0.3, 2.0)) ≈ [0.25 0.0; 0.0 0.5]
     @test NL._focei_expected_information(LogNormal(0.1, 2.0)) ≈ [0.25 0.0; 0.0 0.5]
     @test NL._focei_expected_information(Poisson(3.0)) ≈ fill(1 / 3, 1, 1)
@@ -233,7 +233,7 @@ end
 
 @testset "FOCEI Hessian catches numeric failures (backtracks, no crash)" begin
     # σ = sqrt(c + η) throws a DomainError when η < -c; the FOCEI Hessian builder must
-    # convert that to a NaN Hessian (→ -Inf marginal → optimiser backtracks), mirroring
+    # convert that to a NaN Hessian (→ -Inf marginal → optimizer backtracks), mirroring
     # the robustness of _laplace_logf_batch, rather than crashing the fit.
     model = @Model begin
         @fixedEffects begin
@@ -266,7 +266,7 @@ end
     @test all(isnan,
         NL._focei_negH_batch(
             dm, info, θu, [-1.0], const_cache, ll_cache; interaction = true))
-    # A full fit must complete (the optimiser may probe the invalid region).
+    # A full fit must complete (the optimizer may probe the invalid region).
     res = fit_model(
         dm, NL.FOCEI(multistart_n = 1, multistart_k = 1, optim_kwargs = (maxiters = 4,));
         serialization = NL.EnsembleSerial())

--- a/test/fixtures.jl
+++ b/test/fixtures.jl
@@ -4,7 +4,7 @@
 # fits in testset after testset: every distinct `@Model` recompiles the formula/
 # DE/logf closures + the estimator specialised to its types, and every fit
 # repeats that work. This module builds a small set of canonical model archetypes
-# and ONE fit per (archetype, method), built LAZILY and memoised, so the whole
+# and ONE fit per (archetype, method), built LAZILY and memoized, so the whole
 # suite shares them: a model is compiled once and each method is fit once, then
 # reused by the estimation / plotting / UQ / residual / summary / RE-diagnostic
 # tests instead of each rebuilding its own.

--- a/test/hmm_mv_continuous_tests.jl
+++ b/test/hmm_mv_continuous_tests.jl
@@ -196,11 +196,11 @@ end
     p_prior = probabilities_hidden_states(hmm)
     @test isapprox(posterior_hidden_states(hmm, [missing, missing]), p_prior; atol = 1e-10)
 
-    # Observation at state-1 means → posterior favours state 1
+    # Observation at state-1 means → posterior favors state 1
     post1 = posterior_hidden_states(hmm, [0.0, 2.0])
     @test post1[1] > post1[2]
 
-    # Observation at state-2 means → posterior favours state 2
+    # Observation at state-2 means → posterior favors state 2
     post2 = posterior_hidden_states(hmm, [3.0, -1.0])
     @test post2[2] > post2[1]
 end

--- a/test/hmm_mv_discrete_tests.jl
+++ b/test/hmm_mv_discrete_tests.jl
@@ -187,11 +187,11 @@ end
     p_prior = probabilities_hidden_states(hmm)
     @test isapprox(posterior_hidden_states(hmm, [missing, missing]), p_prior; atol = 1e-10)
 
-    # Observation at state-1 means → posterior favours state 1
+    # Observation at state-1 means → posterior favors state 1
     post1 = posterior_hidden_states(hmm, [0.0, 2.0])
     @test post1[1] > post1[2]
 
-    # Observation at state-2 means → posterior favours state 2
+    # Observation at state-2 means → posterior favors state 2
     post2 = posterior_hidden_states(hmm, [3.0, -1.0])
     @test post2[2] > post2[1]
 end

--- a/test/ode_callbacks_tests.jl
+++ b/test/ode_callbacks_tests.jl
@@ -137,7 +137,7 @@ using OrdinaryDiffEq
         @test isapprox(sol(2.0)[1], 1.0)
 
         # infusion_rates must be reset between solves on the same DataModel —
-        # regression test: t=t0 infusion was only initialised once at construction,
+        # regression test: t=t0 infusion was only initialized once at construction,
         # so the second solve saw infusion_rates=[0] and subsequent solves saw negative rates
         dm_evt = DataModel(model, df_evt; primary_id = :ID, time_col = :t,
             evid_col = :EVID, amt_col = :AMT, rate_col = :RATE, cmt_col = :CMT)

--- a/test/stickbreak_parameter_tests.jl
+++ b/test/stickbreak_parameter_tests.jl
@@ -27,8 +27,8 @@ using Distributions
         @test p.prior isa Dirichlet
     end
 
-    @testset "ProbabilityVector silent normalisation" begin
-        # Sum slightly off from 1 — should be normalised silently
+    @testset "ProbabilityVector silent normalization" begin
+        # Sum slightly off from 1 — should be normalized silently
         v = [0.2, 0.5, 0.3 + 1e-8]
         p = ProbabilityVector(v)
         @test isapprox(sum(p.value), 1.0; atol = 1e-14)
@@ -72,7 +72,7 @@ using Distributions
         @test A.calculate_se == true
     end
 
-    @testset "DiscreteTransitionMatrix silent row normalisation" begin
+    @testset "DiscreteTransitionMatrix silent row normalization" begin
         P = [0.6 0.4+1e-8; 0.3 0.7]
         A = DiscreteTransitionMatrix(P)
         @test all(isapprox.(sum(A.value; dims = 2), 1.0; atol = 1e-14))


### PR DESCRIPTION
## Summary

Round-4 performance audit of the estimation/likelihood hot paths, plus a documentation polish pass.

Found via a fan-out workflow (JET `report_opt` + `@allocated` probes per subsystem) with adversarial per-finding verification for byte-identical numerics and ForwardDiff/Enzyme safety. **8 fixes applied; 4 confirmed findings deferred** (rationale below). All changes are behavior-preserving.

## Performance fixes (8)

| Fix | File(s) | Effect |
|---|---|---|
| Rowwise random-effects likelihood **function barrier** (per-row loop was fully `Any`-typed) | `estimation/common.jl` | 3.8× fewer bytes/individual; ~1.7× faster |
| Laplace `re_info` **concrete eltype** (removes per-RE-group dispatch on the EBE inner loop) | `estimation/laplace.jl` | per-batch log-density ~2.1×; objective driver ~40% |
| DE builder/accessor **struct type-params** (RGF types flow into the model type) | `model/DifferentialEquation.jl` | removes ~12 dynamic dispatches per ODE solve |
| PreDE **macro-time branch** (no fresh `Set` per generated-builder call) | `model/PreDE.jl` | ~61× fewer bytes in `calculate_prede` |
| Pooled **Core.Box-killing barrier** | `estimation/pooled.jl` | pooled gradient ~2.4× |
| SAEM **symmetrize θ once per E-step** (threaded into the MH kernels) | `estimation/saemix_mh.jl`, `estimation/adaptive_mh.jl` | 38–53% of E-step allocations for PSD-RE models |
| MCEM-IS bijection log-Jacobian **`===`-chain** | `estimation/adaptive_mh.jl` | removes per-IS-sample `Val(::Symbol)` boxing |
| CT-HMM **shared `exp(QΔt)` propagation** across logpdf/posterior | `distributions/outcomes/*`, `estimation/common.jl` | one matrix exponential per observed row instead of two |

Broadest impact: the Laplace `re_info` fix and the rowwise barrier speed up the inner objective shared by Laplace, FOCEI, GHQuadrature, SAEM, and MCEM. ODE models benefit from the DE-struct and PreDE fixes; PSD-covariance SAEM/MCEM and continuous-time HMM models get the largest targeted wins.

## Documentation

Concise-tutorial pass across `docs/src/tutorials/*` (prose only — precomputed code/output blocks kept byte-identical, verified), spelling consistency across docstrings, and a README example refresh.

## Verification

- **Numerical baseline byte-identical** — 81 pinned quantities (ll/grad/Hessian on representative non-ODE / MvNormal-PSD / ODE / HMM / mixed-family / MvNormal-outcome models, FOCE/FOCEI negH incl. dual-θ freeze branch, HMM logpdf/posterior, RE-builder dists, symmetrize, resid stats, deterministic Laplace/FOCEI fit objectives + θ̂) **and** a 22-quantity gap-path gate (rowwise-RE ll + dual-η gradient, CT-HMM model-level ll, `calculate_prede`, pooled etas, deterministic Pooled/GHQ/SAEM-SaemixMH/SAEM-AdaptiveMH/MCEM-IS fits).
- **Thread-determinism (8 threads):** every threaded path (`loglikelihood`, Laplace, FOCEI, SAEM SaemixMH/PSD/AdaptiveMH, MCEM-IS) returns identical results across two runs — **no races introduced**.
- **Aqua** (ambiguities/piracy/exports/deps) and the **Enzyme-compat proxy** pass.
- **JuliaFormatter v1 (sciml)** clean (idempotent).
- Targeted test suites pass: estimation (SAEM/MCEM/MCEM-IS/pooled/Laplace/FOCEI/GHQ) and distributions/model/AD (HMM continuous + MV + observed-states + coarsed, Markov, ODE, preDE, random-effects, AD/ForwardDiff).

## Deferred (confirmed but not applied)

- **SAEM per-proposal η buffer reuse** — GC-only win; the multi-individual kernel path isn't covered by the byte-identity gates.
- **MCMC RE-vector build** — codegen inside Turing's differentiated `@model` body, can't be byte-gated.
- **Two LOW GHQ tweaks** — ~2% / PSD-only, with GHQ-PSD-UQ paths not covered by the gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
