### PR TITLE
Remove Zygote dependency (ForwardDiff-only)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -51,7 +51,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [weakdeps]
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
@@ -107,5 +106,4 @@ StaticArrays = "1"
 Statistics = "1.11.1"
 StatsFuns = "1.5.2, 2"
 Turing = "0.42.5, 0.43, 0.44, 0.45"
-Zygote = "0.7"
 julia = "1.12"

--- a/docs/src/developers-guide.md
+++ b/docs/src/developers-guide.md
@@ -63,9 +63,8 @@ A few conventions are load-bearing and enforced throughout the codebase:
   default backend, propagates `Dual` numbers and handles in-place mutation fine; what it needs is
   *type-generic* code that lets a `Dual` flow through, so allocate temporaries from the input
   element type (`similar(x)`, `zeros(eltype(x), n)`) rather than a hard-coded `Float64`.
-  Non-mutating implementations are required only on paths that also run through a reverse-mode
-  backend such as Zygote (used for VI and normalizing flows), which cannot differentiate array
-  mutation. See [Helpers](model-building/helpers.md).
+  Non-mutating implementations are preferred where code may also run through a reverse-mode
+  backend that cannot differentiate array mutation. See [Helpers](model-building/helpers.md).
 - **Accessor functions.** Struct fields are reached through `get_*` accessor functions rather
   than direct field access. This applies internally and, above all, in the public API: every
   user-facing type ships `get_*` accessors, so users never have to reach into a struct with dot

--- a/docs/src/model-building/helpers.md
+++ b/docs/src/model-building/helpers.md
@@ -24,7 +24,7 @@ end
 - Helper arguments must be simple symbols, optionally typed (e.g., `x` or `x::Float64`).
 - Duplicate helper names within the same block are rejected.
 - An empty block is valid and yields `NamedTuple()`.
-- Mutating helper patterns (e.g., in-place array operations) trigger a warning, since reverse-mode automatic differentiation backends such as Zygote require non-mutating code.
+- Mutating helper patterns (e.g., in-place array operations) trigger a warning, since some reverse-mode automatic differentiation backends require non-mutating code.
 
 ## Example: Standalone Helper Block
 
@@ -110,4 +110,4 @@ end
 
 ## Note on Automatic Differentiation
 
-Helpers that mutate arrays in place are detected and produce a warning. When reverse-mode AD compatibility is needed (e.g., with Zygote), prefer non-mutating implementations.
+Helpers that mutate arrays in place are detected and produce a warning. When reverse-mode AD compatibility is needed, prefer non-mutating implementations.

--- a/src/model/Helpers.jl
+++ b/src/model/Helpers.jl
@@ -44,7 +44,7 @@ end
 
 function _warn_if_mutating_helper(def::HelperDef)
     _helper_contains_mutation(def.body) || return nothing
-    @warn "Possible mutation detected in @helpers for $(def.name). Zygote may still work depending on the exact code, but mutation often breaks it. ForwardDiff usually handles mutation but can increase compile time and runtime for large models. Consider a non-mutating form if you need Zygote."
+    @warn "Possible mutation detected in @helpers for $(def.name). ForwardDiff usually handles mutation but it can increase compile time and runtime for large models, and may break some reverse-mode AD backends. Consider a non-mutating form."
     return nothing
 end
 
@@ -115,7 +115,7 @@ The helpers `NamedTuple` is stored in the `Model` and passed automatically at
 evaluation time via `get_helper_funs`.
 
 Mutating operations (calls ending in `!`, indexed assignment) trigger a warning since
-they may break Zygote-based automatic differentiation.
+they may break some reverse-mode automatic differentiation backends.
 """
 macro helpers(block)
     defs = parse_helpers(block)

--- a/src/model/PreDE.jl
+++ b/src/model/PreDE.jl
@@ -121,7 +121,7 @@ end
 
 function _warn_if_mutating_prede(name::Symbol, ex::Expr)
     _prede_contains_mutation(ex) || return nothing
-    @warn "Possible mutation detected in @preDifferentialEquation for $(name). Zygote may still work depending on the exact code, but mutation often breaks it. ForwardDiff usually handles mutation but can increase compile time and runtime for large models. Consider a non-mutating form if you need Zygote."
+    @warn "Possible mutation detected in @preDifferentialEquation for $(name). ForwardDiff usually handles mutation but it can increase compile time and runtime for large models, and may break some reverse-mode AD backends. Consider a non-mutating form."
     return nothing
 end
 
@@ -238,7 +238,7 @@ The symbols `t` and `ξ` are forbidden (pre-DE variables are time-constant).
 Pre-DE variables are computed once per individual before the ODE is integrated and
 are available inside `@DifferentialEquation` and `@initialDE`.
 
-Mutating operations trigger a warning since they may break Zygote-based AD.
+Mutating operations trigger a warning since they may break some reverse-mode AD backends.
 """
 macro preDifferentialEquation(block)
     RuntimeGeneratedFunctions.init(__module__)

--- a/src/soft_trees/SoftTrees.jl
+++ b/src/soft_trees/SoftTrees.jl
@@ -1,6 +1,5 @@
 using LinearAlgebra
 using Random
-using Zygote
 using Functors
 using Optimisers
 
@@ -231,15 +230,16 @@ end
 # default's ordering so all three entry points agree for any parameters.
 function (tree::SoftTree)(
         x::AbstractVector{<:Real}, params::SoftTreeParams, ::Val{:inplace})
-    # Zygote-compatible variant: identical traversal to the default method, but the
-    # probability buffer is a Zygote.Buffer so reverse-mode AD can differentiate
-    # through the in-place writes.
+    # Mutating-buffer variant kept for API compatibility: identical traversal to the
+    # default method, but the probability buffer is filled in place. ForwardDiff
+    # propagates `Dual`s through the promoted-eltype buffer, so the result matches the
+    # default method for any params.
     length(x) == tree.input_dim ||
         error("Invalid input length. Expected $(tree.input_dim); got $(length(x)).")
     n_leaves = 2^tree.depth
     T = promote_type(
         eltype(params.node_weights), eltype(params.node_biases), eltype(x))
-    probs = Zygote.Buffer(zeros(T, n_leaves))
+    probs = zeros(T, n_leaves)
     probs[1] = one(T)
     for level in 0:(tree.depth - 1)
         n_prev = 2^level
@@ -252,8 +252,7 @@ function (tree::SoftTree)(
             probs[k] = old * p
         end
     end
-    probs_v = copy(probs)
-    return [_st_leafdot(params.leaf_values, o, probs_v)
+    return [_st_leafdot(params.leaf_values, o, probs)
             for o in 1:size(params.leaf_values, 1)]
 end
 

--- a/src/utils/GeneralUtils.jl
+++ b/src/utils/GeneralUtils.jl
@@ -4,7 +4,6 @@ export flatten_re_values
 export rowsoftmax
 
 using ForwardDiff
-using Zygote
 import DiffEqBase
 
 function dir(x)
@@ -41,11 +40,6 @@ const _ODE_VERBOSE_LOUD = pkgversion(DiffEqBase) >= v"7" ?
                           DiffEqBase.SciMLLogging.Standard() : true
 @inline _ode_verbose(v::Bool) = v ? _ODE_VERBOSE_LOUD : _ODE_VERBOSE_SILENT
 @inline _ode_verbose(v) = v   # already a verbosity object — pass through unchanged
-
-function hessian_fwd_over_zygote(f, x)
-    g(xv) = Zygote.gradient(f, xv)[1]
-    return ForwardDiff.jacobian(g, x)
-end
 
 function build_ode_params(de, θ;
         random_effects = ComponentArray(NamedTuple()),

--- a/src/utils/ParameterTranformations.jl
+++ b/src/utils/ParameterTranformations.jl
@@ -267,8 +267,8 @@ function stickbreak_forward(p::AbstractVector{<:Real})
     k >= 2 || error("stickbreak_forward requires at least 2 elements.")
     T = promote_type(eltype(p), Float64)
     # `remaining` tracks 1 - Σ_{j<i} p_j, updated by subtracting each pᵢ in the loop.
-    # A simple mutating loop suffices here: unlike the inverse, the forward transform
-    # is not typically differentiated by Zygote, so it need not be non-mutating.
+    # A simple mutating loop suffices here: the forward transform runs at parameter
+    # setup and is not differentiated by the optimizer, so it need not be non-mutating.
     t = Vector{T}(undef, k - 1)
     remaining = one(T)
     for i in 1:(k - 1)
@@ -291,7 +291,8 @@ Single-allocation sequential fill. `remaining` carries the running product
 `∏_{j<i}(1-σ_j)` — the same left-to-right multiplication order as the historical
 `cumprod` formulation, so results are bit-identical. ForwardDiff/Enzyme-forward
 compatible (plain index assignment into a locally allocated, promoted-eltype
-vector); reverse-mode Zygote would need the old non-mutating `cumprod` form.
+vector); a reverse-mode backend that cannot differentiate mutation would need the
+old non-mutating `cumprod` form.
 """
 function stickbreak_inverse(t::AbstractVector{<:Real})
     k1 = length(t)

--- a/test/ad_misc.jl
+++ b/test/ad_misc.jl
@@ -4,7 +4,7 @@ using DifferentiationInterface
 using ForwardDiff
 
 @testset "Helpers mutation warnings" begin
-    # Mutating helpers should emit warnings for Zygote compatibility.
+    # Mutating helpers should emit warnings (reverse-mode AD compatibility).
     @test_logs (:warn,) @eval @helpers begin
         bump!(x) = (y = copy(x); push!(y, 1.0); y)
     end

--- a/test/ad_model_full.jl
+++ b/test/ad_model_full.jl
@@ -3,7 +3,6 @@ using NoLimits
 using ComponentArrays
 using Distributions
 using OrdinaryDiffEq
-using SciMLSensitivity
 using ForwardDiff
 using FiniteDifferences
 using DataInterpolations
@@ -104,8 +103,7 @@ using DataInterpolations
         u0 = calculate_initial_state(model, fe0, η, const_covariates_i)
         prob = ODEProblem(f!_local, u0, tspan, θt)
         sol = solve(prob, Tsit5();
-            callback = cb, abstol = 1e-9, reltol = 1e-9,
-            sensealg = InterpolatingAdjoint(autojacvec = ZygoteVJP()))
+            callback = cb, abstol = 1e-9, reltol = 1e-9)
         sol_accessors = get_de_accessors_builder(model.de.de)(sol,
             get_de_compiler(model.de.de)((;
                 fixed_effects = fe0,

--- a/test/ad_softtree.jl
+++ b/test/ad_softtree.jl
@@ -30,15 +30,16 @@ end
     val_fwd, grad_fwd = value_and_gradient(f, AutoForwardDiff(), x)
     @test length(grad_fwd) == length(x)
 
-    # ReverseDiff does not support Zygote.Buffer-based implementation.
+    # The mutating-buffer Val(:inplace) variant must agree with the default under
+    # ForwardDiff (it uses a plain promoted-eltype buffer, so Duals flow through).
+    val_fwd_inplace, grad_fwd_inplace = value_and_gradient(f_inplace, AutoForwardDiff(), x)
+    @test isapprox(val_fwd_inplace, val_fwd; rtol = 1e-6, atol = 1e-8)
+    @test isapprox(grad_fwd_inplace, grad_fwd; rtol = 1e-6, atol = 1e-8)
 
     val_fwd_fast, grad_fwd_fast = value_and_gradient(f_fast, AutoForwardDiff(), x)
     @test isapprox(val_fwd_fast, val_fwd; rtol = 1e-6, atol = 1e-8)
     @test isapprox(grad_fwd_fast, grad_fwd; rtol = 1e-6, atol = 1e-8)
 
-    # ReverseDiff does not support Zygote.Buffer-based implementation.
-
     val_fwd_p, grad_fwd_p = value_and_gradient(f_params, AutoForwardDiff(), flat)
-
-    # ReverseDiff does not support Zygote.Buffer-based implementation.
+    @test length(grad_fwd_p) == length(flat)
 end

--- a/test/prede_tests.jl
+++ b/test/prede_tests.jl
@@ -42,7 +42,7 @@ end
 end
 
 @testset "PreDifferentialEquation mutation warnings" begin
-    # Mutating patterns should emit warnings for Zygote compatibility.
+    # Mutating patterns should emit warnings (reverse-mode AD compatibility).
     @test_logs (:warn,) @eval @preDifferentialEquation begin
         v = (x = [1.0, 2.0]; x[1] = 0.0; x[1])
     end


### PR DESCRIPTION
## Summary

Removes the `Zygote` dependency - NoLimits is now ForwardDiff-only (with FiniteDifferences cross-checks in the AD tests). Completes the long-standing goal of a Zygote-free package.

## Changes

- **`Project.toml`**: drop `Zygote` from `[deps]` + `[compat]`.
- **`src/utils/GeneralUtils.jl`**: remove `using Zygote` and the `hessian_fwd_over_zygote` helper (its only `Zygote.gradient` caller).
- **`src/soft_trees/SoftTrees.jl`**: rewrite the `Val(:inplace)` SoftTree variant from a `Zygote.Buffer` to a plain promoted-eltype buffer - ForwardDiff propagates `Dual`s through it, and the result matches the default method for any params.
- **`test/ad_model_full.jl`**: drop `SciMLSensitivity` + the `ZygoteVJP()` sensealg from an ODE-solve test.
- **`test/ad_softtree.jl`**: replace the "ReverseDiff doesn't support `Zygote.Buffer`" skips with real ForwardDiff checks that the `:inplace` variant agrees with the default.
- Reword warnings / docstrings / docs: "Zygote" -> "some reverse-mode AD backends".

## Verification

`rg Zygote src/ Project.toml` -> no matches. AD test files run locally + CI full suite as the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
