### PR TITLE
ci: fix TagBot trigger so v0.1.0 (and future releases) get tagged

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -23,9 +23,7 @@ permissions:
 
 jobs:
   TagBot:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.actor == 'JuliaTagBot' && startsWith(github.event.comment.body, '@JuliaRegistrator'))
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1


### PR DESCRIPTION
## Problem

NoLimits v0.1.0 was registered ([JuliaRegistries/General#158012](https://github.com/JuliaRegistries/General/pull/158012), merged 2026-06-16) but **no git tag or GitHub release was ever created**. The repo has zero tags, and JuliaTagBot has posted reminder comments:

> *"I expected a tag to exist by now, but it doesn't... check your TagBot configuration."*

## Root cause

The `TagBot` job `if` condition required the trigger comment body to start with `@JuliaRegistrator`:

```yaml
if: |
  github.event_name == 'workflow_dispatch' ||
  (github.actor == 'JuliaTagBot' && startsWith(github.event.comment.body, '@JuliaRegistrator'))
```

But JuliaTagBot's registry-merge trigger comment body is `"Triggering TagBot for merged registry pull request: ..."` — it does **not** start with `@JuliaRegistrator`. Every TagBot run since the merge was therefore **skipped**.

## Fix

Restore the standard TagBot condition:

```yaml
if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
```

## Will it tag the correct commit?

Yes. TagBot tags the commit whose tree matches the registry's recorded `git-tree-sha1`. For v0.1.0 that is `33e9e508...`, which matches commit `40cc131b` (the registered PR #30 commit) — **not** current `main` HEAD. Verified locally.

After this merges, the next JuliaTagBot reminder will trigger correctly, or TagBot can be run manually via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)