### PR TITLE
ci: TagBot tags via workflows-scoped PAT (fixes auto-tagging)

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -28,5 +28,9 @@ jobs:
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          # Fine-grained PAT (Contents + Workflows: write). A workflow-scoped,
+          # user-tied credential is required: GITHUB_TOKEN and SSH deploy keys are
+          # both blocked from pushing tags to commits that contain .github/workflows/
+          # ("refusing to allow an OAuth App ... without workflow scope"). The PAT push
+          # also triggers the tag-based Documenter build.
+          token: ${{ secrets.TAGBOT_PAT }}


### PR DESCRIPTION
## Why

v0.1.0 had to be tagged manually because TagBot could not push the tag. Root cause, verified empirically:

GitHub rejects any push to a tag whose commit contains `.github/workflows/` unless the credential is **user-tied with `workflow` scope**:

```
! [remote rejected] v0.1.0 -> v0.1.0
  (refusing to allow an OAuth App to create or update workflow
   `.github/workflows/TagBot.yml` without `workflow` scope)
```

This blocks **both** `GITHUB_TOKEN` *and* SSH deploy keys (I confirmed a write-enabled PEM deploy key hits the exact same rejection — the older Documenter/TagBot docs claiming deploy keys bypass it are out of date). `GITHUB_TOKEN` cannot be granted `workflow` scope.

## Fix

Point TagBot's `token` at a **fine-grained PAT** secret `TAGBOT_PAT` (Contents: write + Workflows: write), and drop the now-useless `ssh:` deploy-key input. A PAT push is user-attributed, so it (a) is exempt from the workflow-scope restriction and (b) triggers the tag-based Documenter (versioned docs) build.

## Required before next release

Add the `TAGBOT_PAT` secret (fine-grained PAT scoped to this repo only). Until then, tag manually. This PR is safe to merge ahead of the secret — TagBot only runs on registration/dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)