### PR TITLE
Fix NPFParameter test for Distributions 0.25.129 MvTDist alias change

### DIFF
--- a/test/parameters_tests.jl
+++ b/test/parameters_tests.jl
@@ -147,7 +147,7 @@ end
     # Custom base distribution: MvTDist (uses passthrough _adapt_base_dist)
     q0_t = MvTDist(3, zeros(2), Matrix(I, 2, 2))
     npf_tdist = NPFParameter(2, 2; name = :npf_tdist, base_dist = q0_t)
-    @test npf_tdist.base_dist isa MvTDist
+    @test npf_tdist.base_dist isa Distributions.AbstractMvTDist
     flow_tdist = NormalizingPlanarFlow(
         npf_tdist.value, npf_tdist.reconstructor, npf_tdist.base_dist)
     @test length(flow_tdist) == 2


### PR DESCRIPTION
## Problem

CI's `test` job is failing on every open PR (`patch-1`, the DataInterpolations dependabot PR, etc.) at `test/parameters_tests.jl:150`:

```
Expression: npf_tdist.base_dist isa MvTDist
Evaluated:  Distributions.GenericMvTDist{Float64, PDMats.PDMat{…}, Vector{Float64}} isa MvTDist
```

This is **dependency drift**, not branch-specific. CI resolves **Distributions v0.25.129**, which narrowed the `MvTDist` alias so `MvTDist === GenericMvTDist` is now `false` (it was `true` in ≤0.25.126). A `GenericMvTDist` backed by a full `PDMat` covariance — exactly what `NPFParameter`'s `_adapt_base_dist` produces — therefore no longer satisfies `isa MvTDist`. Branches that last ran CI before 0.25.129 was published (e.g. `auto-uniform-prior-from-bounds`) went green but would fail if re-run today.

## Fix

Assert against the abstract supertype `AbstractMvTDist`, which every multivariate Student-t representation satisfies on all Distributions versions, while still asserting the meaningful property.

```diff
-    @test npf_tdist.base_dist isa MvTDist
+    @test npf_tdist.base_dist isa Distributions.AbstractMvTDist
```

## Verification

- `GenericMvTDist <: AbstractMvTDist` holds by the type hierarchy (guaranteed for the exact type CI reported).
- Confirmed `MvTDist === GenericMvTDist` flipped to `false` in 0.25.129.
- `parameters_tests.jl` passes 92/92 both via the real `Pkg.test` sandbox (0.25.126) and pinned to 0.25.129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)