### PR TITLE
Add RealLiePSDMatrix: Lie-algebraic covariance parameterization

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -25,6 +25,7 @@ the docstring attached to the corresponding function, type, or macro.
 RealNumber
 RealVector
 RealPSDMatrix
+RealLiePSDMatrix
 RealDiagonalMatrix
 ProbabilityVector
 DiscreteTransitionMatrix

--- a/docs/src/model-building/fixed-effects.md
+++ b/docs/src/model-building/fixed-effects.md
@@ -36,6 +36,7 @@ NoLimits provides parameter types for scalars, vectors, structured matrices, and
 | `RealNumber` | Scalar parameter | scalar `Real` |
 | `RealVector` | Vector parameter with per-element scale | `Vector{<:Real}` |
 | `RealPSDMatrix` | Symmetric positive semi-definite matrix | square `Matrix` |
+| `RealLiePSDMatrix` | Symmetric positive-definite matrix with eigenvalue bounds and optional block structure | square `Matrix` |
 | `RealDiagonalMatrix` | Diagonal matrix | diagonal entries `Vector` |
 | `ProbabilityVector` | Probability simplex of length k≥2 | `Vector` summing to 1 |
 | `DiscreteTransitionMatrix` | n×n row-stochastic matrix (n≥2) | row-stochastic `Matrix` |
@@ -91,11 +92,30 @@ The behavior of each scale option is summarized below:
 - **`:logit` scale** applies the logit transform (`log(x/(1-x))`, clamped to `[-20, 20]`) and is supported for `RealNumber` and `RealVector`. Use this for parameters that must lie in `(0, 1)`, such as probabilities. The inverse is the sigmoid function. The initial value must be strictly between 0 and 1; the constructor errors otherwise. Bounds are enforced implicitly via clamping - no explicit `lower`/`upper` are needed.
 - **`:cholesky`** (for `RealPSDMatrix`) parameterizes the matrix via its Cholesky factor with log-transformed diagonal entries.
 - **`:expm`** (for `RealPSDMatrix`) parameterizes the matrix via matrix logarithm/exponential, storing only the upper-triangular elements.
+- **`:lie`** (for `RealLiePSDMatrix`) parameterizes the matrix via its eigendecomposition Σ = exp(A) diag(exp λ) exp(A)ᵀ, with log-eigenvalues λ and an antisymmetric A built from rotation coefficients. Because the eigenvalues are exposed directly, box bounds on the spectrum are supported (`eigenvalue_lower`/`eigenvalue_upper`). Setting `blocks` fixes cross-block rotation coefficients to zero, enforcing a block-diagonal covariance without constrained optimization; `fix_eigenvalues` pins individual eigenvalues. Fixed coefficients are dropped from the optimizer.
 - **`:stickbreak`** (for `ProbabilityVector`) maps a k-probability simplex to k-1 unconstrained reals via the logistic stick-breaking transform. Each element νᵢ = pᵢ/(1-Σⱼ<ᵢ pⱼ) is passed through logit. The last probability is determined and not stored. Silently normalizes the initial value if the sum is within 1e-6 of 1.
 - **`:stickbreakrows`** (for `DiscreteTransitionMatrix`) applies the stick-breaking transform independently to each row of an n×n row-stochastic matrix, yielding n*(n-1) unconstrained parameters.
 - **`:lograterows`** (for `ContinuousTransitionMatrix`) maps each off-diagonal entry of a rate matrix to its logarithm, yielding n*(n-1) unconstrained reals. The diagonal is always recomputed as minus the row sum and is never stored as a free parameter. Initial off-diagonal values must be non-negative.
 
 For `RealVector`, scales can be mixed per element by passing a `Vector{Symbol}`, e.g. `scale=[:logit, :log, :identity]`. Mixed vectors use an elementwise dispatch that applies each element's transform independently.
+
+## Choosing a Covariance Parameterization
+
+`RealPSDMatrix` (`:cholesky`, `:expm`) and `RealLiePSDMatrix` (`:lie`) all represent a full covariance, but they differ in cost, conditioning, and what structure they can enforce. The guidance below reflects both benchmarking and the Lie parameterization's design intent.
+
+- **Default: `RealPSDMatrix(:cholesky)`.** For an ordinary random-effect covariance with no special requirements, log-Cholesky is the cheapest map and the best-conditioned under optimization. `:expm` is a reasonable alternative with no clear advantage.
+- **`RealLiePSDMatrix` without bounds or blocks is not recommended for a full matrix.** It costs more per gradient than Cholesky and conditions worse as the dimension grows, because a full rotation's coefficients are not uniquely identified.
+- **Use `RealLiePSDMatrix` with eigenvalue bounds when the covariance drives an ODE.** When random effects enter ODE initial conditions or rates, an unconstrained Cholesky/matrix-log start can produce an ill-conditioned Σ that makes the solver fail at the first optimization step. Bounding the spectrum with `eigenvalue_lower`/`eigenvalue_upper` keeps every candidate matrix well-conditioned. This is the parameterization's primary motivation (Stapor, 2020).
+- **Use `blocks` for known block structure.** When some random effects are known not to correlate, `blocks` enforces the zeros exactly and removes the cross-block parameters from the optimizer, which reduces the parameter count and speeds up convergence versus fitting a full matrix.
+- **Use `RealDiagonalMatrix` for a diagonal covariance.** It is simpler and cheaper than any full parameterization.
+
+```julia
+# Full covariance driving an ODE: bound the eigenvalues for solver robustness.
+Omega = RealLiePSDMatrix(Matrix(I, 3, 3), eigenvalue_lower=1e-3, eigenvalue_upper=1e3)
+
+# Block-diagonal covariance: random effects 1-2 correlate, 3 is independent.
+Omega_block = RealLiePSDMatrix(Matrix(I, 3, 3), blocks=[1, 1, 2])
+```
 
 ## Example: Learned Function Approximators
 

--- a/src/Constants.jl
+++ b/src/Constants.jl
@@ -2,6 +2,7 @@ export EPSILON
 
 const REAL_SCALES = (:identity, :log, :logit)
 const PSD_SCALES = (:cholesky, :expm)
+const LIE_PSD_SCALES = (:lie,)
 const DIAGONAL_SCALES = (:log,)
 const PROBABILITY_SCALES = (:stickbreak,)
 const TRANSITION_SCALES = (:stickbreakrows,)

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -2467,7 +2467,8 @@ end
 # `_symmetrize_psd_params` return immediately for the (common) no-PSD case
 # instead of running a boxing `getfield(params, name)` loop on every call.
 @generated function _has_psd_params(::NamedTuple{names, T}) where {names, T}
-    return any(p -> p <: RealPSDMatrix, T.parameters) ? :(true) : :(false)
+    return any(p -> p <: RealPSDMatrix || p <: RealLiePSDMatrix, T.parameters) ?
+           :(true) : :(false)
 end
 
 function _symmetrize_psd_params(θ::ComponentArray, fe::FixedEffects)
@@ -2476,7 +2477,7 @@ function _symmetrize_psd_params(θ::ComponentArray, fe::FixedEffects)
     θsym = θ
     for name in get_names(fe)
         p = getfield(params, name)
-        if p isa RealPSDMatrix
+        if p isa RealPSDMatrix || p isa RealLiePSDMatrix
             A = getproperty(θsym, name)
             if A isa AbstractMatrix
                 Asym = 0.5 .* (A .+ A')

--- a/src/model/FixedEffects.jl
+++ b/src/model/FixedEffects.jl
@@ -418,7 +418,8 @@ function build_fixed_effects(params::NamedTuple)
         names, specs, getaxes(θ0_transformed), length(θ0_transformed))
     inverse_transform = InverseTransform(
         names, specs, getaxes(θ0_untransformed), length(θ0_untransformed))
-    bounds_transformed = _transform_bounds(bounds_untransformed, names, specs)
+    bounds_transformed = _transform_bounds(
+        bounds_untransformed, names, specs; params = params)
 
     flat_names, _ = _flatten_by_specs(θ0_transformed, names, specs)
 
@@ -453,6 +454,12 @@ function _param_lower(p::RealPSDMatrix)
     return fill(-Inf, size(p.value))
 end
 
+# Natural-scale bounds on the matrix entries are unbounded; the eigenvalue box bounds
+# are applied on the transformed (log-eigenvalue) scale in `_transform_bounds`.
+function _param_lower(p::RealLiePSDMatrix)
+    return fill(-Inf, size(p.value))
+end
+
 function _param_lower(p::RealDiagonalMatrix)
     return fill(-Inf, length(p.value))
 end
@@ -477,6 +484,10 @@ function _param_lower(p::ContinuousTransitionMatrix)
 end
 
 function _param_upper(p::RealPSDMatrix)
+    return fill(Inf, size(p.value))
+end
+
+function _param_upper(p::RealLiePSDMatrix)
     return fill(Inf, size(p.value))
 end
 
@@ -512,6 +523,11 @@ end
 
 function _param_spec(name::Symbol, p::RealPSDMatrix)
     return TransformSpec(name, p.scale, size(p.value), nothing)
+end
+
+function _param_spec(name::Symbol, p::RealLiePSDMatrix)
+    layout = _build_lie_layout(p.value, p.blocks, p.fixed_eigenvalues)
+    return TransformSpec(name, :lie, size(p.value), nothing, layout)
 end
 
 function _param_spec(name::Symbol, p::RealDiagonalMatrix)
@@ -778,7 +794,7 @@ function _flatten_by_specs(
 end
 
 function _transform_bounds(bounds::Tuple{ComponentArray, ComponentArray},
-        names::Vector{Symbol}, specs::Vector{TransformSpec})
+        names::Vector{Symbol}, specs::Vector{TransformSpec}; params = NamedTuple())
     lower, upper = bounds
     lower_pairs = Pair{Symbol, Any}[]
     upper_pairs = Pair{Symbol, Any}[]
@@ -849,6 +865,21 @@ function _transform_bounds(bounds::Tuple{ComponentArray, ComponentArray},
             n = spec.size[1]
             push!(lower_pairs, name => fill(-Inf, n * (n - 1)))
             push!(upper_pairs, name => fill(Inf, n * (n - 1)))
+        elseif spec.kind == :lie
+            # Transformed layout is `[λ (n); α (nA)]` (or, when structured, only the free
+            # entries). Eigenvalue box bounds map through the log to bounds on the λ slots
+            # (0 → -Inf, Inf → Inf); rotation-coefficient (α) slots are unbounded.
+            n = spec.size[1]
+            p = hasproperty(params, name) ? getproperty(params, name) : nothing
+            lo_eig = p isa RealLiePSDMatrix ? p.eigenvalue_lower : fill(0.0, n)
+            up_eig = p isa RealLiePSDMatrix ? p.eigenvalue_upper : fill(Inf, n)
+            _lie_lo(i) = i > n ? -Inf : (lo_eig[i] <= 0 ? -Inf : log(lo_eig[i]))
+            _lie_up(i) = i > n ? Inf : (isinf(up_eig[i]) ? Inf : log(up_eig[i]))
+            slots = spec.lie === nothing ? (1:(n * (n + 1) ÷ 2)) : spec.lie.free_idx
+            l2 = [_lie_lo(i) for i in slots]
+            u2 = [_lie_up(i) for i in slots]
+            push!(lower_pairs, name => l2)
+            push!(upper_pairs, name => u2)
         else
             push!(lower_pairs, name => l)
             push!(upper_pairs, name => u)

--- a/src/model/Parameters.jl
+++ b/src/model/Parameters.jl
@@ -9,8 +9,8 @@ using FunctionChains
 using Turing: Flat
 
 export AbstractParameterBlock
-export RealNumber, RealVector, RealPSDMatrix, RealDiagonalMatrix, NNParameters,
-       NPFParameter, SoftTreeParameters, SplineParameters
+export RealNumber, RealVector, RealPSDMatrix, RealLiePSDMatrix, RealDiagonalMatrix,
+       NNParameters, NPFParameter, SoftTreeParameters, SplineParameters
 export ProbabilityVector, DiscreteTransitionMatrix, ContinuousTransitionMatrix
 export Priorless
 
@@ -28,7 +28,7 @@ struct Priorless end
 Abstract base type for all parameter block types used in `@fixedEffects`.
 
 Concrete subtypes: [`RealNumber`](@ref), [`RealVector`](@ref),
-[`RealPSDMatrix`](@ref), [`RealDiagonalMatrix`](@ref),
+[`RealPSDMatrix`](@ref), [`RealLiePSDMatrix`](@ref), [`RealDiagonalMatrix`](@ref),
 [`ProbabilityVector`](@ref), [`DiscreteTransitionMatrix`](@ref),
 [`ContinuousTransitionMatrix`](@ref), [`NNParameters`](@ref),
 [`SoftTreeParameters`](@ref), [`SplineParameters`](@ref),
@@ -221,6 +221,164 @@ function RealPSDMatrix(value::AbstractMatrix{<:Real}; name::Symbol = :unnamed,
     _is_psd(v) ||
         error("Invalid initial value for parameter $(name). Expected symmetric positive semi-definite matrix; got matrix with min eigenvalue $(minimum(eigen(Symmetric(v)).values)).")
     return RealPSDMatrix{T, typeof(v)}(name, v, scale, prior, calculate_se)
+end
+
+"""
+    RealLiePSDMatrix(value; blocks, fix_eigenvalues, eigenvalue_lower, eigenvalue_upper, name, scale, prior, calculate_se)
+    RealLiePSDMatrix(; log_eigenvalues, angles, blocks, fix_eigenvalues, eigenvalue_lower, eigenvalue_upper, name, prior, calculate_se)
+
+A symmetric positive-definite matrix parameter block using the Lie-algebraic
+parameterization of Stapor (2020, PhD thesis, §5.3). The matrix is described by its
+eigendecomposition `Σ = U * diag(exp λ) * Uᵀ` with `U = exp(A)` and `A = Σₘ αₘ Aₘ`
+antisymmetric. The free parameters are the `n` log-eigenvalues `λ` (optimized on ℝ, so
+eigenvalues stay strictly positive) and the `nA = n*(n-1)/2` rotation coefficients `α`
+(one per index pair `(i, j)`, `i < j`).
+
+Unlike [`RealPSDMatrix`](@ref) (`:cholesky`/`:expm`), the eigenvalues are exposed
+directly, so box bounds on the spectrum are supported through
+`eigenvalue_lower`/`eigenvalue_upper`. Constraining the eigenvalues keeps the matrix
+well-conditioned at optimization start points, which reduces ODE-integration failure
+when the matrix parameterizes a random-effect covariance.
+
+## Structured covariances (block-diagonal / fixed eigenvalues)
+
+Because each rotation coefficient `αₘ` couples exactly one pair of dimensions, setting the
+cross-block coefficients to zero makes `A` — and hence `exp(A)` and `Σ` — block-diagonal.
+Passing `blocks` therefore enforces a block-diagonal covariance *without constrained
+optimization*: the cross-block coefficients are removed from the optimizer entirely. Fixed
+eigenvalues (`fix_eigenvalues`) are likewise dropped from the optimizer and pinned at their
+initial values. The transformed (optimizer) vector then contains only the free
+`(λ, α)` entries.
+
+# Arguments
+- `value::AbstractMatrix{<:Real}`: initial symmetric positive-definite matrix. When
+  `blocks` is given, `value` must be block-diagonal (cross-block entries ≈ 0).
+
+# Keyword Arguments
+- `log_eigenvalues::AbstractVector{<:Real}`, `angles::AbstractVector{<:Real}`:
+  alternative to `value` — build the matrix directly from the `n` log-eigenvalues and
+  the `n*(n-1)/2` rotation coefficients. Cross-block angles are zeroed if `blocks` is set.
+- `blocks::Union{Nothing, AbstractVector{<:Integer}} = nothing`: length-`n` block membership
+  labels. Dimensions sharing a label form one covariance block; cross-block correlations are
+  fixed to zero. `nothing` (or a single label) means a full covariance.
+- `fix_eigenvalues = Int[]`: dimension indices `1:n` whose eigenvalue is held fixed at its
+  initial value (block-order, ascending within each block). Removed from the optimizer.
+- `eigenvalue_lower`, `eigenvalue_upper`: box bounds on the eigenvalues (a scalar, broadcast
+  to all `n`, or a length-`n` vector), indexed by dimension. `eigenvalue_lower` defaults to
+  `0.0` (unbounded below) and `eigenvalue_upper` to `Inf` (unbounded above).
+- `name::Symbol = :unnamed`: parameter name (injected automatically by `@fixedEffects`).
+- `scale::Symbol = :lie`: reparameterization. Must be in `LIE_PSD_SCALES` (`:lie`).
+- `prior = Priorless()`: a matrix-variate `Distributions.Distribution` (e.g.
+  `InverseWishart`) evaluated on the natural-scale matrix, or `Priorless()`.
+- `calculate_se::Bool = false`: whether to include this parameter in standard-error
+  calculations.
+"""
+struct RealLiePSDMatrix{T <: Real, MT <: AbstractMatrix{T}} <: AbstractParameterBlock
+    name::Symbol
+    value::MT
+    scale::Symbol
+    prior::Any
+    calculate_se::Bool
+    eigenvalue_lower::Vector{Float64}
+    eigenvalue_upper::Vector{Float64}
+    blocks::Vector{Int}
+    fixed_eigenvalues::Vector{Int}
+end
+
+# Normalize scalar-or-vector eigenvalue bounds to length-n Float64 vectors and validate.
+# `lower` of 0 means "unbounded below" (maps to log(EPSILON) = -Inf); `upper` of Inf
+# means "unbounded above". Bounds live on the natural (eigenvalue) scale.
+function _normalize_eig_bounds(lower, upper, n::Int, name::Symbol)
+    lo = lower isa AbstractVector ? collect(Float64, lower) : fill(Float64(lower), n)
+    up = upper isa AbstractVector ? collect(Float64, upper) : fill(Float64(upper), n)
+    length(lo) == n ||
+        error("eigenvalue_lower for $(name) must have length $(n); got $(length(lo)).")
+    length(up) == n ||
+        error("eigenvalue_upper for $(name) must have length $(n); got $(length(up)).")
+    for i in 1:n
+        (isfinite(lo[i]) && lo[i] >= 0) ||
+            error("eigenvalue_lower[$(i)] for $(name) must be finite and ≥ 0; got $(lo[i]).")
+        up[i] >= lo[i] ||
+            error("eigenvalue_upper[$(i)] for $(name) must be ≥ eigenvalue_lower[$(i)]; got upper=$(up[i]), lower=$(lo[i]).")
+    end
+    return lo, up
+end
+
+# Normalize `blocks` to a length-n Int vector and validate `fix_eigenvalues` indices.
+function _normalize_lie_structure(blocks, fix_eigenvalues, n::Int, name::Symbol)
+    blk = if blocks === nothing
+        ones(Int, n)
+    else
+        length(blocks) == n ||
+            error("blocks for $(name) must have length $(n); got $(length(blocks)).")
+        collect(Int, blocks)
+    end
+    fixed = collect(Int, fix_eigenvalues)
+    for i in fixed
+        (1 <= i <= n) ||
+            error("fix_eigenvalues index $(i) for $(name) is out of range 1:$(n).")
+    end
+    return blk, sort(unique(fixed))
+end
+
+# When `blocks` groups dimensions, the initial matrix must be block-diagonal so that its
+# recovered cross-block rotation coefficients are zero.
+function _validate_block_diagonal(v::AbstractMatrix, blk::Vector{Int}, name::Symbol)
+    n = size(v, 1)
+    scale = maximum(abs, v) + one(eltype(v))
+    for i in 1:n, j in 1:n
+        if blk[i] != blk[j] && abs(v[i, j]) > sqrt(eps(Float64)) * scale
+            error("RealLiePSDMatrix($(name)): `value` must be block-diagonal for the given `blocks`; entry ($(i),$(j)) couples different blocks but is $(v[i, j]).")
+        end
+    end
+    return nothing
+end
+
+function RealLiePSDMatrix(value::AbstractMatrix{<:Real}; name::Symbol = :unnamed,
+        scale::Symbol = :lie, prior = Priorless(), calculate_se::Bool = false,
+        eigenvalue_lower = 0.0, eigenvalue_upper = Inf, blocks = nothing,
+        fix_eigenvalues = Int[])
+    _check_prior(prior, name)
+    scale in LIE_PSD_SCALES ||
+        error("Invalid scale for parameter $(name). Expected one of $(LIE_PSD_SCALES); got $(scale).")
+    size(value, 1) == size(value, 2) ||
+        error("Invalid value for parameter $(name). Expected a square matrix; got size $(size(value)).")
+    T = eltype(value) <: AbstractFloat ? eltype(value) : Float64
+    v = T.(value)
+    _is_psd(v) ||
+        error("Invalid initial value for parameter $(name). Expected symmetric positive semi-definite matrix; got matrix with min eigenvalue $(minimum(eigen(Symmetric(v)).values)).")
+    lo, up = _normalize_eig_bounds(eigenvalue_lower, eigenvalue_upper, size(v, 1), name)
+    blk, fixed = _normalize_lie_structure(blocks, fix_eigenvalues, size(v, 1), name)
+    blocks !== nothing && _validate_block_diagonal(v, blk, name)
+    return RealLiePSDMatrix{T, typeof(v)}(
+        name, v, scale, prior, calculate_se, lo, up, blk, fixed)
+end
+
+function RealLiePSDMatrix(; log_eigenvalues::AbstractVector{<:Real},
+        angles::AbstractVector{<:Real} = Float64[], name::Symbol = :unnamed,
+        prior = Priorless(), calculate_se::Bool = false,
+        eigenvalue_lower = 0.0, eigenvalue_upper = Inf, blocks = nothing,
+        fix_eigenvalues = Int[])
+    n = length(log_eigenvalues)
+    n >= 1 ||
+        error("RealLiePSDMatrix($(name)): requires at least one log-eigenvalue.")
+    nA = n * (n - 1) ÷ 2
+    length(angles) == nA ||
+        error("RealLiePSDMatrix($(name)): expected $(nA) angles for n=$(n); got $(length(angles)).")
+    ang = Float64.(collect(angles))
+    # Zero any cross-block angles so the constructed matrix is exactly block-diagonal.
+    if blocks !== nothing
+        blk, = _normalize_lie_structure(blocks, Int[], n, name)
+        for (k, (i, j)) in enumerate(_lie_pairs(n))
+            blk[i] != blk[j] && (ang[k] = 0.0)
+        end
+    end
+    t = vcat(Float64.(collect(log_eigenvalues)), ang)
+    value = liepsd_inverse(t)
+    return RealLiePSDMatrix(value; name = name, scale = :lie, prior = prior,
+        calculate_se = calculate_se, eigenvalue_lower = eigenvalue_lower,
+        eigenvalue_upper = eigenvalue_upper, blocks = blocks,
+        fix_eigenvalues = fix_eigenvalues)
 end
 
 """

--- a/src/summaries/fit_uq_summary.jl
+++ b/src/summaries/fit_uq_summary.jl
@@ -234,7 +234,7 @@ function _fq_value_from_lookup(v0, name::Symbol, spec::TransformSpec, lookup::Fu
         val = lookup(string(name))
         return val === nothing ? v0 : val
     end
-    if spec.kind == :expm && v0 isa AbstractMatrix
+    if (spec.kind == :expm || spec.kind == :lie) && v0 isa AbstractMatrix
         n = size(v0, 1)
         vv = Matrix{Float64}(undef, size(v0)...)
         for j in 1:n

--- a/src/uq/common.jl
+++ b/src/uq/common.jl
@@ -90,7 +90,21 @@ end
 @inline function _coords_for_param(value, spec::TransformSpec; natural::Bool)
     if value isa Number
         return Float64[value]
-    elseif natural && spec.kind == :expm && value isa AbstractMatrix
+    elseif natural && spec.kind == :lie && spec.lie !== nothing &&
+           value isa AbstractMatrix
+        # Structured Lie covariance: report per free slot — the eigenvalue for a free
+        # log-eigenvalue slot, the coefficient for a free rotation slot. Count equals the
+        # transformed free-parameter count (Wald delta-method stays square).
+        layout = spec.lie
+        p_full = _liepsd_forward_blocks(value, layout.blocks)
+        out = Float64[]
+        for idx in layout.free_idx
+            push!(out, idx <= layout.n ? exp(p_full[idx]) : p_full[idx])
+        end
+        return out
+    elseif natural && (spec.kind == :expm ||
+                       (spec.kind == :lie && spec.lie === nothing)) &&
+           value isa AbstractMatrix
         n = size(value, 1)
         out = Float64[]
         for j in 1:n

--- a/src/uq/mcmc.jl
+++ b/src/uq/mcmc.jl
@@ -17,7 +17,13 @@ function _chain_keys_for_free(fe::FixedEffects, free_names::Vector{Symbol})
         spec = spec_map[name]
         if v isa Number
             push!(out, string(name))
-        elseif spec.kind == :expm && v isa AbstractMatrix
+        elseif spec.kind == :lie && spec.lie !== nothing
+            # Structured Lie: one key per free (λ/α) slot, matching the transformed count.
+            for k in eachindex(spec.lie.free_idx)
+                push!(out, string(name, "[", k, "]"))
+            end
+        elseif (spec.kind == :expm ||
+                (spec.kind == :lie && spec.lie === nothing)) && v isa AbstractMatrix
             n = size(v, 1)
             for j in 1:n
                 for i in 1:j

--- a/src/utils/ParameterTranformations.jl
+++ b/src/utils/ParameterTranformations.jl
@@ -19,13 +19,34 @@ export stickbreak_forward
 export stickbreak_inverse
 export lograterows_forward
 export lograterows_inverse
+export liepsd_forward
+export liepsd_inverse
 export apply_inv_jacobian_T
+
+# Layout for a structured (block-diagonal and/or fixed-eigenvalue) Lie PSD matrix.
+# `free_idx`/`fixed_idx` partition the positions `1:L` of the full parameter vector
+# `[λ (n); α (nA)]` (L = n(n+1)/2); the transformed (optimizer) vector holds the free
+# entries in `free_idx` order, while `fixed_idx` entries are pinned to `fixed_val`
+# (log-eigenvalues for fixed eigenvalues, `0` for cross-block rotation coefficients).
+struct LiePSDLayout
+    n::Int
+    blocks::Vector{Int}
+    free_idx::Vector{Int}
+    fixed_idx::Vector{Int}
+    fixed_val::Vector{Float64}
+end
 
 struct TransformSpec
     name::Symbol
     kind::Symbol
     size::Tuple{Int, Int}
     mask::Union{Nothing, Vector{Symbol}}
+    lie::Union{Nothing, LiePSDLayout}
+end
+# Backward-compatible 4-arg constructor (all non-Lie specs carry no layout).
+function TransformSpec(name::Symbol, kind::Symbol, size::Tuple{Int, Int},
+        mask::Union{Nothing, Vector{Symbol}})
+    TransformSpec(name, kind, size, mask, nothing)
 end
 
 # `out_axes`/`n_out` (when provided) describe the output ComponentArray layout and
@@ -138,6 +159,10 @@ function _write_forward_spec!(flat::Vector, k::Int, spec::TransformSpec, val)
         return k
     elseif kind === :lograterows
         return _write_flat!(flat, lograterows_forward(val), k)
+    elseif kind === :lie
+        fwd = spec.lie === nothing ? liepsd_forward(val) :
+              _liepsd_forward_layout(val, spec.lie)
+        return _write_flat!(flat, fwd, k)
     else
         return _write_flat!(flat, val, k)
     end
@@ -185,6 +210,10 @@ function _write_inverse_spec!(flat::Vector, k::Int, spec::TransformSpec, val)
     elseif kind === :lograterows
         n = spec.size[1]
         return _write_flat!(flat, lograterows_inverse(val, n), k)
+    elseif kind === :lie
+        inv = spec.lie === nothing ? liepsd_inverse(val) :
+              _liepsd_inverse_layout(val, spec.lie)
+        return _write_flat!(flat, inv, k)
     else
         return _write_flat!(flat, val, k)
     end
@@ -539,6 +568,230 @@ function _upper_tri_vec_grad(G::AbstractMatrix{<:Real})
     return out
 end
 
+# ── Lie-algebraic PSD parameterization (Stapor 2020, §5.3) ────────────────────
+# A symmetric positive-definite matrix is written via its eigendecomposition
+#   Σ = U · diag(exp λ) · Uᵀ,   U = exp(A),   A = Σₘ αₘ Aₘ  (antisymmetric),
+# so the transformed vector is [λ (n) ; α (nA)] with nA = n(n-1)/2 (total n(n+1)/2).
+# The log-eigenvalues λ live on ℝ (eigenvalues stay positive) and can be box-bounded;
+# the rotation coefficients α are unbounded. `exp(A)` for antisymmetric A is a general
+# (non-symmetric) matrix exponential, so it goes through the generic Padé path under
+# ForwardDiff (no eigengap issue, unlike the symmetric `:expm` scale) and needs no
+# `Dual` specialization.
+
+# Recover n from the packed length L = n(n+1)/2.
+function _lie_dim(L::Int)
+    n = (isqrt(8L + 1) - 1) ÷ 2
+    n * (n + 1) ÷ 2 == L ||
+        error("Invalid Lie-parameter length $(L); not of the form n(n+1)/2.")
+    return n
+end
+
+# Antisymmetric matrix from angle coefficients in lexicographic (i<j) order.
+function _lie_antisym(α::AbstractVector, n::Int)
+    A = zeros(eltype(α), n, n)
+    k = 1
+    for i in 1:n
+        for j in (i + 1):n
+            A[i, j] = α[k]
+            A[j, i] = -α[k]
+            k += 1
+        end
+    end
+    return A
+end
+
+# Ordered list of index pairs (i, j), i < j — the enumeration used for the angle block
+# (and matching `_lie_antisym`). Angle k in `1:nA` maps to `_lie_pairs(n)[k]`.
+function _lie_pairs(n::Int)
+    pairs = Tuple{Int, Int}[]
+    for i in 1:n
+        for j in (i + 1):n
+            push!(pairs, (i, j))
+        end
+    end
+    return pairs
+end
+
+"""
+    liepsd_inverse(t::AbstractVector{<:Real}) -> Matrix
+
+Map the packed vector `t = [λ (n); α (n(n-1)/2)]` to the symmetric positive-definite
+matrix `Σ = exp(A) · diag(exp λ) · exp(A)ᵀ`, `A` antisymmetric built from `α`.
+"""
+function liepsd_inverse(t::AbstractVector{<:Real})
+    L = length(t)
+    n = _lie_dim(L)
+    λ = @view t[1:n]
+    α = @view t[(n + 1):L]
+    A = _lie_antisym(collect(α), n)
+    U = exp(A)
+    Σ = U * Diagonal(exp.(λ)) * U'
+    # Wrap in `Symmetric` before densifying to guarantee an exactly Hermitian matrix
+    # (value and ForwardDiff partials) for the stricter `cholesky` inside MvNormal/PDMats.
+    return Matrix(Symmetric(Σ))
+end
+
+# ForwardDiff-aware `liepsd_inverse` (single-level Dual). LinearAlgebra's `exp!` only has
+# a BLAS method, so `exp(::Matrix{Dual})` errors; mirror the `:expm` treatment and build
+# the partials from the block-2×2 Padé Fréchet derivative of the matrix exponential
+# (`_expm_frechet`, general-matrix, no eigengaps). The value is computed with LAPACK on the
+# Float64 antisymmetric matrix. Nested Duals fall back to the generic `<:Real` method above.
+function liepsd_inverse(t::AbstractVector{ForwardDiff.Dual{
+        Tg, V, N}}) where {
+        Tg, V <: AbstractFloat, N}
+    L = length(t)
+    n = _lie_dim(L)
+    tv = ForwardDiff.value.(t)
+    λv = tv[1:n]
+    αv = tv[(n + 1):L]
+    Av = _lie_antisym(αv, n)
+    Uv = exp(Av)                                   # value (LAPACK — no AD here)
+    Dv = Diagonal(exp.(λv))
+    Σv = Matrix(Symmetric(Uv * Dv * Uv'))
+    dΣs = ntuple(N) do k
+        p = ForwardDiff.partials.(t, k)            # length-L seed direction
+        dλ = @view p[1:n]
+        dα = @view p[(n + 1):L]
+        dAk = _lie_antisym(collect(dα), n)
+        _, dUk = _expm_frechet(Av, dAk)            # ∂exp(A)[dA]
+        dDk = Diagonal(exp.(λv) .* collect(dλ))
+        dΣ = dUk * Dv * Uv' + Uv * dDk * Uv' + Uv * Dv * dUk'
+        Matrix(Symmetric(dΣ))
+    end
+    out = Matrix{ForwardDiff.Dual{Tg, V, N}}(undef, n, n)
+    @inbounds for j in 1:n, i in 1:n
+        out[i, j] = ForwardDiff.Dual{Tg}(Σv[i, j], ntuple(k -> dΣs[k][i, j], N)...)
+    end
+    return out
+end
+
+"""
+    liepsd_forward(Σ::AbstractMatrix{<:Real}) -> Vector
+
+Inverse of [`liepsd_inverse`](@ref): recover `[λ; α]` from a symmetric positive-definite
+`Σ` via its eigendecomposition. Runs at model construction on `Float64`.
+"""
+function liepsd_forward(Σ::AbstractMatrix{<:Real})
+    n = size(Σ, 1)
+    Σsym = Matrix(Symmetric((Σ + Σ') / 2))
+    nA = n * (n - 1) ÷ 2
+    # Diagonal fast path: the eigenvector rotation is the identity, so α = 0.
+    if isdiag(Σsym)
+        λ = [log(Σsym[i, i]) for i in 1:n]
+        return vcat(λ, zeros(nA))
+    end
+    F = eigen(Σsym)
+    Λ = F.values
+    U = Matrix(F.vectors)
+    # Ensure U ∈ SO(n) (det +1): a sign flip of one eigenvector leaves Σ unchanged.
+    if det(U) < 0
+        U[:, 1] .= .-U[:, 1]
+    end
+    λ = log.(Λ)
+    Alog = real.(log(U))
+    As = (Alog .- Alog') ./ 2
+    α = [As[i, j] for i in 1:n for j in (i + 1):n]
+    return vcat(λ, α)
+end
+
+# Block-aware forward: recover the full `[λ; α]` vector for a block-diagonal `Σ` by
+# eigendecomposing each block separately. Global `eigen` would mix eigenvectors across
+# blocks and yield nonzero cross-block angles; the block-wise route guarantees the
+# cross-block coefficients are exactly zero (so `Σ` stays block-diagonal under `liepsd_inverse`).
+function _liepsd_forward_blocks(Σ::AbstractMatrix{<:Real}, blocks::Vector{Int})
+    n = size(Σ, 1)
+    Σsym = Matrix(Symmetric((Σ + Σ') / 2))
+    pairs = _lie_pairs(n)
+    pair_index = Dict(pairs[k] => k for k in eachindex(pairs))
+    λ = zeros(Float64, n)
+    α = zeros(Float64, length(pairs))
+    for b in unique(blocks)
+        dims = findall(==(b), blocks)
+        if length(dims) == 1
+            λ[dims[1]] = log(Σsym[dims[1], dims[1]])
+            continue
+        end
+        sub = Matrix(Symmetric(Σsym[dims, dims]))
+        if isdiag(sub)
+            for (loc, d) in enumerate(dims)
+                λ[d] = log(sub[loc, loc])
+            end
+            continue
+        end
+        F = eigen(sub)
+        U = Matrix(F.vectors)
+        det(U) < 0 && (U[:, 1] .= .-U[:, 1])
+        for (loc, d) in enumerate(dims)
+            λ[d] = log(F.values[loc])
+        end
+        Alog = real.(log(U))
+        As = (Alog .- Alog') ./ 2
+        nb = length(dims)
+        for a in 1:nb, c in (a + 1):nb
+            α[pair_index[(dims[a], dims[c])]] = As[a, c]
+        end
+    end
+    return vcat(λ, α)
+end
+
+# Build the structured layout from an initial matrix, block labels and fixed-eigenvalue
+# dimension indices. Returns `nothing` for the unstructured full case (single block, no
+# fixed eigenvalues), which keeps the plain `liepsd_forward`/`liepsd_inverse` fast path.
+function _build_lie_layout(Σ0::AbstractMatrix{<:Real}, blocks::Vector{Int},
+        fixed_eigenvalues::Vector{Int})
+    n = size(Σ0, 1)
+    L = n * (n + 1) ÷ 2
+    single_block = all(==(blocks[1]), blocks)
+    if single_block && isempty(fixed_eigenvalues)
+        return nothing
+    end
+    p_full = _liepsd_forward_blocks(Σ0, blocks)
+    pairs = _lie_pairs(n)
+    fixed_set = Set{Int}()
+    fixed_idx = Int[]
+    fixed_val = Float64[]
+    # Fixed eigenvalues (positions 1:n) pinned at their initial log-eigenvalue.
+    for i in fixed_eigenvalues
+        push!(fixed_idx, i)
+        push!(fixed_val, p_full[i])
+        push!(fixed_set, i)
+    end
+    # Cross-block rotation coefficients (positions n+1:L) pinned at 0.
+    for (k, (i, j)) in enumerate(pairs)
+        if blocks[i] != blocks[j]
+            pos = n + k
+            push!(fixed_idx, pos)
+            push!(fixed_val, 0.0)
+            push!(fixed_set, pos)
+        end
+    end
+    free_idx = [pos for pos in 1:L if !(pos in fixed_set)]
+    order = sortperm(fixed_idx)
+    return LiePSDLayout(n, blocks, free_idx, fixed_idx[order], fixed_val[order])
+end
+
+# Scatter the free transformed vector into the full `[λ; α]` layout (fixed entries pinned)
+# and map to `Σ`. ForwardDiff-transparent: the element type follows `t`, so the pinned
+# Float64 values are promoted to `Dual` (with zero partials) on the AD path.
+function _liepsd_inverse_layout(t::AbstractVector, layout::LiePSDLayout)
+    L = layout.n * (layout.n + 1) ÷ 2
+    p = Vector{eltype(t)}(undef, L)
+    @inbounds for k in eachindex(layout.free_idx)
+        p[layout.free_idx[k]] = t[k]
+    end
+    @inbounds for k in eachindex(layout.fixed_idx)
+        p[layout.fixed_idx[k]] = eltype(t)(layout.fixed_val[k])
+    end
+    return liepsd_inverse(p)
+end
+
+# Forward for the structured case: recover the full block-wise `[λ; α]` and keep the free
+# entries in `free_idx` order.
+function _liepsd_forward_layout(Σ::AbstractMatrix{<:Real}, layout::LiePSDLayout)
+    p_full = _liepsd_forward_blocks(Σ, layout.blocks)
+    return p_full[layout.free_idx]
+end
+
 function apply_inv_jacobian_T(
         it::InverseTransform, θt::ComponentArray, grad_u::ComponentArray)
     names = it.names
@@ -629,6 +882,16 @@ function _inv_jac_spec_val(spec::TransformSpec, θti, gu)
                 end
             end
             return out
+        elseif spec.kind == :lie
+            # θti: free transformed vector; gu: n×n natural gradient w.r.t. Σ.
+            # gₜ[k] = Σ_ij (∂Σ_ij/∂t_k) gu_ij = (Jᵀ vec(gu))[k], with J the Jacobian of the
+            # (possibly structured) inverse map. The transform is Float64 on both gradient
+            # paths that call this (Laplace/FOCEI, identifiability), so ForwardDiff is exact.
+            tvec = collect(Float64, θti)
+            J = spec.lie === nothing ?
+                ForwardDiff.jacobian(liepsd_inverse, tvec) :
+                ForwardDiff.jacobian(t -> _liepsd_inverse_layout(t, spec.lie), tvec)
+            return J' * vec(collect(Float64, gu))
         else
             return gu
         end
@@ -659,6 +922,9 @@ function _transform_vals(
             return _stickbreakrow_forward(val)
         elseif spec.kind == :lograterows
             return lograterows_forward(val)
+        elseif spec.kind == :lie
+            return spec.lie === nothing ? liepsd_forward(val) :
+                   _liepsd_forward_layout(val, spec.lie)
         else
             return val
         end
@@ -693,6 +959,9 @@ function _inverse_vals(
         elseif spec.kind == :lograterows
             n = spec.size[1]
             return lograterows_inverse(val, n)
+        elseif spec.kind == :lie
+            return spec.lie === nothing ? liepsd_inverse(val) :
+                   _liepsd_inverse_layout(val, spec.lie)
         else
             return val
         end

--- a/test/enzyme_compat_proxy_tests.jl
+++ b/test/enzyme_compat_proxy_tests.jl
@@ -55,6 +55,7 @@ end
             lower = [-Inf, 1e-12], upper = [Inf, Inf])
         Ω = RealPSDMatrix([1.0 0.2; 0.2 1.0], scale = :cholesky)
         E = RealPSDMatrix([1.5 0.1; 0.1 0.8], scale = :expm)
+        G = RealLiePSDMatrix([1.5 0.1; 0.1 0.8])
         p = ProbabilityVector([0.2, 0.3, 0.5])
         P = DiscreteTransitionMatrix([0.9 0.1; 0.2 0.8])
     end

--- a/test/lie_psd_matrix_tests.jl
+++ b/test/lie_psd_matrix_tests.jl
@@ -1,0 +1,391 @@
+using Test
+using NoLimits
+using ComponentArrays
+using LinearAlgebra
+using Distributions
+using ForwardDiff
+using Random
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+function _rand_spd(n, rng)
+    M = randn(rng, n, n)
+    return Matrix(Symmetric(M * M' + 0.5I))
+end
+
+# ---------------------------------------------------------------------------
+# 1. Constructor tests
+# ---------------------------------------------------------------------------
+@testset "RealLiePSDMatrix construction" begin
+    @testset "from full matrix" begin
+        Σ = [4.0 -1.3; -1.3 1.75]
+        p = RealLiePSDMatrix(Σ; name = :Ω, eigenvalue_lower = 1e-3,
+            eigenvalue_upper = 1e3, calculate_se = true)
+        @test p.name == :Ω
+        @test p.scale == :lie
+        @test p.prior isa Priorless
+        @test p.calculate_se == true
+        @test p.value == Σ
+        @test p.eigenvalue_lower == [1e-3, 1e-3]
+        @test p.eigenvalue_upper == [1e3, 1e3]
+    end
+
+    @testset "scalar bounds broadcast; vector bounds honored" begin
+        p1 = RealLiePSDMatrix([2.0 0.0; 0.0 3.0]; eigenvalue_lower = 0.1)
+        @test p1.eigenvalue_lower == [0.1, 0.1]
+        @test p1.eigenvalue_upper == [Inf, Inf]
+        p2 = RealLiePSDMatrix([2.0 0.0; 0.0 3.0]; eigenvalue_lower = [0.1, 0.2],
+            eigenvalue_upper = [10.0, 20.0])
+        @test p2.eigenvalue_lower == [0.1, 0.2]
+        @test p2.eigenvalue_upper == [10.0, 20.0]
+    end
+
+    @testset "from (log_eigenvalues, angles)" begin
+        p = RealLiePSDMatrix(; log_eigenvalues = [0.0, 0.7], angles = [0.3], name = :Ω)
+        @test size(p.value) == (2, 2)
+        @test issymmetric(p.value)
+        @test minimum(eigen(Symmetric(p.value)).values) > 0
+        # Recovering (λ, α) and re-expanding reproduces the same matrix.
+        t = liepsd_forward(p.value)
+        @test isapprox(liepsd_inverse(t), p.value; atol = 1e-10)
+    end
+
+    @testset "n = 1 edge (no angles)" begin
+        p = RealLiePSDMatrix(reshape([2.5], 1, 1))
+        @test size(p.value) == (1, 1)
+        p2 = RealLiePSDMatrix(; log_eigenvalues = [log(2.5)], angles = Float64[])
+        @test isapprox(p2.value[1, 1], 2.5; atol = 1e-12)
+    end
+
+    @testset "invalid inputs error" begin
+        @test_throws ErrorException RealLiePSDMatrix([1.0 2.0; 0.0 1.0])   # not PSD
+        @test_throws ErrorException RealLiePSDMatrix([1.0 0.0 0.0; 0.0 1.0 0.0])  # non-square
+        @test_throws ErrorException RealLiePSDMatrix([1.0 0.0; 0.0 1.0];
+            scale = :cholesky)                                            # wrong scale
+        @test_throws ErrorException RealLiePSDMatrix([1.0 0.0; 0.0 1.0];
+            eigenvalue_lower = -1.0)                                      # negative lower
+        @test_throws ErrorException RealLiePSDMatrix([1.0 0.0; 0.0 1.0];
+            eigenvalue_lower = 5.0, eigenvalue_upper = 1.0)               # lower > upper
+        @test_throws ErrorException RealLiePSDMatrix(; log_eigenvalues = [0.0, 0.0],
+            angles = [0.1, 0.2])                                         # wrong angle count
+    end
+end
+
+# ---------------------------------------------------------------------------
+# 2. Transform round-trip: liepsd_inverse ∘ liepsd_forward ≈ id
+# ---------------------------------------------------------------------------
+@testset "RealLiePSDMatrix transform round-trip" begin
+    rng = MersenneTwister(20200525)
+
+    @testset "diagonal (α = 0)" begin
+        Σ = [2.0 0.0; 0.0 3.0]
+        t = liepsd_forward(Σ)
+        @test t[3] == 0.0                       # single angle is zero
+        @test isapprox(t[1:2], log.([2.0, 3.0]); atol = 1e-14)
+        @test isapprox(liepsd_inverse(t), Σ; atol = 1e-14)
+    end
+
+    @testset "thesis example (Fig. 5.6)" begin
+        Σ = [3.25 -1.30; -1.30 1.75]
+        t = liepsd_forward(Σ)
+        @test isapprox(liepsd_inverse(t), Σ; atol = 1e-12)
+        # Eigenvalues are ≈ 1 and 4 (thesis Fig. 5.6 rounds them), so λ ≈ log([1, 4]).
+        @test isapprox(sort(exp.(t[1:2])), sort(eigen(Symmetric(Σ)).values); atol = 1e-10)
+        @test isapprox(sort(exp.(t[1:2])), [1.0, 4.0]; atol = 1e-2)
+    end
+
+    @testset "random SPD, n = 2..5 (non-diagonal, det-fix branch)" begin
+        for n in 2:5
+            for _ in 1:5
+                Σ = _rand_spd(n, rng)
+                t = liepsd_forward(Σ)
+                @test length(t) == n * (n + 1) ÷ 2
+                @test isapprox(liepsd_inverse(t), Σ; atol = 1e-8)
+                @test issymmetric(liepsd_inverse(t))
+            end
+        end
+    end
+end
+
+# ---------------------------------------------------------------------------
+# 3. ForwardDiff through the inverse map (incl. repeated eigenvalues at Λ = I)
+# ---------------------------------------------------------------------------
+@testset "RealLiePSDMatrix ForwardDiff correctness" begin
+    rng = MersenneTwister(1)
+    n = 3
+    L = n * (n + 1) ÷ 2
+
+    @testset "gradient finite & matches finite differences" begin
+        for _ in 1:3
+            t0 = vcat(0.5 .* randn(rng, n), 0.4 .* randn(rng, n * (n - 1) ÷ 2))
+            W = Symmetric(randn(rng, n, n)) |> Matrix
+            f = t -> sum(liepsd_inverse(t) .* W)
+            g = ForwardDiff.gradient(f, t0)
+            @test all(isfinite, g)
+            gfd = similar(g)
+            ε = 1e-6
+            for k in 1:L
+                tp = copy(t0)
+                tp[k] += ε
+                tm = copy(t0)
+                tm[k] -= ε
+                gfd[k] = (f(tp) - f(tm)) / (2ε)
+            end
+            @test isapprox(g, gfd; atol = 1e-6)
+        end
+    end
+
+    @testset "finite & symmetric at Λ = I (repeated eigenvalues)" begin
+        t0 = vcat(zeros(n), 0.3 .* randn(rng, n * (n - 1) ÷ 2))
+        J = ForwardDiff.jacobian(liepsd_inverse, t0)
+        @test all(isfinite, J)
+        # Dual output must be exactly symmetric in value and partials.
+        td = [ForwardDiff.Dual{:t}(t0[i], ntuple(k -> k == i ? 1.0 : 0.0, L)...)
+              for i in 1:L]
+        Σd = liepsd_inverse(td)
+        for i in 1:n, j in 1:n
+            @test ForwardDiff.value(Σd[i, j]) == ForwardDiff.value(Σd[j, i])
+            @test ForwardDiff.partials(Σd[i, j]) == ForwardDiff.partials(Σd[j, i])
+        end
+    end
+end
+
+# ---------------------------------------------------------------------------
+# 4. Jacobianᵀ (`_inv_jac_spec_val`) matches the transform Jacobian
+# ---------------------------------------------------------------------------
+@testset "RealLiePSDMatrix Jacobianᵀ" begin
+    using NoLimits: _inv_jac_spec_val, TransformSpec
+    rng = MersenneTwister(7)
+    n = 3
+    spec = TransformSpec(:Ω, :lie, (n, n), nothing)
+    for _ in 1:4
+        t = vcat(0.5 .* randn(rng, n), 0.4 .* randn(rng, n * (n - 1) ÷ 2))
+        G = randn(rng, n, n)                       # raw natural gradient (any G)
+        gt = _inv_jac_spec_val(spec, t, G)
+        J = ForwardDiff.jacobian(liepsd_inverse, collect(t))
+        @test isapprox(gt, J' * vec(G); atol = 1e-9)
+    end
+end
+
+# ---------------------------------------------------------------------------
+# 5. @fixedEffects integration: spec, bounds, flat names
+# ---------------------------------------------------------------------------
+@testset "RealLiePSDMatrix @fixedEffects integration" begin
+    fe = @fixedEffects begin
+        Ω = RealLiePSDMatrix([1.0 0.0; 0.0 1.0]; eigenvalue_lower = 1e-3,
+            eigenvalue_upper = 1e3, calculate_se = true)
+    end
+
+    specs = get_transforms(fe).forward.specs
+    @test specs[1].kind == :lie
+    @test specs[1].size == (2, 2)
+
+    # Identity matrix → log-eigenvalues 0, angle 0.
+    θ0t = get_θ0_transformed(fe)
+    @test isapprox(collect(θ0t[:Ω]), [0.0, 0.0, 0.0]; atol = 1e-14)
+
+    # Untransformed round-trip is the identity matrix.
+    θ0u = get_θ0_untransformed(fe)
+    @test isapprox(Matrix(θ0u[:Ω]), [1.0 0.0; 0.0 1.0]; atol = 1e-14)
+
+    # Transformed bounds: eigenvalue box on the λ block, unbounded α.
+    lo, up = get_bounds_transformed(fe)
+    @test isapprox(collect(lo[:Ω]), [log(1e-3), log(1e-3), -Inf]; atol = 1e-12)
+    @test isapprox(collect(up[:Ω]), [log(1e3), log(1e3), Inf]; atol = 1e-12)
+
+    # SE mask covers all n(n+1)/2 transformed entries.
+    @test count(get_se_mask(fe)) == 3
+end
+
+# ---------------------------------------------------------------------------
+# 6. UQ natural-scale coordinates (upper triangle, same count as transformed)
+# ---------------------------------------------------------------------------
+@testset "RealLiePSDMatrix UQ coords (natural scale)" begin
+    using NoLimits: _coords_for_param
+
+    fe = @fixedEffects begin
+        Ω = RealLiePSDMatrix([2.0 0.5; 0.5 1.0]; calculate_se = true)
+    end
+    θ0u = get_θ0_untransformed(fe)
+    spec = get_transforms(fe).forward.specs[1]
+
+    coords_nat = _coords_for_param(Matrix(θ0u[:Ω]), spec; natural = true)
+    @test length(coords_nat) == 3               # upper triangle of a 2×2
+    @test isapprox(coords_nat, [2.0, 0.5, 1.0]; atol = 1e-12)
+
+    # Count matches transformed coords (Wald delta-method stays square).
+    θ0t = get_θ0_transformed(fe)
+    coords_trans = _coords_for_param(collect(θ0t[:Ω]), spec; natural = false)
+    @test length(coords_trans) == length(coords_nat)
+end
+
+# ---------------------------------------------------------------------------
+# 6b. Structured covariances: block-diagonal + fixed eigenvalues
+# ---------------------------------------------------------------------------
+@testset "RealLiePSDMatrix block-diagonal structure" begin
+    using NoLimits: _inv_jac_spec_val
+
+    Σ0 = [2.0 0.5 0.0; 0.5 1.0 0.0; 0.0 0.0 3.0]
+
+    @testset "construction validates block-diagonal input" begin
+        @test_throws ErrorException RealLiePSDMatrix(
+            [2.0 0.5 0.1; 0.5 1.0 0.0;
+             0.1 0.0 3.0]; blocks = [1, 1, 2])           # nonzero cross-block entry
+        @test_throws ErrorException RealLiePSDMatrix(Σ0; blocks = [1, 1])   # wrong length
+        p = RealLiePSDMatrix(Σ0; blocks = [1, 1, 2])
+        @test p.blocks == [1, 1, 2]
+    end
+
+    fe = @fixedEffects begin
+        Ω = RealLiePSDMatrix([2.0 0.5 0.0; 0.5 1.0 0.0; 0.0 0.0 3.0];
+            blocks = [1, 1, 2], eigenvalue_lower = 1e-3, eigenvalue_upper = 1e3,
+            calculate_se = true)
+    end
+    θ0t = get_θ0_transformed(fe)
+    θ0u = get_θ0_untransformed(fe)
+    spec = get_transforms(fe).forward.specs[1]
+
+    @testset "drops cross-block coefficients from the optimizer" begin
+        # 3×3 full = 6 params; block-diag [1,1,2] drops the 2 cross-block angles → 4 free.
+        @test length(θ0t.Ω) == 4
+        @test spec.lie !== nothing
+        @test spec.lie.fixed_idx == [5, 6]           # cross-block angle positions
+        @test spec.lie.fixed_val == [0.0, 0.0]
+        @test isapprox(Matrix(θ0u.Ω), Σ0; atol = 1e-10)
+    end
+
+    @testset "block-diagonal structure preserved under any free params" begin
+        it = get_inverse_transform(fe)
+        rng = MersenneTwister(3)
+        for _ in 1:5
+            tp = copy(θ0t)
+            tp.Ω .= θ0t.Ω .+ 0.8 .* randn(rng, 4)
+            Σp = Matrix(it(tp).Ω)
+            @test abs(Σp[1, 3]) < 1e-12
+            @test abs(Σp[2, 3]) < 1e-12
+            @test minimum(eigen(Symmetric(Σp)).values) > 0
+        end
+    end
+
+    @testset "Jacobianᵀ matches structured inverse Jacobian" begin
+        rng = MersenneTwister(9)
+        for _ in 1:3
+            t = θ0t.Ω .+ 0.5 .* randn(rng, 4)
+            G = randn(rng, 3, 3)
+            gt = _inv_jac_spec_val(spec, collect(t), G)
+            J = ForwardDiff.jacobian(
+                x -> NoLimits._liepsd_inverse_layout(x, spec.lie), collect(t))
+            @test isapprox(gt, J' * vec(G); atol = 1e-9)
+        end
+    end
+
+    @testset "UQ natural-coord count equals transformed count" begin
+        using NoLimits: _coords_for_param
+        coords_t = _coords_for_param(collect(θ0t.Ω), spec; natural = false)
+        coords_n = _coords_for_param(Matrix(θ0u.Ω), spec; natural = true)
+        @test length(coords_t) == 4
+        @test length(coords_n) == 4
+    end
+end
+
+@testset "RealLiePSDMatrix fixed eigenvalues" begin
+    fe = @fixedEffects begin
+        Ω = RealLiePSDMatrix([2.0 0.0; 0.0 3.0]; fix_eigenvalues = [1],
+            calculate_se = true)
+    end
+    θ0t = get_θ0_transformed(fe)
+    spec = get_transforms(fe).forward.specs[1]
+    @test length(θ0t.Ω) == 2                         # 3 full − 1 fixed eigenvalue
+    @test spec.lie.fixed_idx == [1]
+    @test isapprox(spec.lie.fixed_val, [log(2.0)]; atol = 1e-12)
+
+    it = get_inverse_transform(fe)
+    tp = copy(θ0t)
+    tp.Ω .= θ0t.Ω .+ [0.4, 0.3]
+    Σp = Matrix(it(tp).Ω)
+    # The fixed eigenvalue stays pinned at 2.0 regardless of the free params.
+    @test minimum(abs.(sort(eigen(Symmetric(Σp)).values) .- 2.0)) < 1e-10
+end
+
+# ---------------------------------------------------------------------------
+# 7. Model integration + end-to-end estimation (RE covariance)
+# ---------------------------------------------------------------------------
+@testset "RealLiePSDMatrix as random-effect covariance" begin
+    using DataFrames
+
+    model = @Model begin
+        @fixedEffects begin
+            a = RealNumber(1.0)
+            σ = RealNumber(0.5, scale = :log)
+            Ω = RealLiePSDMatrix([1.0 0.0; 0.0 1.0]; eigenvalue_lower = 1e-3,
+                eigenvalue_upper = 1e3)
+        end
+        @randomEffects begin
+            η = RandomEffect(MvNormal(zeros(2), Ω); column = :ID)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @formulas begin
+            y ~ Normal(a + η[1] + η[2] * t, σ)
+        end
+    end
+
+    rng = MersenneTwister(2020)
+    ids = repeat(1:12, inner = 4)
+    tt = repeat([0.0, 1.0, 2.0, 3.0], 12)
+    y = 1.0 .+ 0.2 .* tt .+ 0.3 .* randn(rng, length(ids))
+    df = DataFrame(ID = ids, t = tt, y = y)
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+
+    res_lap = fit_model(dm, NoLimits.Laplace())
+    @test NoLimits.get_converged(res_lap)
+    Ω_est = NoLimits.get_params(res_lap; scale = :untransformed).Ω
+    @test issymmetric(Matrix(Ω_est))
+    @test minimum(eigen(Symmetric(Matrix(Ω_est))).values) > 0
+
+    # FOCEI exercises the analytic Jacobianᵀ path and should agree with Laplace.
+    res_foc = fit_model(dm, NoLimits.FOCEI())
+    @test NoLimits.get_converged(res_foc)
+    @test isapprox(NoLimits.get_objective(res_lap), NoLimits.get_objective(res_foc);
+        atol = 1e-2)
+end
+
+@testset "RealLiePSDMatrix block-diagonal RE covariance end-to-end" begin
+    using DataFrames
+
+    # Three random effects; a block-diagonal covariance couples RE 1&2 but not RE 3.
+    model = @Model begin
+        @fixedEffects begin
+            a = RealNumber(1.0)
+            σ = RealNumber(0.5, scale = :log)
+            Ω = RealLiePSDMatrix(Matrix{Float64}(I, 3, 3); blocks = [1, 1, 2],
+                eigenvalue_lower = 1e-3, eigenvalue_upper = 1e3)
+        end
+        @randomEffects begin
+            η = RandomEffect(MvNormal(zeros(3), Ω); column = :ID)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @formulas begin
+            y ~ Normal(a + η[1] + η[2] * t + η[3] * t^2, σ)
+        end
+    end
+
+    rng = MersenneTwister(11)
+    ids = repeat(1:15, inner = 4)
+    tt = repeat([0.0, 1.0, 2.0, 3.0], 15)
+    y = 1.0 .+ 0.2 .* tt .+ 0.3 .* randn(rng, length(ids))
+    df = DataFrame(ID = ids, t = tt, y = y)
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+
+    res = fit_model(dm, NoLimits.Laplace())
+    @test NoLimits.get_converged(res)
+    Ω_est = Matrix(NoLimits.get_params(res; scale = :untransformed).Ω)
+    # The estimated covariance must retain the enforced block-diagonal zeros.
+    @test abs(Ω_est[1, 3]) < 1e-8
+    @test abs(Ω_est[2, 3]) < 1e-8
+    @test minimum(eigen(Symmetric(Ω_est)).values) > 0
+end

--- a/test/parameters_tests.jl
+++ b/test/parameters_tests.jl
@@ -47,6 +47,15 @@ using Turing: Flat
     @test_throws ErrorException RealPSDMatrix(
         [1.0 0.0; 0.0 1.0]; name = :bad_psd_scale, scale = :foo)
 
+    lie = RealLiePSDMatrix([2.0 0.5; 0.5 1.0]; name = :Ωlie, eigenvalue_lower = 1e-3,
+        eigenvalue_upper = 1e3)
+    @test lie.value == [2.0 0.5; 0.5 1.0]
+    @test lie.scale == :lie
+    @test lie.eigenvalue_lower == [1e-3, 1e-3]
+    @test_throws ErrorException RealLiePSDMatrix([1.0 2.0; 3.0 4.0]; name = :bad_lie)
+    @test_throws ErrorException RealLiePSDMatrix(
+        [1.0 0.0; 0.0 1.0]; name = :bad_lie_scale, scale = :cholesky)
+
     d = RealDiagonalMatrix([1, 2, 3]; name = :d)
     @test d.value == [1.0, 2.0, 3.0]
     @test_throws ErrorException RealDiagonalMatrix([1.0, -2.0]; name = :badd)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,6 +117,7 @@ const TEST_FILES = [
     "stickbreak_uq_natural_extension_tests.jl",
     "ad_stickbreak_hmm.jl",
     "continuous_transition_matrix_tests.jl",
+    "lie_psd_matrix_tests.jl",
     # Enzyme regression tests (merged from enzyme-compat). proxy = always-on,
     # ForwardDiff-only structural/numeric invariants; smoke = opt-in real Enzyme
     # gradients, no-op unless NOLIMITS_TEST_ENZYME=true (+ Julia>=1.12.5 + Enzyme).

--- a/test/transform_tests.jl
+++ b/test/transform_tests.jl
@@ -40,6 +40,17 @@ using Distributions
     @test isapprox(Erec, Aexp; rtol = 1e-8, atol = 1e-8)
     @test length(θEt.E) == 3
 
+    # Lie-algebraic transform round-trip on a PSD matrix block.
+    Alie = [3.25 -1.30; -1.30 1.75]
+    θL = ComponentArray((L = Alie,))
+    specsL = [TransformSpec(:L, :lie, (2, 2), nothing)]
+    ftL = ForwardTransform([:L], specsL)
+    itL = InverseTransform([:L], specsL)
+    θLt = ftL(θL)
+    Lrec = itL(θLt).L
+    @test isapprox(Lrec, Alie; rtol = 1e-8, atol = 1e-8)
+    @test length(θLt.L) == 3
+
     # AD check for log transform (ForwardDiff).
     f_log(x) = log_forward(x)
     @test isapprox(ForwardDiff.derivative(f_log, 2.0), 1 / 2.0; rtol = 1e-8, atol = 1e-10)

--- a/test/uq_tests.jl
+++ b/test/uq_tests.jl
@@ -221,6 +221,24 @@ end
 end
 
 function _uq_psd_re_model(scale::Symbol)
+    if scale === :lie
+        return @Model begin
+            @covariates begin
+                t = Covariate()
+            end
+            @fixedEffects begin
+                a = RealNumber(0.2, calculate_se = false)
+                σ = RealNumber(0.5, scale = :log, calculate_se = false)
+                Ω = RealLiePSDMatrix(Matrix{Float64}(I, 2, 2); calculate_se = true)
+            end
+            @randomEffects begin
+                η = RandomEffect(MvNormal([0.0, 0.0], Ω); column = :ID)
+            end
+            @formulas begin
+                y ~ Normal(a + η[1], σ)
+            end
+        end
+    end
     return @Model begin
         @covariates begin
             t = Covariate()
@@ -247,8 +265,8 @@ function _uq_psd_re_df()
     )
 end
 
-@testset "UQ Wald for Laplace with PSD fixed covariance (cholesky/expm)" begin
-    for (scale, n_coords, seed) in ((:cholesky, 4, 31), (:expm, 3, 32))
+@testset "UQ Wald for Laplace with PSD fixed covariance (cholesky/expm/lie)" begin
+    for (scale, n_coords, seed) in ((:cholesky, 4, 31), (:expm, 3, 32), (:lie, 3, 33))
         model = _uq_psd_re_model(scale)
         dm = DataModel(model, _uq_psd_re_df(); primary_id = :ID, time_col = :t)
         # The default outer optimizer (NLopt.LN_BOBYQA) is derivative-free and


### PR DESCRIPTION
## Summary

Adds `RealLiePSDMatrix`, the Lie-algebraic parameterization of symmetric positive-definite matrices from Paul Stapor's PhD thesis (TUM 2020, §5.3, Eq. 5.14):

Σ = exp(A) · diag(exp λ) · exp(A)ᵀ,  A antisymmetric

with log-eigenvalues `λ` and rotation coefficients that build `A`. Unlike the existing `RealPSDMatrix` (`:cholesky` / `:expm`), the eigenvalues are exposed directly, which is what enables the features below.

## Why a new type

`:cholesky` and `:expm` bundle the whole matrix into one object and cannot bound the spectrum. Exposing the eigenvalues lets `RealLiePSDMatrix` support:

- **Eigenvalue box bounds** (`eigenvalue_lower` / `eigenvalue_upper`) — keeps Σ well-conditioned at optimization start points, reducing ODE-integration failure when Σ parameterizes a random-effect covariance (the thesis's motivating result).
- **Block-diagonal structure** (`blocks`) — fixes cross-block rotation coefficients to zero and drops them from the optimizer, enforcing structure without constrained optimization.
- **Fixed eigenvalues** (`fix_eigenvalues`) — pins individual eigenvalues and removes them from the optimizer.

## What's included

- New `:lie` scale (`LIE_PSD_SCALES`) and the `RealLiePSDMatrix` block, with a full-matrix constructor and a direct `(log_eigenvalues, angles)` constructor.
- `liepsd_forward` / `liepsd_inverse` with a `ForwardDiff.Dual` specialization (the generic matrix exponential has no `Dual` method on Julia 1.12; partials come from the Fréchet derivative, mirroring the existing `:expm` treatment). Block-diagonal matrices are recovered block-wise so cross-block angles are exactly zero.
- A structured layout (`LiePSDLayout`) threaded through the transform, bounds, flat-name, SE-mask, Jacobianᵀ, and Wald / MCMC UQ coordinate paths.
- Docs: parameter-type table entry, `:lie` scale description, and a concise **"Choosing a Covariance Parameterization"** recommendation section.

## Testing

- New `test/lie_psd_matrix_tests.jl` covering construction/validation, transform round-trips, ForwardDiff correctness at repeated eigenvalues, the analytic Jacobianᵀ, eigenvalue-bound mapping, block-diagonal and fixed-eigenvalue structure, and end-to-end Laplace/FOCEI fits with a Lie random-effect covariance.
- Additions to the parameters, transform, fixed-effects, UQ, and Enzyme-proxy suites.
- Aqua (zero ambiguities, exports reachable) and JuliaFormatter v1 (sciml) clean.

## Recommendation (in the docs)

Default to `RealPSDMatrix(:cholesky)` for ordinary covariances; reach for `RealLiePSDMatrix` specifically when you need eigenvalue bounds (ODE robustness) or block-diagonal structure. A standalone benchmark confirmed that full-matrix `:lie` costs more and conditions worse than Cholesky, while block-`:lie` is decisively more efficient on structured problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)