### PR TITLE
Fix extra_objective for SAEM/MCEM RE-variance and MCMC/VI

### DIFF
--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -1675,13 +1675,17 @@ Fit a model to data using the specified estimation method.
   natural scale. Fixed parameters are removed from the optimizer state.
 - `penalty::NamedTuple = NamedTuple()`: add per-parameter quadratic penalties on the
   natural scale (not available for MCMC).
-- `extra_objective = nothing`: optional user-supplied objective term `θu -> Real`, a
-  function of the natural-scale parameters, added to the negative log-likelihood (and,
-  for gradient-based methods, differentiated via ForwardDiff). Behaves exactly like
-  `penalty`: a no-op when `nothing` (default), so existing fits are unaffected, and
-  honored by the same methods as `penalty` — `MLE`, `MAP`, `Laplace`, `FOCEI`,
-  `SAEM`, `MCEM`, `GHQuadrature`, `Pooled`, `PooledMap` (not `MCMC`/`VI`, which use
-  priors). Intended for adding likelihood terms that depend only on the population
+- `extra_objective = nothing`: optional user-supplied term `θu -> Real`, a function of
+  the natural-scale parameters, expressing extra log-likelihood contributions as a
+  *cost* — added to the negative log-likelihood (and, for gradient-based methods,
+  differentiated via ForwardDiff). A no-op when `nothing` (default), so existing fits
+  are unaffected. Honored by every estimator: the optimization methods (`MLE`, `MAP`,
+  `Laplace`, `FOCEI`, `GHQuadrature`, `SAEM`, `MCEM`, `Pooled`, `PooledMap`) add it to
+  the objective, and `MCMC`/`VI` add it to the Turing target via `@addlogprob!` as
+  `-extra_objective` (i.e. a log-likelihood contribution on the natural scale). Under
+  `SAEM`/`MCEM` the presence of `extra_objective` switches the RE-variance M-step from
+  the closed-form/Q2 path to a single joint numeric M-step so the term also informs the
+  RE covariance `D`. Intended for likelihood terms that depend only on the population
   parameters (β and the RE covariance D), e.g. population-average or
   single-cell-snapshot contributions.
 - `ode_args::Tuple = ()`: extra positional arguments forwarded to the ODE solver.

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -1251,8 +1251,14 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
     T0 = eltype(θt_free)
 
     # Detect Q2-only free parameters (appear only in RE distributions, never in obs-side blocks).
-    q2_base_free_names = let p = _partition_q1_q2_names(dm.model, free_names)
-        p.q2
+    # With extra_objective the objective is non-separable in (β,σ) vs D, so route the whole Q2
+    # set into the joint Q1 M-step (exact joint maximizer of Q + extra).
+    q2_base_free_names = if extra_objective === nothing
+        let p = _partition_q1_q2_names(dm.model, free_names)
+            p.q2
+        end
+    else
+        Symbol[]
     end
 
     diag = _MCEMDiagnostics{T0}(Vector{AbstractVector{T0}}(),

--- a/src/estimation/mcmc_turing.jl
+++ b/src/estimation/mcmc_turing.jl
@@ -125,13 +125,19 @@ function _build_turing_model(fixed_names::Vector{Symbol}, free_names::Vector{Sym
         Expr(:tuple, val_exprs...))
     θ_expr = :(ComponentArray($nt_expr))
     ex = quote
-        @model function $(fname)(dm, cache, serialization, priors, constants)
+        @model function $(fname)(
+                dm, cache, serialization, priors, constants, extra_objective)
             $(assigns...)
             θ = $θ_expr
             θ_re = _symmetrize_psd_params(θ, dm.model.fixed.fixed)
             ll = loglikelihood(
                 dm, θ_re, ComponentArray(); cache = cache, serialization = serialization)
             Turing.@addlogprob! ll
+            # extra_objective is a negative-log-likelihood cost (-J); @addlogprob! adds a
+            # log-density, so add +J = -extra_objective(θ_re) (θ_re is natural-scale).
+            if extra_objective !== nothing
+                Turing.@addlogprob! -extra_objective(θ_re)
+            end
         end
     end
     Core.eval(@__MODULE__, ex)
@@ -225,7 +231,7 @@ function _build_turing_model_re(
 
     ex = quote
         @model function $(fname)(dm, cache, serialization, priors, constants, re_names,
-                re_meta, fixed_maps, const_covs, const_re_info)
+                re_meta, fixed_maps, const_covs, const_re_info, extra_objective)
             $(assigns...)
             θ = $θ_expr
             θ_re = _symmetrize_psd_params(θ, dm.model.fixed.fixed)
@@ -319,6 +325,11 @@ function _build_turing_model_re(
             ll = loglikelihood(
                 dm, θ_re, η_vec; cache = cache, serialization = serialization)
             Turing.@addlogprob! ll
+            # extra_objective is a negative-log-likelihood cost (-J); @addlogprob! adds a
+            # log-density, so add +J = -extra_objective(θ_re) (θ_re is natural-scale).
+            if extra_objective !== nothing
+                Turing.@addlogprob! -extra_objective(θ_re)
+            end
         end
     end
     Core.eval(@__MODULE__, ex)
@@ -344,6 +355,7 @@ function _fit_model(dm::DataModel, method::MCMC, args...;
         serialization::SciMLBase.EnsembleAlgorithm = EnsembleThreads(),
         rng::AbstractRNG = Random.default_rng(),
         theta_0_untransformed::Union{Nothing, ComponentArray} = nothing,
+        extra_objective = nothing,
         store_data_model::Bool = true)
     fit_kwargs = (constants = constants,
         constants_re = constants_re,
@@ -393,7 +405,8 @@ function _fit_model(dm::DataModel, method::MCMC, args...;
     if isempty(re_names)
         fname = _build_turing_model(fixed_names, free_names)
         model_fn = Base.invokelatest(getfield, @__MODULE__, fname)
-        model = Base.invokelatest(model_fn, dm, cache, serialization, priors_nt, constants)
+        model = Base.invokelatest(
+            model_fn, dm, cache, serialization, priors_nt, constants, extra_objective)
     else
         fixed_maps = _normalize_constants_re(dm, constants_re)
         # Validate constants_re shape and dimensions before launching Turing.
@@ -457,7 +470,7 @@ function _fit_model(dm::DataModel, method::MCMC, args...;
         fname = _build_turing_model_re(fixed_names, free_names, re_names)
         model_fn = Base.invokelatest(getfield, @__MODULE__, fname)
         model = Base.invokelatest(model_fn, dm, cache, serialization, priors_nt, constants,
-            re_names, re_meta, fixed_maps, const_covs, const_re_info)
+            re_names, re_meta, fixed_maps, const_covs, const_re_info, extra_objective)
     end
     model = _invokelatest_model(model)
     sampler = method.sampler

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -2837,12 +2837,32 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
             builtin_stats_mode = :none
         end
     end
+    # `extra_objective` couples β and D through the ODE ensemble moments, so the M-step
+    # objective is no longer separable and the closed-form covariance/Q2 split is no longer
+    # exact. Disable the builtin closed-form updates so ω/σ are optimized numerically in the
+    # single joint Q1 M-step (which already adds `extra_objective`).
+    if extra_objective !== nothing
+        if builtin_stats_mode != :none
+            @info "SAEM: extra_objective present — disabling closed-form M-step; all free parameters (means, σ, ω) optimized numerically in the joint M-step."
+            builtin_stats_mode = :none
+        end
+        re_cov_params = NamedTuple()
+        re_mean_params = NamedTuple()
+        resid_var_param = NamedTuple()
+        hmm_emission_params = NamedTuple()
+    end
     has_custom_closed_form = method.saem.suffstats !== nothing &&
                              method.saem.mstep_closed_form !== nothing
     # Detect Q2-only free parameters (appear only in RE distributions, never in obs-side blocks).
     # These are optimized in a cheap separate M-step that skips ODE evaluation entirely.
-    q2_base_free_names = let p = _partition_q1_q2_names(dm.model, base_free_names)
-        p.q2
+    q2_base_free_names = if extra_objective === nothing
+        let p = _partition_q1_q2_names(dm.model, base_free_names)
+            p.q2
+        end
+    else
+        # With extra_objective the objective is non-separable in (β,σ) vs D, so route the
+        # whole Q2 set into the joint Q1 M-step (exact joint maximizer of Q + extra).
+        Symbol[]
     end
     _saem_log_closed_form_plan(
         method.saem.builtin_stats, builtin_stats_mode, builtin_cf_elig,

--- a/src/estimation/vi_turing.jl
+++ b/src/estimation/vi_turing.jl
@@ -186,6 +186,7 @@ function _fit_model(dm::DataModel, method::VI, args...;
         serialization::SciMLBase.EnsembleAlgorithm = EnsembleThreads(),
         rng::AbstractRNG = Random.default_rng(),
         theta_0_untransformed::Union{Nothing, ComponentArray} = nothing,
+        extra_objective = nothing,
         store_data_model::Bool = true)
     fit_kwargs = (constants = constants,
         constants_re = constants_re,
@@ -240,7 +241,8 @@ function _fit_model(dm::DataModel, method::VI, args...;
     priors_nt = NamedTuple{free_names_t}(Tuple(getfield(priors, n) for n in free_names))
     fname = _build_turing_model(fixed_names, free_names)
     model_fn = Base.invokelatest(getfield, @__MODULE__, fname)
-    model = Base.invokelatest(model_fn, dm, cache, serialization, priors_nt, constants)
+    model = Base.invokelatest(
+        model_fn, dm, cache, serialization, priors_nt, constants, extra_objective)
     model = _invokelatest_model(model)
 
     max_iter = Int(get(method.turing_kwargs, :max_iter, 1000))

--- a/test/extra_objective_tests.jl
+++ b/test/extra_objective_tests.jl
@@ -1,0 +1,171 @@
+using Test
+using NoLimits
+using DataFrames
+using Distributions
+using ComponentArrays
+using ForwardDiff
+using Random
+using Turing
+using MCMCChains
+using SciMLBase
+
+# `extra_objective` is a user cost `θu -> Real` added to the negative log-likelihood.
+# These tests pin the two fixes:
+#   - SAEM/MCEM must fold a variance-only extra term into the RE covariance (ω), not drop it.
+#   - MCMC/VI must accept extra_objective and add it to the target (via @addlogprob!).
+# The `extra_objective === nothing` path must stay a no-op.
+
+# RE model where ω appears ONLY in the RE distribution (a Q2/closed-form param).
+function _eo_re_model()
+    return @Model begin
+        @fixedEffects begin
+            a = RealNumber(0.5)
+            σ = RealNumber(0.5, scale = :log, lower = 1e-8, upper = Inf)
+            ω = RealNumber(0.6, scale = :log, lower = 1e-8, upper = Inf)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η = RandomEffect(Normal(0.0, ω); column = :ID)
+        end
+        @formulas begin
+            y ~ Normal(a + η, σ)
+        end
+    end
+end
+
+# Data with a_true = 2.0, σ_true = 0.3, ω_true = 1.0.
+function _eo_re_data(; n_id = 30, n_obs = 3, seed = 20260708)
+    rng = MersenneTwister(seed)
+    a_true, σ_true, ω_true = 2.0, 0.3, 1.0
+    ids = Int[]
+    ts = Float64[]
+    ys = Float64[]
+    for i in 1:n_id
+        ηi = ω_true * randn(rng)
+        for j in 1:n_obs
+            push!(ids, i)
+            push!(ts, float(j))
+            push!(ys, a_true + ηi + σ_true * randn(rng))
+        end
+    end
+    return DataFrame(ID = ids, t = ts, y = ys)
+end
+
+_eo_re_dm() = DataModel(_eo_re_model(), _eo_re_data(); primary_id = :ID, time_col = :t)
+
+_ω(res) = NoLimits.get_params(res; scale = :untransformed).ω
+
+# variance-only cost pulling ω toward a target away from its data-implied value (~1.0)
+const _EO_ΩTARGET = 0.2
+_eo_var_pull(λ) = θu -> λ * (θu.ω - _EO_ΩTARGET)^2
+
+@testset "extra_objective ForwardDiff-compatible" begin
+    dm = _eo_re_dm()
+    θ0 = get_θ0_untransformed(dm.model.fixed.fixed)
+    ax = getaxes(θ0)
+    f = _eo_var_pull(200.0)
+    g = ForwardDiff.gradient(v -> f(ComponentArray(v, ax)), collect(θ0))
+    @test length(g) == length(θ0)
+    @test all(isfinite, g)
+end
+
+@testset "SAEM: variance-only extra_objective moves ω (bug fix)" begin
+    dm = _eo_re_dm()
+    saem = NoLimits.SAEM(; maxiters = 80, mcmc_steps = 10, n_chains = 1, progress = false)
+    res0 = fit_model(dm, saem; rng = MersenneTwister(1),
+        serialization = SciMLBase.EnsembleSerial())
+    res1 = fit_model(dm, saem; rng = MersenneTwister(1),
+        serialization = SciMLBase.EnsembleSerial(),
+        extra_objective = _eo_var_pull(200.0))
+    ω0, ω1 = _ω(res0), _ω(res1)
+    @test ω0 > 0.7               # closed-form path recovers the data-implied ω (~1.0)
+    @test ω1 < 0.65              # numeric joint M-step pulls ω toward the target 0.2 (~0.52)
+    @test ω1 < ω0 - 0.3          # clearly moved (would be identical under the bug)
+    @test isfinite(get_objective(res1))
+end
+
+@testset "MCEM: variance-only extra_objective moves ω (bug fix)" begin
+    dm = _eo_re_dm()
+    mcem = NoLimits.MCEM(; sampler = MH(),
+        turing_kwargs = (n_samples = 30, n_adapt = 5, progress = false),
+        maxiters = 40)
+    res0 = fit_model(dm, mcem; rng = MersenneTwister(1),
+        serialization = SciMLBase.EnsembleSerial())
+    res1 = fit_model(dm, mcem; rng = MersenneTwister(1),
+        serialization = SciMLBase.EnsembleSerial(),
+        extra_objective = _eo_var_pull(200.0))
+    ω0, ω1 = _ω(res0), _ω(res1)
+    @test ω0 > 0.7
+    @test ω1 < 0.65
+    @test ω1 < ω0 - 0.3
+end
+
+@testset "SAEM ω with extra approaches Laplace/FOCEI" begin
+    dm = _eo_re_dm()
+    pull = _eo_var_pull(200.0)
+    lap = fit_model(dm, NoLimits.Laplace(); extra_objective = pull,
+        serialization = SciMLBase.EnsembleSerial())
+    foc = fit_model(dm, NoLimits.FOCEI(); extra_objective = pull,
+        serialization = SciMLBase.EnsembleSerial())
+    saem = fit_model(dm,
+        NoLimits.SAEM(; maxiters = 80, mcmc_steps = 10, n_chains = 1, progress = false);
+        rng = MersenneTwister(2), extra_objective = pull,
+        serialization = SciMLBase.EnsembleSerial())
+    @test isapprox(_ω(lap), _ω(foc); atol = 0.05)   # both fold extra into D identically
+    @test isapprox(_ω(saem), _ω(lap); atol = 0.08)  # SAEM now matches the faithful ω
+end
+
+@testset "extra_objective === nothing is a no-op (SAEM/MCEM unchanged)" begin
+    dm = _eo_re_dm()
+    saem = NoLimits.SAEM(; maxiters = 40, mcmc_steps = 8, n_chains = 1, progress = false)
+    a = fit_model(dm, saem; rng = MersenneTwister(7),
+        serialization = SciMLBase.EnsembleSerial())
+    b = fit_model(dm, saem; rng = MersenneTwister(7),
+        serialization = SciMLBase.EnsembleSerial(), extra_objective = nothing)
+    @test get_objective(a) == get_objective(b)
+    @test _ω(a) == _ω(b)
+end
+
+# Fixed-effects-only model with priors, for MCMC / VI.
+function _eo_fe_dm()
+    m = @Model begin
+        @fixedEffects begin
+            a = RealNumber(0.0; prior = Normal(0.0, 10.0))
+            σ = RealNumber(0.5, scale = :log, lower = 1e-8, upper = Inf;
+                prior = LogNormal(0.0, 1.0))
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @formulas begin
+            y ~ Normal(a, σ)
+        end
+    end
+    return DataModel(m, _eo_re_data(); primary_id = :ID, time_col = :t)
+end
+
+@testset "MCMC honors extra_objective (bug fix)" begin
+    dm = _eo_fe_dm()
+    meth = NoLimits.MCMC(; sampler = NUTS(80, 0.8),
+        turing_kwargs = (n_samples = 300, n_adapt = 120, progress = false))
+    res0 = fit_model(dm, meth; rng = MersenneTwister(3))
+    # strong pull of a toward 8.0 (cost = negative log-likelihood ⇒ Gaussian likelihood on a)
+    res1 = fit_model(dm, meth; rng = MersenneTwister(3),
+        extra_objective = θu -> 50.0 * (θu.a - 8.0)^2)
+    amean(r) = mean(vec(Array(get_chain(r)[:, :a, :])))
+    @test amean(res0) < 4.0             # data pulls a toward ~2
+    @test amean(res1) > amean(res0) + 1.0  # extra term shifts the posterior toward 8
+end
+
+@testset "VI accepts extra_objective" begin
+    dm = _eo_fe_dm()
+    meth = NoLimits.VI(; turing_kwargs = (max_iter = 50,))
+    # both the nothing path and a real term must run without error
+    r0 = fit_model(dm, meth; rng = MersenneTwister(5), extra_objective = nothing)
+    r1 = fit_model(dm, meth; rng = MersenneTwister(5),
+        extra_objective = θu -> 10.0 * (θu.a - 5.0)^2)
+    @test r0 isa FitResult
+    @test r1 isa FitResult
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,6 +101,7 @@ const TEST_FILES = [
     "saem_mstep_sa_on_params_tests.jl",
     "estimation_multistart_tests.jl",
     "estimation_ghquadrature_tests.jl",
+    "extra_objective_tests.jl",
     "uq_tests.jl",
     "uq_edge_cases_tests.jl",
     # ── B6: HMM / Markov / stickbreak / Enzyme ───────────────────────────────


### PR DESCRIPTION
## Summary

`extra_objective` (a negative-log-likelihood cost for population-level moment terms that depend on the population parameters β and the RE covariance `D`) was silently dropped for the parameters it is meant to inform. This fixes two independent bugs.

### Bug 1 — SAEM/MCEM dropped the term for the RE covariance `D` (ω)
The term reached only the **Q1** numeric M-step (rates + observation-side means). The RE-variance params `D` were updated by the closed-form covariance step or the ODE-free **Q2** M-step, both of which ignore `extra_objective`, so a variance-only term (e.g. a single-cell-snapshot variance) never moved `D`.

Adding the term couples β and `D` through the ODE ensemble moments, so the objective is **non-separable** and the classic Q1/Q2 block split is no longer exact. The rigorous M-step is the joint maximizer `argmax_θ [Q(θ) + J(θ)]`. Since Q1's objective already uses the full log-joint (obs + RE-prior `Σ log p(bᵢ|D)`), already adds `extra_objective`, and applies the same γ-damped SA update, when `extra_objective` is present we route **all** free params into that single joint Q1 M-step. This mirrors the already-faithful Laplace/FOCEI single pass.

### Bug 2 — MCMC/VI did not accept `extra_objective` at all
No kwarg and no `kwargs...` slurp, so passing it errored / the term was absent from the posterior. It is now threaded into the Turing model builders and added to the target via `@addlogprob! -extra_objective(θ_re)` (sign-flipped because the closure is a cost; θ is natural-scale).

All changes are gated on `extra_objective !== nothing`, so the default path is **bit-identical**.

## Validation

A variance-only pull of ω toward 0.2 on a small linear RE fixture (data-implied ω ≈ 1.0):

| Estimator | ω, no term | ω, with term |
|---|---|---|
| SAEM | 1.00 | 0.52 |
| MCEM | 1.08 | 0.52 |
| Laplace | 1.01 | 0.52 |
| FOCEI | — | 0.52 |

Pre-fix SAEM/MCEM's ω was inert; now all four estimators agree (~0.003).

- New `test/extra_objective_tests.jl` (7 testsets, 17 tests): ForwardDiff-compat, SAEM/MCEM ω-moves, SAEM≈Laplace/FOCEI, `nothing`-path no-op, MCMC posterior shift, VI accepts.
- Regression across every touched path (`estimation_saem`, `saem_autodetect`, `mcem`, `mcmc`, `mcmc_re`, `vi`) + the new file: green in the `Pkg.test` sandbox.
- JuliaFormatter: no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)