### PR TITLE
Add crossing_rootval and DataModel t0 option (+ plotting crossing fix)

### DIFF
--- a/ext/NoLimitsPlotsExt.jl
+++ b/ext/NoLimitsPlotsExt.jl
@@ -67,7 +67,7 @@ using NoLimits: COLOR_ACCENT, COLOR_CI, COLOR_PRIMARY, COLOR_REFERENCE, COLOR_SE
                 _resolve_observables, _resolve_plot_path, _resolve_re_names,
                 _row_random_effects_at,
                 _sample_random_effects_levels, _simulate_obs, _solve_dense_individual,
-                _standardize_re,
+                _sol_accessors_with_crossings, _standardize_re,
                 _stat_from_dist, _state_emission_marginals, _uq_density_ylabel, _uq_kde_xy,
                 _uq_merge_limits, _uq_param_indices, _uq_param_label,
                 _uq_wald_coord_transforms,

--- a/ext/plotting/plots.jl
+++ b/ext/plotting/plots.jl
@@ -404,7 +404,8 @@ function plot_fits(res::FitResult;
                 compiled = nothing
                 if dm.model.de.de !== nothing
                     sol, compiled = _solve_dense_individual(dm, ind, θ, η_ind)
-                    sol_accessors = get_de_accessors_builder(dm.model.de.de)(sol, compiled)
+                    sol_accessors = _sol_accessors_with_crossings(
+                        dm.model, sol, compiled, θ, η_ind, ind.const_cov)
                 end
                 if use_dense
                     dists = plot_density ? Vector{Distribution}(undef, length(x_fit)) :
@@ -509,7 +510,8 @@ function plot_fits(res::FitResult;
                     model_funs = get_model_funs(dm.model),
                     preDE = calculate_prede(dm.model, θ, η_ind, ind.const_cov)
                 ))
-                sol_accessors = get_de_accessors_builder(dm.model.de.de)(sol, compiled)
+                sol_accessors = _sol_accessors_with_crossings(
+                    dm.model, sol, compiled, θ, η_ind, ind.const_cov)
             end
 
             n_points = length(use_dense ? x_fit : obs_rows)
@@ -681,7 +683,8 @@ function _plot_hidden_states_impl(dm::DataModel,
             sol = cache = nothing
             sol = dm.model.de.de !== nothing ?
                   _solve_dense_individual(dm, ind, θ_ind, η_ind)[1] : nothing
-            sol_accessors = get_de_accessors_builder(dm.model.de.de)(sol, compiled)
+            sol_accessors = _sol_accessors_with_crossings(
+                dm.model, sol, compiled, θ_ind, η_ind, ind.const_cov)
         end
 
         times = Float64[]
@@ -961,7 +964,8 @@ function _plot_emission_for_individual(dm::DataModel,
         )
         compiled = get_de_compiler(dm.model.de.de)(pc)
         sol = _solve_dense_individual(dm, ind, θ, η_ind)[1]
-        sol_accessors = get_de_accessors_builder(dm.model.de.de)(sol, compiled)
+        sol_accessors = _sol_accessors_with_crossings(
+            dm.model, sol, compiled, θ, η_ind, ind.const_cov)
     end
 
     vary = _varying_at(dm, ind, row_pos, row)

--- a/ext/plotting/plotting_observation_distributions.jl
+++ b/ext/plotting/plotting_observation_distributions.jl
@@ -110,8 +110,8 @@ function plot_observation_distributions(res::FitResult;
                         compiled = nothing
                         if dm.model.de.de !== nothing
                             sol, compiled = _solve_dense_individual(dm, ind, θ, η_ind)
-                            sol_accessors = get_de_accessors_builder(dm.model.de.de)(
-                                sol, compiled)
+                            sol_accessors = _sol_accessors_with_crossings(
+                                dm.model, sol, compiled, θ, η_ind, ind.const_cov)
                         end
                         vary = _varying_at(dm, ind, j, row)
                         η_row = _row_random_effects_at(
@@ -219,8 +219,8 @@ function plot_observation_distributions(res::FitResult;
                             model_funs = get_model_funs(dm.model),
                             preDE = calculate_prede(dm.model, θ, η_ind, ind.const_cov)
                         ))
-                        sol_accessors = get_de_accessors_builder(dm.model.de.de)(
-                            sol, compiled)
+                        sol_accessors = _sol_accessors_with_crossings(
+                            dm.model, sol, compiled, θ, η_ind, ind.const_cov)
                     end
                     dist = if cache_obs_dists && cache.obs_dists !== nothing
                         getproperty(cache.obs_dists[i][j], obs_name)

--- a/src/data_model/DataModel.jl
+++ b/src/data_model/DataModel.jl
@@ -1362,6 +1362,7 @@ function DataModel(model,
         amt_col::Symbol = :AMT,
         rate_col::Symbol = :RATE,
         cmt_col::Symbol = :CMT,
+        t0::Union{Nothing, Real} = 0.0,
         serialization::SciMLBase.EnsembleAlgorithm = EnsembleSerial())
     if primary_id === nothing
         re_groups = get_re_groups(model.random.random)
@@ -1424,8 +1425,13 @@ function DataModel(model,
         series = IndividualSeries(obs, vary, dyn)
         const_cov = _build_const_cov(cov, df, rows)
         callbacks = _build_callbacks(model, df, rows, config)
+        # Integration start defaults to `t0` (0.0) so the initial conditions are applied
+        # at t = 0 even when the first observation is later; `t0 = nothing` recovers the
+        # legacy behaviour of starting at the first data time. The lower bound is never
+        # raised above the data (extended down to `t0`, not truncated).
         if isempty(time_offsets)
-            tspan = (minimum(tvals), maximum(tvals))
+            lo = minimum(tvals)
+            tspan = (t0 === nothing ? lo : min(oftype(lo, t0), lo), maximum(tvals))
         else
             extra_min = minimum(time_offsets)
             extra_max = maximum(time_offsets)
@@ -1436,7 +1442,7 @@ function DataModel(model,
                 push!(bad_ids, id_val)
                 bad_tmin[id_val] = tmin
             end
-            tspan = (tmin, tmax)
+            tspan = (t0 === nothing ? tmin : min(oftype(tmin, t0), tmin), tmax)
         end
         re_groups = _build_re_groups(model, df, rows)
         cb_times = callbacks !== nothing ? callbacks.all_times : Float64[]

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -1970,12 +1970,12 @@ function _ll_solve_de(dm::DataModel, idx::Int, θ, η_ind, cache::_LLCache, pre)
     saveat_use = _ll_saveat(cache, idx, ind)
     state_names = get_de_states(model.de.de)
     n_cross = length(crossings)
-    if n_cross == 1
+    if n_cross == 1 && crossings[1].kind === :time
         # type-stable fast path (the common case, incl. a single apoptosis event):
         # no Vector{Any} / splat, concrete callback.
         spec = crossings[1]
         sidx = findfirst(==(spec.state), state_names)
-        sidx === nothing && error("crossing_time state `$(spec.state)` is not a DE state.")
+        sidx === nothing && error("crossing state `$(spec.state)` is not a DE state.")
         c = _crossing_threshold(spec.threshold, θ, pre)
         tinit = spec.tmax === nothing ? convert(T, ind.tspan[2]) : convert(T, spec.tmax)
         r = Ref{T}(tinit)
@@ -1990,30 +1990,46 @@ function _ll_solve_de(dm::DataModel, idx::Int, θ, η_ind, cache::_LLCache, pre)
         acc = get_de_accessors_builder(model.de.de)(sol, compiled)
         return merge(acc, NamedTuple{(spec.name,)}((r[],)))
     end
-    refs = Vector{Base.RefValue{T}}(undef, n_cross)
-    cross_cbs = Vector{Any}(undef, n_cross)
+    # General path: attach an event callback only for :time crossings; :rootval
+    # crossings need no callback and are read off the solved trajectory afterwards.
+    sidxs = Vector{Int}(undef, n_cross)
+    thr = Vector{Any}(undef, n_cross)
+    time_refs = Vector{Any}(undef, n_cross)   # Ref{T} for :time, `nothing` for :rootval
+    cross_cbs = Any[]
     for k in 1:n_cross
         spec = crossings[k]
         sidx = findfirst(==(spec.state), state_names)
-        sidx === nothing && error("crossing_time state `$(spec.state)` is not a DE state.")
+        sidx === nothing && error("crossing state `$(spec.state)` is not a DE state.")
         c = _crossing_threshold(spec.threshold, θ, pre)
-        tinit = spec.tmax === nothing ? convert(T, ind.tspan[2]) : convert(T, spec.tmax)
-        r = Ref{T}(tinit)
-        refs[k] = r
-        fired = Ref(false)
-        cross_cbs[k] = SciMLBase.DiscreteCallback(
-            _CrossingCondition(sidx, c, fired), _CrossingAffect(sidx, c, r, fired);
-            save_positions = (false, false))
+        sidxs[k] = sidx
+        thr[k] = c
+        if spec.kind === :time
+            tinit = spec.tmax === nothing ? convert(T, ind.tspan[2]) : convert(T, spec.tmax)
+            r = Ref{T}(tinit)
+            time_refs[k] = r
+            fired = Ref(false)
+            push!(cross_cbs,
+                SciMLBase.DiscreteCallback(_CrossingCondition(sidx, c, fired),
+                    _CrossingAffect(sidx, c, r, fired); save_positions = (false, false)))
+        else
+            time_refs[k] = nothing
+        end
     end
-    cbset = cb === nothing ? SciMLBase.CallbackSet(cross_cbs...) :
-            SciMLBase.CallbackSet(cb, cross_cbs...)
+    cbset = if isempty(cross_cbs)
+        cb
+    elseif cb === nothing
+        SciMLBase.CallbackSet(cross_cbs...)
+    else
+        SciMLBase.CallbackSet(cb, cross_cbs...)
+    end
     prob = ODEProblem{true, SciMLBase.FullSpecialize}(
         f!_use, u0_T, ind.tspan, p_flat; _ll_prob_kwargs(cbset, saveat_use)...)
     sol = _ll_ode_solve_baked(cache, prob)
     SciMLBase.successful_retcode(sol) || return nothing
     acc = get_de_accessors_builder(model.de.de)(sol, compiled)
     cross_nt = NamedTuple{Tuple(crossings[k].name for k in 1:n_cross)}(
-        Tuple(refs[k][] for k in 1:n_cross))
+        Tuple(crossings[k].kind === :time ? time_refs[k][] :
+              _crossing_rootval_from_sol(sol, sidxs[k], thr[k]) for k in 1:n_cross))
     return merge(acc, cross_nt)
 end
 

--- a/src/model/Formulas.jl
+++ b/src/model/Formulas.jl
@@ -194,7 +194,8 @@ end
 
 function formulas_has_crossing(f::Formulas)
     for ex in vcat(f.ir.det_exprs, f.ir.obs_exprs)
-        _formulas_expr_has_call(ex, :crossing_time) && return true
+        (_formulas_expr_has_call(ex, :crossing_time) ||
+         _formulas_expr_has_call(ex, :crossing_rootval)) && return true
     end
     return false
 end
@@ -398,11 +399,15 @@ function _parse_formulas(block::Expr)
     return det_names, det_exprs, obs_names, obs_exprs, lines
 end
 
-# Recognize a crossing-time deterministic node
-# `name = crossing_time(:state, :threshold; tmax = T)` and return
-# `(name, state, threshold, tmax_expr)`, or `nothing` if `rhs` is not one.
+# Recognize a crossing deterministic node
+# `name = crossing_time(:state, :threshold; tmax = T)` or
+# `name = crossing_rootval(:state, :threshold; tmax = T)` and return
+# `(name, state, threshold, tmax_expr, kind)`, or `nothing` if `rhs` is not one.
 function _formulas_crossing_spec(name::Symbol, rhs)
-    (rhs isa Expr && rhs.head == :call && rhs.args[1] === :crossing_time) || return nothing
+    (rhs isa Expr && rhs.head == :call &&
+     (rhs.args[1] === :crossing_time || rhs.args[1] === :crossing_rootval)) ||
+        return nothing
+    kind = rhs.args[1] === :crossing_rootval ? :rootval : :time
     tmax = :nothing
     pos = Any[]
     for a in rhs.args[2:end]
@@ -418,13 +423,13 @@ function _formulas_crossing_spec(name::Symbol, rhs)
         end
     end
     length(pos) == 2 ||
-        error("crossing_time expects `crossing_time(:state, :threshold; tmax = T)`.")
+        error("$(rhs.args[1]) expects `$(rhs.args[1])(:state, :threshold; tmax = T)`.")
     function _sym(x)
         x isa QuoteNode ? x.value :
         (x isa Symbol ? x :
-         error("crossing_time arguments must be symbol literals, e.g. :state."))
+         error("$(rhs.args[1]) arguments must be symbol literals, e.g. :state."))
     end
-    return (name, _sym(pos[1]), _sym(pos[2]), tmax)
+    return (name, _sym(pos[1]), _sym(pos[2]), tmax, kind)
 end
 
 function _formulas_build_formulas_expr(ir::FormulasIR,
@@ -742,7 +747,7 @@ macro formulas(block)
         cs === nothing && continue
         push!(crossing_specs,
             :(CrossingSpec($(QuoteNode(cs[1])), $(QuoteNode(cs[2])),
-                $(QuoteNode(cs[3])), $(cs[4]))))
+                $(QuoteNode(cs[3])), $(cs[4]), $(QuoteNode(cs[5])))))
     end
 
     return quote

--- a/src/model/crossing.jl
+++ b/src/model/crossing.jl
@@ -1,38 +1,49 @@
 export crossing_time
+export crossing_rootval
 
 # ============================================================================
 # Threshold-crossing (first-passage / time-to-event) support for @formulas, via
 # solver-native event detection (ContinuousCallback).
 #
-# Declared as a deterministic node:
+# Declared as deterministic nodes:
 #
-#     tstar = crossing_time(:state, :threshold; tmax = T)
+#     tstar   = crossing_time(:state, :threshold; tmax = T)
+#     rootval = crossing_rootval(:state, :threshold; tmax = T)
 #
 # where `:state` is an ODE state and `:threshold` is an in-scope symbol (a fixed
-# effect or a preDifferentialEquation variable) giving the crossing level. The
-# value is the first time `state(t)` crosses `threshold`, detected DURING
-# integration — no dense solution, no re-solving, one event detection per solve.
-# Its parameter sensitivity is exact under ForwardDiff (the callback root runs on
-# dual numbers). `tmax` (optional) is returned when no crossing occurs within the
-# horizon (defaults to the individual's final integration time).
+# effect or a preDifferentialEquation variable) giving the crossing level.
+# `crossing_time` is the first time `state(t)` crosses `threshold` (detected DURING
+# integration — no dense solution, one event detection per solve; `tmax`, optional,
+# is returned when no crossing occurs, defaulting to the individual's final
+# integration time). `crossing_rootval` is the AMICI-style rootvalue: `0` when the
+# state crosses, else `state(t_end) − threshold` (the shortfall). Pairing
+# `zt ~ Normal(tstar, σ)` with `rz ~ Normal(rootval, σ)` reproduces MEMOIR's
+# time-to-event likelihood term-for-term and keeps a gradient for non-crossing cells.
 #
-# Only models that declare a crossing take the event path (see `_ll_solve_de`);
-# every other model is completely unaffected (same sparse solve, same template
-# cache).
+# Parameter sensitivity is exact under ForwardDiff (the callback root runs on dual
+# numbers). Only models that declare a crossing take the event path (see
+# `_ll_solve_de`); every other model is unaffected.
 # ============================================================================
 
 struct CrossingSpec
-    name::Symbol        # deterministic-node name holding the crossing time
+    name::Symbol        # deterministic-node name holding the crossing value
     state::Symbol       # ODE state whose crossing is detected
     threshold::Symbol   # in-scope symbol (fixed effect or preDE var) = crossing level
     tmax::Any           # Float64 horizon, or `nothing` (use the individual's tspan end)
+    kind::Symbol        # :time (crossing time) or :rootval (root value at the horizon)
 end
 
-# Marker recognized and rewritten by @formulas; never actually invoked at runtime.
+# Markers recognized and rewritten by @formulas; never actually invoked at runtime.
 function crossing_time(args...; kwargs...)
     error(
         "`crossing_time` may only be used as a deterministic node inside @formulas, " *
         "e.g. `tstar = crossing_time(:state, :threshold; tmax = T)`.")
+end
+
+function crossing_rootval(args...; kwargs...)
+    error(
+        "`crossing_rootval` may only be used as a deterministic node inside @formulas, " *
+        "e.g. `rootval = crossing_rootval(:state, :threshold; tmax = T)`.")
 end
 
 get_formulas_crossings(f) = f.ir.crossings
@@ -106,4 +117,89 @@ end
     ca.ref[] = abs(ForwardDiff.value(gdot)) > 0 ? troot - g / gdot : oftype(g, troot)
     ca.fired[] = true
     return nothing
+end
+
+# Plotting/diagnostics re-solve without the crossing event callback, so the crossing
+# nodes @formulas rewrites to `sol_accessors.<name>` are recovered here from the solved
+# trajectory instead. `_crossing_time_from_sol` mirrors `_CrossingAffect` off a completed
+# `sol`; `_sol_accessors_with_crossings` merges the values into the accessors.
+
+# First-passage time of state `idx` past level `c`; returns `tmax` if never crossed.
+function _crossing_time_from_sol(sol, idx::Int, c, tmax)
+    cv = ForwardDiff.value(c)
+    ts = sol.t
+    n = length(ts)
+    n < 2 && return oftype(0.5 * (ts[1] + ts[1]) - cv, tmax)
+    va = ForwardDiff.value(sol.u[1][idx]) - cv
+    a = ts[1]
+    b = ts[1]
+    found = false
+    @inbounds for k in 2:n
+        vk = ForwardDiff.value(sol.u[k][idx]) - cv
+        if (va < 0) != (vk < 0)                             # first sign change across saved steps
+            a = ts[k - 1]
+            b = ts[k]
+            found = true
+            break
+        end
+        va = vk
+    end
+    found || return oftype(0.5 * (ts[1] + ts[1]) - cv, tmax)
+    va = ForwardDiff.value(sol(a; idxs = idx)) - cv
+    @inbounds for _ in 1:40                                 # bisection on the step interpolant
+        m = 0.5 * (a + b)
+        vm = ForwardDiff.value(sol(m; idxs = idx)) - cv
+        if (vm < 0) == (va < 0)
+            a = m
+            va = vm
+        else
+            b = m
+        end
+    end
+    troot = 0.5 * (a + b)
+    g = sol(troot; idxs = idx) - c
+    gdot = sol(troot, Val{1})[idx]
+    return abs(ForwardDiff.value(gdot)) > 0 ? troot - g / gdot : oftype(g, troot)
+end
+
+# AMICI-style rootvalue read off a solved trajectory: 0 if state `idx` crosses level `c`
+# within the saved points, else `state(t_end) − c` (the shortfall). Carries the dual
+# sensitivity of the final state; zero (with zero gradient) once the state has crossed.
+function _crossing_rootval_from_sol(sol, idx::Int, c)
+    us = sol.u
+    n = length(us)
+    rend = us[n][idx] - c                                   # shortfall at the horizon
+    n < 2 && return rend
+    cv = ForwardDiff.value(c)
+    va = ForwardDiff.value(us[1][idx]) - cv
+    @inbounds for k in 2:n
+        vk = ForwardDiff.value(us[k][idx]) - cv
+        (va < 0) != (vk < 0) && return zero(rend)           # crossed → rootvalue 0
+        va = vk
+    end
+    return rend
+end
+
+# Accessors for plotting, with any crossing node values (time or rootvalue) merged in
+# (no-op when the model declares no crossings).
+function _sol_accessors_with_crossings(model, sol, compiled, θ, η, const_cov)
+    acc = get_de_accessors_builder(model.de.de)(sol, compiled)
+    crossings = get_formulas_crossings(model.formulas.formulas)
+    isempty(crossings) && return acc
+    pre = calculate_prede(model, θ, η, const_cov)
+    state_names = get_de_states(model.de.de)
+    names = ntuple(k -> crossings[k].name, length(crossings))
+    vals = ntuple(length(crossings)) do k
+        spec = crossings[k]
+        sidx = findfirst(==(spec.state), state_names)
+        sidx === nothing && error("crossing state `$(spec.state)` is not a DE state.")
+        c = _crossing_threshold(spec.threshold, θ, pre)
+        if spec.kind === :rootval
+            _crossing_rootval_from_sol(sol, sidx, c)
+        else
+            tmax = spec.tmax === nothing ? sol.t[end] : spec.tmax
+            _crossing_time_from_sol(sol, sidx, c, tmax)
+        end
+    end
+    return merge(acc, NamedTuple{names}(vals))
 end

--- a/src/plotting/plots.jl
+++ b/src/plotting/plots.jl
@@ -384,7 +384,8 @@ function _fit_curve_from_cache(dm::DataModel,
             model_funs = get_model_funs(dm.model),
             preDE = calculate_prede(dm.model, θ, η_ind, ind.const_cov)
         ))
-        sol_accessors = get_de_accessors_builder(dm.model.de.de)(sol, compiled)
+        sol_accessors = _sol_accessors_with_crossings(
+            dm.model, sol, compiled, θ, η_ind, ind.const_cov)
     end
 
     preds = Vector{Float64}(undef, length(x_fit))
@@ -466,7 +467,8 @@ function _collect_pred_series(dm::DataModel, obs_name::Symbol,
         sol_accessors = nothing
         if dm.model.de.de !== nothing
             sol, compiled = _solve_dense_individual(dm, ind, θ, η_ind)
-            sol_accessors = get_de_accessors_builder(dm.model.de.de)(sol, compiled)
+            sol_accessors = _sol_accessors_with_crossings(
+                dm.model, sol, compiled, θ, η_ind, ind.const_cov)
         end
 
         for (j, row) in enumerate(obs_rows)
@@ -520,7 +522,8 @@ function _collect_ipred_series(dm::DataModel, obs_name::Symbol,
         sol_accessors = nothing
         if dm.model.de.de !== nothing
             sol, compiled = _solve_dense_individual(dm, ind, θ, η_ind)
-            sol_accessors = get_de_accessors_builder(dm.model.de.de)(sol, compiled)
+            sol_accessors = _sol_accessors_with_crossings(
+                dm.model, sol, compiled, θ, η_ind, ind.const_cov)
         end
 
         for (j, row) in enumerate(obs_rows)

--- a/src/plotting/plotting.jl
+++ b/src/plotting/plotting.jl
@@ -1264,8 +1264,8 @@ function build_plot_cache(res::FitResult;
             η_ind = η_vec[i] isa ComponentArray ? η_vec[i] : ComponentArray(η_vec[i])
             rowwise_re = _needs_rowwise_random_effects(dm, i; obs_only = true)
             sol_accessors = dm.model.de.de === nothing ? nothing :
-                            get_de_accessors_builder(dm.model.de.de)(
-                sols[i], compiled_cache[i])
+                            _sol_accessors_with_crossings(
+                dm.model, sols[i], compiled_cache[i], θ, η_ind, ind.const_cov)
             dists_i = Vector{NamedTuple}(undef, length(obs_rows))
             hmm_priors = Dict{Symbol, Any}()
             for (j, row) in enumerate(obs_rows)
@@ -1335,8 +1335,8 @@ function build_plot_cache(dm::DataModel;
             η_ind = η_vec[i] isa ComponentArray ? η_vec[i] : ComponentArray(η_vec[i])
             rowwise_re = _needs_rowwise_random_effects(dm, i; obs_only = true)
             sol_accessors = dm.model.de.de === nothing ? nothing :
-                            get_de_accessors_builder(dm.model.de.de)(
-                sols[i], compiled_cache[i])
+                            _sol_accessors_with_crossings(
+                dm.model, sols[i], compiled_cache[i], θ, η_ind, ind.const_cov)
             dists_i = Vector{NamedTuple}(undef, length(obs_rows))
             hmm_priors = Dict{Symbol, Any}()
             for (j, row) in enumerate(obs_rows)

--- a/src/plotting/plotting_residuals.jl
+++ b/src/plotting/plotting_residuals.jl
@@ -385,8 +385,8 @@ function get_residuals(res::FitResult;
                 else
                     sol, compiled = _solve_dense_individual(
                         dm, ind, θ, η_ind; ode_args = ode_args, ode_kwargs = ode_kwargs)
-                    sol_accessors_draw[d] = get_de_accessors_builder(dm.model.de.de)(
-                        sol, compiled)
+                    sol_accessors_draw[d] = _sol_accessors_with_crossings(
+                        dm.model, sol, compiled, θ, η_ind, ind.const_cov)
                 end
             end
 
@@ -514,7 +514,8 @@ function get_residuals(res::FitResult;
                     model_funs = get_model_funs(dm.model),
                     preDE = calculate_prede(dm.model, θ, η_ind, ind.const_cov)
                 ))
-                sol_accessors = get_de_accessors_builder(dm.model.de.de)(sol, compiled)
+                sol_accessors = _sol_accessors_with_crossings(
+                    dm.model, sol, compiled, θ, η_ind, ind.const_cov)
             end
 
             for obs_name in obs_list

--- a/src/plotting/plotting_vpc.jl
+++ b/src/plotting/plotting_vpc.jl
@@ -208,7 +208,8 @@ function _simulate_obs(dm::DataModel,
         sol_accessors = nothing
         if dm.model.de.de !== nothing
             sol, compiled = _solve_dense_individual(dm, ind, θ, η_ind)
-            sol_accessors = get_de_accessors_builder(dm.model.de.de)(sol, compiled)
+            sol_accessors = _sol_accessors_with_crossings(
+                dm.model, sol, compiled, θ, η_ind, ind.const_cov)
         end
         vals = Vector{Float64}(undef, length(obs_rows))
         hmm_prev_state = 0
@@ -245,7 +246,8 @@ function _representative_dist(dm::DataModel, obs_name::Symbol, x_axis_feature)
     sol_accessors = nothing
     if dm.model.de.de !== nothing
         sol, compiled = _solve_dense_individual(dm, ind, θ, η_ind)
-        sol_accessors = get_de_accessors_builder(dm.model.de.de)(sol, compiled)
+        sol_accessors = _sol_accessors_with_crossings(
+            dm.model, sol, compiled, θ, η_ind, ind.const_cov)
     end
     vary = _varying_at(dm, ind, 1, obs_rows[1])
     if dm.model.de.de === nothing && x_axis_feature !== nothing

--- a/test/crossing_tests.jl
+++ b/test/crossing_tests.jl
@@ -1,0 +1,107 @@
+using Test
+using NoLimits
+using DataFrames
+using Distributions
+using ComponentArrays
+using OrdinaryDiffEq
+using ForwardDiff
+
+# x(t) = t  (D(x) = k = 1, x0 = 0); crosses `level` at t = level.
+function _crossing_model()
+    @Model begin
+        @fixedEffects begin
+            k = RealNumber(1.0)
+            σ = RealNumber(0.2, scale = :log)
+            level = RealNumber(1.0)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @preDifferentialEquation begin
+            thr = level
+        end
+        @DifferentialEquation begin
+            D(x) ~ k
+        end
+        @initialDE begin
+            x = 0.0
+        end
+        @formulas begin
+            tc = crossing_time(:x, :thr)
+            rv = crossing_rootval(:x, :thr)
+            y ~ Normal(x(t), σ)
+            zt ~ Normal(tc, 0.5)
+            rz ~ Normal(rv, 0.5)
+        end
+    end
+end
+
+# ind 1 crosses within its horizon (t up to 2 > 1); ind 2 does not (t up to 0.5 < 1).
+function _crossing_dm()
+    df = DataFrame(
+        ID = [1, 1, 1, 1, 1, 2, 2, 2],
+        t = [0.0, 0.5, 1.0, 1.5, 2.0, 0.0, 0.25, 0.5],
+        y = [0.0, 0.5, 1.0, 1.5, 2.0, 0.0, 0.25, 0.5],
+        zt = [missing, missing, missing, missing, 1.0, missing, missing, 0.5],
+        rz = [missing, missing, missing, missing, 0.0, missing, missing, 0.0])
+    return DataModel(_crossing_model(), df; primary_id = :ID, time_col = :t)
+end
+
+@testset "crossing_rootval values (fired vs non-fired)" begin
+    dm = _crossing_dm()
+    θ = get_θ0_untransformed(dm.model.fixed.fixed)
+    ηz = NoLimits._default_random_effects_from_dm(dm, NamedTuple(), θ)
+
+    accs = map(1:2) do i
+        ind = dm.individuals[i]
+        sol, comp = NoLimits._solve_dense_individual(dm, ind, θ, ηz[i])
+        NoLimits._sol_accessors_with_crossings(dm.model, sol, comp, θ, ηz[i], ind.const_cov)
+    end
+
+    # ind 1 crosses at t = level = 1 → rootvalue 0
+    @test isapprox(accs[1].tc, 1.0; atol = 1e-4)
+    @test isapprox(accs[1].rv, 0.0; atol = 1e-8)
+
+    # ind 2 never crosses within [0, 0.5] → tc falls back to the horizon (0.5),
+    # rootvalue = x(0.5) - level = 0.5 - 1.0 = -0.5
+    @test isapprox(accs[2].tc, 0.5; atol = 1e-4)
+    @test isapprox(accs[2].rv, -0.5; atol = 1e-6)
+end
+
+@testset "crossing_rootval likelihood is finite and AD-differentiable" begin
+    dm = _crossing_dm()
+    θ = get_θ0_untransformed(dm.model.fixed.fixed)
+    ηz = NoLimits._default_random_effects_from_dm(dm, NamedTuple(), θ)
+
+    ll = NoLimits.loglikelihood(dm, θ, ηz; serialization = NoLimits.EnsembleSerial())
+    @test isfinite(ll)
+
+    tr = get_transform(dm.model.fixed.fixed)
+    itr = get_inverse_transform(dm.model.fixed.fixed)
+    f = θt -> begin
+        θu = itr(θt)
+        η = NoLimits._default_random_effects_from_dm(dm, NamedTuple(), θu)
+        NoLimits.loglikelihood(dm, θu, η; serialization = NoLimits.EnsembleSerial())
+    end
+    g = ForwardDiff.gradient(f, tr(θ))
+    @test all(isfinite, g)
+    # the rootvalue term keeps a gradient w.r.t. the threshold for the non-firing cell
+    @test abs(g.level) > 1e-8
+end
+
+@testset "estimation and plotting crossing values agree" begin
+    dm = _crossing_dm()
+    θ = get_θ0_untransformed(dm.model.fixed.fixed)
+    ηz = NoLimits._default_random_effects_from_dm(dm, NamedTuple(), θ)
+    cache = NoLimits._build_ll_cache_single(dm)
+    for i in 1:2
+        ind = dm.individuals[i]
+        pre = NoLimits.calculate_prede(dm.model, θ, ηz[i], ind.const_cov)
+        acc_ll = NoLimits._ll_solve_de(dm, i, θ, ηz[i], cache, pre)
+        sol, comp = NoLimits._solve_dense_individual(dm, ind, θ, ηz[i])
+        acc_pl = NoLimits._sol_accessors_with_crossings(
+            dm.model, sol, comp, θ, ηz[i], ind.const_cov)
+        @test isapprox(acc_ll.tc, acc_pl.tc; atol = 1e-6)
+        @test isapprox(acc_ll.rv, acc_pl.rv; atol = 1e-6)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,7 @@ const TEST_FILES = [
     "compact_show_tests.jl",
     "data_simulation_tests.jl",
     "ode_callbacks_tests.jl",
+    "crossing_tests.jl",
     "datasets_tests.jl",
     "logit_scale_parameter_tests.jl",
     "logit_scale_transform_tests.jl",


### PR DESCRIPTION
## Summary

Three related changes for threshold/event models (e.g. MOMP first-passage time in apoptosis).

### `crossing_rootval(:state, :threshold)`
An AMICI-style rootvalue node: returns `0` if the threshold was crossed during integration, else `state(t_end) - threshold`. Pairing `crossing_time` (first-passage time) with `crossing_rootval` reproduces MEMOIR's `normal_time` event likelihood term-for-term (a time term + a rootvalue term). Touches `src/model/crossing.jl` (adds the marker fn, a `kind::Symbol` field on `CrossingSpec`, `_crossing_rootval_from_sol`, and `kind`-based dispatch in `_sol_accessors_with_crossings`), `src/model/Formulas.jl` (recognizes both `crossing_time`/`crossing_rootval`), and `src/estimation/common.jl` (`_ll_solve_de` attaches callbacks only for `:time` specs and computes `:rootval` post-solve).

### `DataModel(...; t0=0.0)`
ODE integration now starts at `t0` (default `0.0`) rather than the first observation time; `t0=nothing` restores the legacy behavior. No-op for existing fixtures (all start at `t=0`).

### Plotting fix for crossing models
`plot_fits` previously threw `FieldError: type NamedTuple has no field tcross` for crossing models. `_sol_accessors_with_crossings` now merges crossing values into the plotting accessors.

## Tests

Adds `test/crossing_tests.jl` (wired into `runtests.jl`): fired/non-fired rootvalues, AD gradient through the crossing likelihood, and estimation-vs-plotting agreement. Verified green in the `Pkg.test` sandbox on top of current `main`; JuliaFormatter is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)