### PR TITLE
summarize: fixed 4-decimal numeric formatting

### DIFF
--- a/src/summaries/data_model_summary.jl
+++ b/src/summaries/data_model_summary.jl
@@ -171,16 +171,8 @@ function _obs_time_values(dm::DataModel, obs_rows::Vector{Int})
     return vals
 end
 
-function _format_float(x::Float64)
-    if isnan(x)
-        return "NaN"
-    end
-    ax = abs(x)
-    if ax >= 1e4 || (ax > 0 && ax < 1e-3)
-        return string(round(x; sigdigits = 4))
-    end
-    return string(round(x; digits = 4))
-end
+# Fixed 4-decimal formatting, shared with the fit/UQ summaries (see `_fq_fmt_num`).
+_format_float(x::Float64) = _fq_fmt_num(x)
 
 function _print_key_values(io::IO, title::String, rows::AbstractVector{<:Pair})
     println(io, title)

--- a/src/summaries/fit_uq_summary.jl
+++ b/src/summaries/fit_uq_summary.jl
@@ -65,19 +65,27 @@ end
 
 @inline _fq_fmt_missing(x) = x === nothing ? "-" : x
 
+# Fixed 4-decimal string that keeps trailing zeros (e.g. 1.5 -> "1.5000"), built with
+# integer scaling so no Printf dependency is needed.
+function _fixed4(xv::Float64)
+    scaled = round(Int64, abs(xv) * 10_000)
+    ip, fp = divrem(scaled, 10_000)
+    s = string(ip) * "." * lpad(string(fp), 4, '0')
+    return (signbit(xv) && scaled != 0) ? "-" * s : s
+end
+
 function _fq_fmt_num(x)
     x === nothing && return "-"
     x isa Missing && return "-"
     x isa Real || return string(x)
     xv = Float64(x)
-    if !isfinite(xv)
-        return string(xv)
-    end
-    ax = abs(xv)
-    if ax >= 1e4 || (ax > 0 && ax < 1e-3)
+    isfinite(xv) || return string(xv)
+    # Nonzero values that would collapse to 0.0000 at 4 decimals, or are too large for
+    # fixed-point Int64 scaling, keep 4 significant digits so no information is lost.
+    if xv != 0 && (round(xv; digits = 4) == 0 || abs(xv) >= 1e14)
         return string(round(xv; sigdigits = 4))
     end
-    return string(round(xv; digits = 4))
+    return _fixed4(xv)
 end
 
 function _fq_fmt_objective(x)

--- a/test/summaries_fit_uq_tests.jl
+++ b/test/summaries_fit_uq_tests.jl
@@ -251,3 +251,24 @@ end
     @test occursin("CrI Lower", txt_comb)
     @test !occursin("NaN", txt_comb)
 end
+
+@testset "summarize numeric formatting: fixed 4 decimals" begin
+    f = NoLimits._fq_fmt_num
+    # non-integer floats always show exactly 4 decimals, trailing zeros kept
+    @test f(1.5) == "1.5000"
+    @test f(2.0) == "2.0000"
+    @test f(0.13) == "0.1300"
+    @test f(1.23456) == "1.2346"
+    @test f(-0.13) == "-0.1300"
+    @test f(0.0) == "0.0000"
+    @test f(12345.678) == "12345.6780"
+    # values that would collapse to 0.0000 keep 4 significant digits instead
+    @test f(1.0e-5) != "0.0000"
+    @test occursin("e", f(1.0e-5))
+    # sentinels / non-reals pass through
+    @test f(nothing) == "-"
+    @test f(missing) == "-"
+    @test f(NaN) == "NaN"
+    # the data-model summary shares the same formatter
+    @test NoLimits._format_float(0.5) == "0.5000"
+end


### PR DESCRIPTION
## Summary

All non-integer numeric output from `summarize` (fit, UQ, and data-model summaries, plus
`parameter_comparison`) now prints with **exactly four decimals, trailing zeros kept**.

| value | before | after |
|---|---|---|
| `1.5` | `1.5` | `1.5000` |
| `2.0` | `2.0` | `2.0000` |
| `0.13` | `0.13` | `0.1300` |
| `1.23456` | `1.2346` | `1.2346` |
| `12345.678` | `12350.0` | `12345.6780` |
| `1.0e-5` | `1.0e-5` | `1.0e-5` (kept) |

Previously `string(round(x; digits=4))` dropped trailing zeros, so the decimal count
varied across a table.

### Behavior
- Fixed four decimals for finite non-integer reals.
- Nonzero values that would collapse to `0.0000` (and values too large for fixed-point
  `Int64` scaling) fall back to **four significant digits** so no information is lost
  (e.g. a small variance `1e-5` stays `1.0e-5` rather than becoming `0.0000`).
- Integer counts (`n_obs`, `n`, iterations, …) are formatted separately and unaffected.
- `-` / `NaN` / `Inf` sentinels unchanged.

### Implementation
- `_fq_fmt_num` (the shared fit/UQ formatter) rewritten; new `_fixed4` builds the
  fixed-decimal string via integer scaling — **no new dependency** (Printf is not a
  NoLimits dep).
- `_format_float` (data-model summary) now delegates to `_fq_fmt_num`, removing a
  duplicate formatter.

### Tests
New testset in `summaries_fit_uq_tests.jl` covering fixed-decimal output, the
significant-digit fallback, and the sentinels; full file passes (92 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)