### PR TITLE
MCEM: adopt the windowed noise-aware early-stopping criterion

### DIFF
--- a/docs/src/estimation/mcem.md
+++ b/docs/src/estimation/mcem.md
@@ -203,11 +203,12 @@ method = NoLimits.MCEM(;
     verbose=false,
     progress=true,
     maxiters=100,
-    rtol_theta=1e-4,
-    atol_theta=1e-6,
-    rtol_Q=1e-4,
-    atol_Q=1e-6,
+    rtol_theta=1e-3,
+    atol_theta=1e-4,
+    rtol_Q=1e-3,
+    atol_Q=1e-4,
     consecutive_params=3,
+    convergence_window=20,
 
     # Final EB estimation
     ebe_optimizer=OptimizationOptimJL.LBFGS(linesearch=LineSearches.BackTracking()),
@@ -237,7 +238,7 @@ method = NoLimits.MCEM(;
 | --- | --- | --- |
 | E-step | `e_step` | Sampling or IS strategy for the random effects. |
 | M-step optimizer | `optimizer`, `optim_kwargs`, `adtype` | Optimization of fixed effects using [Optimization.jl](https://docs.sciml.ai/Optimization/stable/). |
-| EM stopping | `maxiters`, `rtol_theta`, `atol_theta`, `rtol_Q`, `atol_Q`, `consecutive_params` | Iteration limit and convergence checks. |
+| EM stopping | `maxiters`, `rtol_theta`, `atol_theta`, `rtol_Q`, `atol_Q`, `consecutive_params`, `convergence_window` | Iteration limit and windowed drift test for early stopping. |
 | Logging | `verbose`, `progress` | Diagnostic output and progress bar. |
 | Final EB estimation | `ebe_*` and `ebe_rescue_*` options | Post-fit empirical Bayes mode computation used by random-effects accessors and diagnostics. |
 | Bounds | `lb`, `ub` | Optional transformed-scale bounds for free fixed effects in M-step optimization. |
@@ -246,7 +247,7 @@ method = NoLimits.MCEM(;
 
 The constructor signature block above lists every keyword with its default. See the [`MCEM`](@ref) entry in the API reference for the full list. The notes below explain the behavior that is not obvious from the names.
 
-- **EM convergence.** MCEM monitors both fixed-effect parameter stability (`rtol_theta`, `atol_theta`) and Q-function stability (`rtol_Q`, `atol_Q`). `consecutive_params` is the number of consecutive iterations that must simultaneously satisfy both criteria before convergence is declared. `verbose` enables iteration-level logging of `Q`, `dtheta`, `dQ`, and sample count.
+- **EM convergence.** MCEM monitors both fixed-effect stability (`rtol_theta`, `atol_theta`) and Q-function stability (`rtol_Q`, `atol_Q`) with the same windowed drift test used by SAEM: the last `convergence_window` iterates are split into two halves, and each coordinate's drift between the half means must satisfy `drift ≤ max(atol, rtol * scale, 2 * mc_se)`, where `mc_se` is the Monte-Carlo standard error of the half-mean difference estimated from the window itself (drift indistinguishable from sampling noise counts as stationary). `consecutive_params` is the number of consecutive iterations on which both tests must pass before convergence is declared; setting `rtol` and `atol` of a test to `0` disables early stopping. See the SAEM page's [Convergence and Early Stopping](saem.md#convergence-and-early-stopping) section for details. Note that with a fixed, small Monte-Carlo sample size the EM iterates keep jittering at sampling scale and the fit typically uses all `maxiters`; a growing `sample_schedule` (classic MCEM practice) shrinks that jitter so the drift can fall below tolerance and trigger the stop. `verbose` enables iteration-level logging of `Q`, `dtheta`, `dQ`, and the drift values.
 - **Final EB modes.** After the EM iterations complete, MCEM computes empirical Bayes (EB) modal estimates of the random effects used by downstream accessors, configured through the `ebe_*` keywords (`ebe_grad_tol=:auto` selects a data-adaptive tolerance). When `ebe_rescue_on_high_grad=true` (default `false`), a rescue multistart governed by the `ebe_rescue_*` keywords is triggered if the final EB gradient norm remains above threshold.
 - **Bounds.** `lb`, `ub` are optional transformed-scale bounds for free fixed effects in the M-step optimization. Parameters held constant via the `constants` fit keyword are excluded automatically.
 

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -138,6 +138,7 @@ struct EMOptions{T}
     rtol_Q::T
     atol_Q::T
     consecutive_params::Int
+    convergence_window::Int
 end
 
 """
@@ -171,9 +172,19 @@ fixed effects.
 - `diagnostics_every::Int = 1`: when `store_diagnostics=true`, store only every n-th
   iteration. E.g. `diagnostics_every=10` keeps one snapshot per 10 iterations.
 - `maxiters::Int = 100`: maximum number of EM iterations.
-- `rtol_theta`, `atol_theta`: relative/absolute convergence tolerance on fixed effects.
-- `rtol_Q`, `atol_Q`: relative/absolute convergence tolerance on the Q-function.
-- `consecutive_params::Int = 3`: consecutive iterations satisfying tolerance to converge.
+- `rtol_theta = 1e-3`, `atol_theta = 1e-4`: convergence tolerances on fixed effects
+  (transformed scale). Each coordinate's drift between the two half-window means of the
+  last `convergence_window` iterates must satisfy
+  `drift ≤ max(atol, rtol * scale, 2 * mc_se)`, where `scale` is the max-abs older-half
+  mean (floored at 1) and `mc_se` is the Monte-Carlo standard error of the half-mean
+  difference estimated from the window itself. Set both to `0` to disable early stopping.
+- `rtol_Q = 1e-3`, `atol_Q = 1e-4`: same windowed drift test applied to the Q-function
+  history; any non-finite Q in the window fails the check.
+- `consecutive_params::Int = 3`: consecutive iterations on which both the θ and the Q
+  drift tests must pass before the fit stops early.
+- `convergence_window::Int = 20`: window length (≥ 4; compared halves have length
+  `convergence_window ÷ 2`) for the drift tests, so the earliest possible stop is
+  iteration `convergence_window + consecutive_params - 1`.
 - `ebe_optimizer`, `ebe_optim_kwargs`, `ebe_adtype`, `ebe_grad_tol`: EBE inner optimizer.
 - `ebe_multistart_n`, `ebe_multistart_k` (default 1), `ebe_multistart_max_rounds`,
   `ebe_multistart_sampling`: multistart settings for EBE mode computation.
@@ -211,11 +222,12 @@ function MCEM(;
         verbose = false,
         progress = true,
         maxiters = 100,
-        rtol_theta = 1e-4,
-        atol_theta = 1e-6,
-        rtol_Q = 1e-4,
-        atol_Q = 1e-6,
+        rtol_theta = 1e-3,
+        atol_theta = 1e-4,
+        rtol_Q = 1e-3,
+        atol_Q = 1e-4,
         consecutive_params = 3,
+        convergence_window::Int = 20,
         ebe_optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking()),
         ebe_optim_kwargs = NamedTuple(),
         ebe_adtype = Optimization.AutoForwardDiff(),
@@ -237,13 +249,16 @@ function MCEM(;
 )
     diagnostics_every >= 1 ||
         error("MCEM: diagnostics_every must be ≥ 1. Got: $diagnostics_every")
+    convergence_window >= 4 ||
+        error("MCEM: convergence_window must be ≥ 4. Got: $convergence_window")
     # When e_step is not provided, build MCEM_MCMC from legacy kwargs (backward compat)
     e_step_actual = if e_step === nothing
         MCEM_MCMC(sampler, turing_kwargs, sample_schedule, warm_start)
     else
         e_step
     end
-    em = EMOptions(maxiters, rtol_theta, atol_theta, rtol_Q, atol_Q, consecutive_params)
+    em = EMOptions(maxiters, rtol_theta, atol_theta, rtol_Q, atol_Q, consecutive_params,
+        convergence_window)
     ebe = EBEOptions(ebe_optimizer, ebe_optim_kwargs, ebe_adtype, ebe_grad_tol,
         ebe_multistart_n, ebe_multistart_k, ebe_multistart_max_rounds,
         ebe_multistart_sampling)
@@ -277,6 +292,8 @@ mutable struct _MCEMDiagnostics{T}
     dθ_rel::Vector{T}
     dQ_abs::Vector{T}
     dQ_rel::Vector{T}
+    drift_θ::Vector{T}
+    drift_Q::Vector{T}
     samples::Vector{Int}
     ess_hist::Vector{Float64}   # mean ESS across batches; NaN for MCMC iterations
 end
@@ -1267,6 +1284,8 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
         Vector{T0}(),
         Vector{T0}(),
         Vector{T0}(),
+        Vector{T0}(),
+        Vector{T0}(),
         Int[],
         Float64[])
 
@@ -1307,10 +1326,15 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
     param_streak = 0
     q_streak = 0
     converged = false
+    # Trajectory windows for the half-mean drift stopping test (see SAEM docs).
+    conv_window = method.em.convergence_window
+    θ_window = Vector{T0}[]
+    Q_window = T0[]
     progress_bar = ProgressMeter.Progress(method.em.maxiters; desc = "MCEM",
         enabled = method.progress)
 
     for iter in 1:(method.em.maxiters)
+        mstep_skipped = false
         θt_curr = θ_prev isa ComponentArray ? θ_prev : ComponentArray(θ_prev, axs_free)
         θt_full_curr = ComponentArray(T0.(θ_const_t), axs_full)
 
@@ -1556,6 +1580,7 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
 
         if any(!isfinite, sol.u)
             @warn "MCEM M-step iter $iter: optimizer returned non-finite parameters; skipping update."
+            mstep_skipped = true
             θu_new = θu_curr
             Q_new = Q_prev
         else
@@ -1585,6 +1610,24 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
         dQ_abs = abs(Q_new - Q_prev)
         dQ_rel = dQ_abs / max(T0(1.0), abs(Q_prev))
 
+        # Stopping test: drift between half-window means of the trajectory
+        # (MC-noise robust, unlike successive differences). See the SAEM docs.
+        push!(θ_window, collect(θ_prev_new))
+        push!(Q_window, Q_new)
+        if length(θ_window) > conv_window
+            popfirst!(θ_window)
+            popfirst!(Q_window)
+        end
+        window_full = length(θ_window) == conv_window
+        passθ, driftθ, _ = window_full ?
+                           _half_window_test(θ_window, method.em.atol_theta,
+            method.em.rtol_theta) : (false, T0(NaN), one(T0))
+        passQ, driftQ, _ = window_full ?
+                           _half_window_test(Q_window, method.em.atol_Q,
+            method.em.rtol_Q) : (false, T0(NaN), one(T0))
+        pass_θ = passθ && !mstep_skipped
+        pass_Q = passQ && !mstep_skipped
+
         if method.store_diagnostics && iter % method.diagnostics_every == 0
             push!(diag.θ_hist, θ_prev_new)
         end
@@ -1593,10 +1636,12 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
         push!(diag.dθ_rel, dθ_rel)
         push!(diag.dQ_abs, dQ_abs)
         push!(diag.dQ_rel, dQ_rel)
+        push!(diag.drift_θ, driftθ)
+        push!(diag.drift_Q, driftQ)
         push!(diag.samples, S_diag)
 
         if method.verbose
-            @info "MCEM iteration" iter=iter samples=S_diag Q=Q_new dθ_abs=dθ_abs dθ_rel=dθ_rel dQ_abs=dQ_abs dQ_rel=dQ_rel
+            @info "MCEM iteration" iter=iter samples=S_diag Q=Q_new dθ_abs=dθ_abs dθ_rel=dθ_rel dQ_abs=dQ_abs dQ_rel=dQ_rel drift_θ=driftθ drift_Q=driftQ
         end
         ProgressMeter.next!(progress_bar;
             showvalues = [(:iter, iter), (:samples, S_diag), (:Q, Q_new)])
@@ -1605,17 +1650,8 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
         Q_prev = Q_new
         θu_last = θu_new
 
-        if dθ_abs <= method.em.atol_theta && dθ_rel <= method.em.rtol_theta
-            param_streak += 1
-        else
-            param_streak = 0
-        end
-        if isfinite(dQ_abs) && isfinite(dQ_rel) &&
-           dQ_abs <= method.em.atol_Q && dQ_rel <= method.em.rtol_Q
-            q_streak += 1
-        else
-            q_streak = 0
-        end
+        param_streak = pass_θ ? param_streak + 1 : 0
+        q_streak = pass_Q ? q_streak + 1 : 0
         if param_streak >= method.em.consecutive_params &&
            q_streak >= method.em.consecutive_params
             converged = true
@@ -1634,7 +1670,9 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
     diagnostics = FitDiagnostics((;), (optimizer = method.optimizer,),
         (em_iters = length(diag.Q_hist),
             dθ_abs = isempty(diag.dθ_abs) ? T0(NaN) : diag.dθ_abs[end],
-            dQ_abs = isempty(diag.dQ_abs) ? T0(NaN) : diag.dQ_abs[end]),
+            dQ_abs = isempty(diag.dQ_abs) ? T0(NaN) : diag.dQ_abs[end],
+            drift_θ = isempty(diag.drift_θ) ? T0(NaN) : diag.drift_θ[end],
+            drift_Q = isempty(diag.drift_Q) ? T0(NaN) : diag.drift_Q[end]),
         NamedTuple())
     last_b_candidates = @isdefined(samples_by_batch) ? samples_by_batch : nothing
     eb_modes = store_eb_modes ?

--- a/test/estimation_mcem_tests.jl
+++ b/test/estimation_mcem_tests.jl
@@ -62,6 +62,33 @@ const _MCEM_DM4 = DataModel(_MCEM_MODEL,
     @test method.ebe_rescue.sampling == :lhs
 end
 
+@testset "MCEM windowed drift test triggers early stop" begin
+    # Inf tolerances make every post-window-fill check pass, so the stop point is
+    # deterministic: window fill (4) + consecutive (2) - 1 = iteration 5.
+    res = fit_model(_MCEM_DM2,
+        NoLimits.MCEM(;
+            sampler = MH(), turing_kwargs = (n_samples = 2, n_adapt = 2, progress = false),
+            maxiters = 30, convergence_window = 4, consecutive_params = 2,
+            atol_theta = Inf, rtol_theta = Inf, atol_Q = Inf, rtol_Q = Inf,
+            progress = false))
+    @test NoLimits.get_converged(res)
+    @test 5 <= res.result.iterations < 30
+    diag = res.result.notes.diagnostics
+    @test isnan(diag.drift_θ[1])  # window not yet full
+    @test isfinite(diag.drift_θ[end])
+end
+
+@testset "MCEM no early stop before drift window fills" begin
+    res = fit_model(_MCEM_DM2,
+        NoLimits.MCEM(;
+            sampler = MH(), turing_kwargs = (n_samples = 2, n_adapt = 2, progress = false),
+            maxiters = 3, convergence_window = 4, consecutive_params = 1,
+            atol_theta = Inf, rtol_theta = Inf, atol_Q = Inf, rtol_Q = Inf,
+            progress = false))
+    @test !NoLimits.get_converged(res)
+    @test res.result.iterations == 3
+end
+
 @testset "MCEM basic (random effects)" begin
     res = fit_model(_MCEM_DM2,
         NoLimits.MCEM(;

--- a/test/estimation_saem_tests.jl
+++ b/test/estimation_saem_tests.jl
@@ -596,12 +596,14 @@ end
         @test !NoLimits.get_converged(res)
     end
     @testset "MCEM" begin
+        # Same discrimination for MCEM: θ passes once its window fills (iteration 4)
+        # but Q never does, so the fit must run to maxiters.
         res = fit_model(dm,
-            NoLimits.MCEM(; sampler = MH(), turing_kwargs = tk, maxiters = 2,
-                consecutive_params = 1, atol_theta = Inf, rtol_theta = Inf,
-                atol_Q = 0.0, rtol_Q = 0.0))
-        # If stopping used only parameter tolerance, this would stop after 1 iteration.
-        @test res.result.iterations == 2
+            NoLimits.MCEM(; sampler = MH(), turing_kwargs = tk, maxiters = 8,
+                convergence_window = 4, consecutive_params = 1,
+                atol_theta = Inf, rtol_theta = Inf, atol_Q = 0.0, rtol_Q = 0.0))
+        @test res.result.iterations == 8
+        @test !NoLimits.get_converged(res)
     end
 end
 


### PR DESCRIPTION
## Summary

Port the windowed noise-aware early-stopping criterion from SAEM (#68) to MCEM, replacing its old successive-difference test (same construction as SAEM's pre-#68 criterion, and equally unable to fire at its defaults):

- New `convergence_window = 20` option on `MCEM` (≥ 4); retuned tolerances `rtol_theta = rtol_Q = 1e-3`, `atol_theta = atol_Q = 1e-4` (`consecutive_params = 3` unchanged).
- Stopping rule: the last `convergence_window` iterates (free transformed θ, and Q) are split into halves; each coordinate's drift between the half means must satisfy `drift ≤ max(atol, rtol·scale, 2·mc_se)` for `consecutive_params` consecutive iterations, for both θ and Q. `mc_se` is the Monte-Carlo standard error of the half-mean difference estimated from the window itself. Reuses `_half_window_test` from #68.
- `atol == rtol == 0` disables a test; iterations whose M-step was skipped (non-finite optimizer result) cannot count toward convergence; per-iteration `drift_θ`/`drift_Q` land in the diagnostics, the `FitDiagnostics` summary, and the `verbose` log.

## Calibration (20-subject linear-Gaussian RE model)

- **Fixed small MC sample size** (20–500 samples/E-step, MCMC or IS): the EM iterates keep jittering at sampling scale — they form an AR(1) at the EM contraction rate (~0.9 here, high missing-information fraction) — and the fit correctly runs to `maxiters`. The old criterion's tolerances were equally unreachable in this regime, so no behavior regresses.
- **Growing `sample_schedule`** (classic MCEM practice, e.g. `iter -> min(2000, 100*iter)`): the jitter decays, the EM path flattens, and the fit stops itself: `converged = true` at iteration 142/150 with estimates at the fixed point. This regime is documented in the MCEM docs note.
- Trending runs never fire prematurely (40-iteration runs mid-contraction refuse to stop, drift ~0.03 ≫ threshold).

## Tests

- New deterministic testsets in `estimation_mcem_tests.jl`: early stop fires exactly at window fill + consecutive checks (Inf tolerances), and no stop is possible before the window fills.
- The shared θ-vs-Q stall regression in `estimation_saem_tests.jl` now exercises the windowed mechanics for the MCEM half too (θ passes once the window fills, zero-tolerance Q blocks the stop, fit runs to `maxiters`).
- `estimation_mcem_tests.jl`, `estimation_mcem_is_tests.jl`, and `estimation_saem_tests.jl` all pass locally through the `Pkg.test` sandbox; JuliaFormatter is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
