### PR TITLE
Fix sa_anneal floor being inert on SAEM's closed-form Gaussian variance path

### DIFF
--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -3217,6 +3217,12 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
         # O3: reuse pre-allocated buffer instead of deepcopy each iteration
         copyto!(θ_const_u_work, θ0_u)
         _apply_constants!(θ_const_u_work, iter_constants)
+        # sa_anneal floor for closed-form constants (the free-param clamp below misses them)
+        if do_sa_anneal
+            θ_const_u_work = _saem_apply_sa_anneal_clamp(θ_const_u_work,
+                sa_anneal_targets_eff, sa_anneal_initial_vals, iter, sa_anneal_iters_eff,
+                method.saem.sa_anneal_alpha, method.saem.sa_anneal_schedule)
+        end
         θ_const_t_iter = transform(θ_const_u_work)
         axs_full_iter = getaxes(θ_const_t_iter)
         base_free_names = free_names_iter
@@ -3296,6 +3302,13 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
                     axs_free = getaxes(θt_free)
                     copyto!(θ_const_u_work, θ0_u)
                     _apply_constants!(θ_const_u_work, iter_constants)
+                    # sa_anneal floor for closed-form constants (Q2 path; mirrors site above)
+                    if do_sa_anneal
+                        θ_const_u_work = _saem_apply_sa_anneal_clamp(θ_const_u_work,
+                            sa_anneal_targets_eff, sa_anneal_initial_vals, iter,
+                            sa_anneal_iters_eff, method.saem.sa_anneal_alpha,
+                            method.saem.sa_anneal_schedule)
+                    end
                     θ_const_t_iter = transform(θ_const_u_work)
                     axs_full_iter = getaxes(θ_const_t_iter)
                     base_free_names = free_names_iter

--- a/test/saem_sa_anneal_tests.jl
+++ b/test/saem_sa_anneal_tests.jl
@@ -5,6 +5,7 @@ using Distributions
 using Turing
 using ComponentArrays
 using LinearAlgebra
+using Random
 
 # ── unit tests ────────────────────────────────────────────────────────────────
 
@@ -354,4 +355,31 @@ end
     # First 3 iters should have clamp active (some of them may clamp, some may not)
     # Just verify the diagnostics vector has the right length
     @test length(conv.anneal_active) == length(conv.gamma)
+end
+
+@testset "SA anneal: closed-form variance floored in returned params" begin
+    # Regression: on the built-in closed-form Gaussian M-step path the RE variance is a
+    # constant (θ_const_t), not a free param, so the floor must be applied there — else the
+    # returned estimate (and next-iteration sampling) escape the floor while diagnostics
+    # show it clamped. With uninformative data the closed-form update collapses omega toward
+    # zero, so the floor binds hard and the returned variance must sit at/above it.
+    Random.seed!(20260714)
+    dm = _anneal_dm_mvnormal()
+    maxiters, aiters, alpha = 4, 200, 0.9
+    res = fit_model(dm,
+        NoLimits.SAEM(;
+            sampler = SaemixMH(),
+            maxiters = maxiters, t0 = maxiters, progress = false, q_store_max = 2,
+            builtin_stats = :auto,
+            store_diagnostics = true, diagnostics_every = 1,
+            sa_anneal_iters = aiters, sa_anneal_alpha = alpha,
+            sa_anneal_schedule = :exponential, sa_anneal_targets = (; omega = alpha)))
+    θ = NoLimits.get_params(res; scale = :untransformed)
+    floor_final = NoLimits._saem_sa_anneal_floor_scalar(
+        0.5, alpha, (maxiters - 1) / (aiters - 1), :exponential)
+    @test all(collect(θ.omega) .>= floor_final - 1e-8)
+    # Returned params must agree with the last (floored) diagnostics snapshot — the
+    # plot-vs-get_params discrepancy that surfaced this bug.
+    diag = NoLimits.get_notes(res).diagnostics
+    @test collect(θ.omega) ≈ exp.(collect(diag.θ_hist[end].omega))
 end


### PR DESCRIPTION
## Summary

`sa_anneal` floors RE variances during SAEM to prevent degenerate collapse (variances → 0 while σ blows up). It worked on the numeric free-param path but was **inert on the built-in closed-form Gaussian M-step path** — auto-enabled for `MvNormal`/`Normal` REs, i.e. the common case.

Those variances live in `θ_const_t` as *constants*, not free names. The post-M-step clamp `_saem_apply_sa_anneal_clamp` only writes back `θt_full` + free names, so the floor reached `diag.θ_hist` (diagnostics) but never `θ_const_t` — which is what `get_params` returns and what seeds the next iteration's RE sampling. Net effect: variances collapsed while the diagnostics showed them pinned to the floor (surfaced as a plot-vs-`get_params` disagreement on a Theophylline neural-ODE fit).

## Fix

Reuse the existing `_saem_apply_sa_anneal_clamp` on the `θ_const_u_work` buffer right after `_apply_constants!`, at **both** sites that materialize `iter_constants` into `θ_const_t`:
- the main closed-form / mean-update path
- the Q2 M-step path

Both `var_lb` and `sa_anneal` are raise-only lower-bound clamps, so applying them in any order yields the max of the two floors — no ordering conflict. The post-M-step clamp becomes a no-op for closed-form vars (already floored) but is kept for the free-param path. No new function; net +13 src lines.

Note: `sa_anneal` is auto-enabled by default (`sa_anneal_alpha=0.95`, `sa_anneal_iters = maxiters÷2`) for any Gaussian-RE fit; this makes that default genuinely active.

## Test

Adds one regression testset in `test/saem_sa_anneal_tests.jl` that fits a closed-form Gaussian-RE model with an aggressive `sa_anneal` and asserts the invariant the bug violated: the returned variance is `>= floor` (a hard bound, robust to sampler noise) **and** `get_params` agrees with the last diagnostics snapshot. Fails on `main`, passes with the fix.

## Verification

- New test red→green confirmed. The sandbox exercised the Q2 path (Site B) while a `--project=.` probe hit the main closed-form path (Site A) — both needed fixing.
- Full SAEM test batch + every other file that fits SAEM (cv, multistart, extra_objective, hmm-matrix, markov, uq_edge_cases, accessors, laplace) all green — no value anchors shifted. The tight anchor at `estimation_saem_tests.jl:789` asserts the raw pre-floor update, so it is unaffected.
- JuliaFormatter (sciml) is a no-op.
- End-to-end on the reporting fit: returned max variance now equals the floor (matching the diagnostics), and the previously degenerate σ collapse is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)