### PR TITLE
perf: type-stability + closed-form allocation on the estimation hot path

### DIFF
--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -2572,9 +2572,17 @@ function _loglikelihood_individual(dm::DataModel, idx::Int, θ, η_ind, cache::_
         length(obs_rows))
     sol_acc = sol_accessors === nothing ? NamedTuple() : sol_accessors
     T_el = promote_type(eltype(θ), eltype(η_ind))
-    return _ll_rows_obs(dm, idx, θ, η_ind, cache, sol_accessors,
-        model.formulas.obs, ctx, sol_acc, const_cov, obs_series,
-        vrows, get_obs_cols(dm), T_el)
+    # For ODE models the per-row `obs` is inferred `Any` (the preDE/formula RGFs and
+    # `_ll_solve_de`'s `Union{Nothing,NamedTuple}` accessors are not inferrable), so
+    # `_ll_rows_obs` returns `Any`. The value is always a real scalar of type `T_el`;
+    # `convert` pins the return so `_loglikelihood_individual` (and `_laplace_logf_batch`)
+    # is concrete and callers stop boxing the likelihood. `convert` (not a `::T_el`
+    # assert) is AD-safe: under ForwardDiff/Enzyme it is identity when the value is
+    # already `T_el` (bit-identical) and a correct zero-partial lift otherwise.
+    return convert(T_el,
+        _ll_rows_obs(dm, idx, θ, η_ind, cache, sol_accessors,
+            model.formulas.obs, ctx, sol_acc, const_cov, obs_series,
+            vrows, get_obs_cols(dm), T_el))::T_el
 end
 
 # Row loop of `_loglikelihood_individual` behind a function barrier: every
@@ -2636,8 +2644,15 @@ function _loglikelihood_individual_rowwise(dm::DataModel, idx::Int, θ, η_ind,
     # barrier every per-row `calculate_formulas_obs`/`getproperty`/`logpdf` boxed
     # through `Any`.)
     row_tmpl = _row_re_template(dm, idx, 1, η_ind; obs_only = true)
-    return _ll_rows_obs_rowwise(dm, idx, model, θ, η_ind, cache, sol_accessors,
-        const_cov, obs_series, obs_cols, vary_cache, ind, t_obs, row_tmpl, T_el)
+    # The rowwise row loop still boxes through the `_RowREFill{Any}` template axes
+    # (concrete axes would need a type-stable runtime-keyed ComponentArray), so its
+    # result is inferred `Any`. `convert` pins it to `T_el`, collapsing
+    # `_loglikelihood_individual`'s branch union to a concrete type so callers stop
+    # boxing the LL. AD-safe (identity under ForwardDiff/Enzyme when already `T_el`).
+    return convert(T_el,
+        _ll_rows_obs_rowwise(dm, idx, model, θ, η_ind, cache,
+            sol_accessors, const_cov, obs_series, obs_cols, vary_cache, ind, t_obs,
+            row_tmpl, T_el))::T_el
 end
 
 # Row loop of `_loglikelihood_individual_rowwise` behind a function barrier: with

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -729,12 +729,19 @@ function _laplace_logf_batch(
         dm::DataModel, batch_info::REBatchInfo, θ::ComponentArray,
         b, const_cache::REConstantsCache, cache::_LLCache;
         anneal_sds::NamedTuple = NamedTuple(), tctx = nothing)
+    T = promote_type(eltype(θ), eltype(b))
     try
-        return _laplace_logf_batch_impl(dm, batch_info, θ, b, const_cache, cache;
-            anneal_sds = anneal_sds, tctx = tctx)
+        # The RE-prior terms box through the RE-distribution RGF (`dists_builder` returns
+        # `Any`, a codegen-level limit shared with `calculate_prede`), so the impl infers
+        # `Any`. Pin the batch log-density to `T` here so the differentiated M-step Q
+        # objective (`acc += w*logf` in the Q-core) stays concrete. AD-safe: `convert` is
+        # identity when the value is already `T`, an AD-correct zero-partial lift otherwise.
+        return convert(T,
+            _laplace_logf_batch_impl(dm, batch_info, θ, b, const_cache,
+                cache; anneal_sds = anneal_sds, tctx = tctx))::T
     catch err
         if _is_numeric_error(err)
-            return convert(promote_type(eltype(θ), eltype(b)), -Inf)
+            return convert(T, -Inf)::T
         end
         rethrow(err)
     end
@@ -942,7 +949,9 @@ function _re_logpdf_batch(dm::DataModel,
     const_ll = _const_re_prior_logf(
         dm, batch_info, θ_re, const_cache, cache; anneal_sds = anneal_sds)
     !isfinite(const_ll) && return T_ll(-Inf)
-    return ll + const_ll
+    # Pin to `T_ll`: the prior terms box through the RE-distribution RGF (`Any`), and the
+    # Q2 M-step optimizer differentiates this objective. AD-safe convert (see above).
+    return convert(T_ll, ll + const_ll)::T_ll
 end
 
 # Returns only the RE prior log-density term for a batch (no observation likelihood).

--- a/src/model/closed_form_ode.jl
+++ b/src/model/closed_form_ode.jl
@@ -326,6 +326,28 @@ function _cf_propagate(mode::Symbol, A, b, x0, Δ)
     return _cf_expv(A, b, x0, Δ)
 end
 
+# In-place `_cf_propagate`: writes the advanced state into `out`. Used by
+# `_cf_materialize` to fill a preallocated grid matrix column-by-column, which removes
+# the fresh per-grid-point state vector (the dominant closed-form allocation). The
+# scalar formulas are identical to `_cf_propagate`/`_cf_bateman`, so results are
+# bit-identical; only the storage differs.
+function _cf_propagate!(out, mode::Symbol, A, b, x0, Δ)
+    if mode === :diagonal
+        @inbounds for i in eachindex(x0)
+            out[i] = _cf_state_value(A[i, i], b[i], x0[i], Δ)
+        end
+    elseif mode === :bateman
+        u = iszero(A[1, 2]) ? 1 : 2
+        d = 3 - u
+        @inbounds out[u] = _cf_state_value(A[u, u], b[u], x0[u], Δ)
+        @inbounds out[d] = _cf_state_value(A[d, d], b[d], x0[d], Δ) +
+                           A[d, u] * x0[u] * _cf_expdd(A[u, u], A[d, d], Δ)
+    else
+        out .= _cf_expv(A, b, x0, Δ)  # :linear (opt-in): matrix-exp action, rare
+    end
+    return out
+end
+
 # Full state vector at time `t`: locate its segment (event-free interval), then
 # propagate from that segment's start state with its constant forcing.
 function _cf_state_vector(mode::Symbol, A, seg_t, seg_x0, seg_b, t)
@@ -333,11 +355,21 @@ function _cf_state_vector(mode::Symbol, A, seg_t, seg_x0, seg_b, t)
     return _cf_propagate(mode, A, seg_b[k], seg_x0[k], t - seg_t[k])
 end
 
-# Materialize the state on a whole grid. For `:linear` the augmented matrix and
-# start vector are constant per segment, so they are built once per segment and
-# reused across that segment's grid points (avoids rebuilding them per point).
+# Materialize the state on a whole grid into an `m × length(grid)` matrix (state ×
+# time), one column per grid point. Storing a matrix (a single allocation) instead of a
+# `Vector{Vector}` (one vector per grid point) removes the dominant closed-form
+# allocation; `_cf_propagate!` fills each column in place. Segment lookup and the scalar
+# formulas are unchanged, so the values are bit-identical to the old comprehension.
 function _cf_materialize(mode::Symbol, A, seg_t, seg_x0, seg_b, grid)
-    return [_cf_state_vector(mode, A, seg_t, seg_x0, seg_b, tk) for tk in grid]
+    m = length(seg_x0[1])
+    T = eltype(seg_x0[1])
+    U = Matrix{T}(undef, m, length(grid))
+    @inbounds for kk in eachindex(grid)
+        tk = grid[kk]
+        k = max(searchsortedlast(seg_t, tk), 1)
+        _cf_propagate!(view(U, :, kk), mode, A, seg_b[k], seg_x0[k], tk - seg_t[k])
+    end
+    return U
 end
 
 """
@@ -348,7 +380,8 @@ Solution-shaped object returned by the closed-form fast path. Not an
 accessor. `mode` is `:diagonal` (per-state scalar closed form) or `:linear`
 (matrix-exponential action). The trajectory is piecewise over event-free
 segments (`seg_t`/`seg_x0`/`seg_b`); with no events there is a single segment.
-Carries a materialized `t`/`u` grid for lookup, inspection, and plotting.
+Carries a materialized `t`/`u` grid (state × time matrix) for lookup, inspection,
+and plotting.
 """
 struct ClosedFormLinearSolution{T}
     mode::Symbol
@@ -358,14 +391,14 @@ struct ClosedFormLinearSolution{T}
     seg_x0::Vector{Vector{T}}
     seg_b::Vector{Vector{T}}
     t::Vector{Float64}
-    u::Vector{Vector{T}}
+    u::Matrix{T}
 end
 
 @inline function (s::ClosedFormLinearSolution)(t; idxs::Integer)
     # Exact-time grid lookup first (every :saveat eval time is on the grid), which
     # avoids recomputing the matrix-exp action per state in :linear mode.
     i = searchsortedfirst(s.t, t)
-    (i <= length(s.t) && @inbounds(s.t[i]==t)) && return @inbounds s.u[i][idxs]
+    (i <= length(s.t) && @inbounds(s.t[i]==t)) && return @inbounds s.u[idxs, i]
     return _cf_state_vector(s.mode, s.A, s.seg_t, s.seg_x0, s.seg_b, t)[idxs]
 end
 
@@ -401,8 +434,9 @@ function _closed_form_solve_de(model, compiled, u0::AbstractVector, tspan, savea
     # A[a,b] = ∂f_{idxs[a]}/∂u_{idxs[b]} = f(e_{idxs[b]})[idxs[a]] − b. For a self-
     # contained subset the excluded states are zero in the probe (they don't feed in).
     A = Matrix{T}(undef, m, m)
+    ej = zeros(Float64, n)   # reused across columns (fill! resets each probe)
     for b in 1:m
-        ej = zeros(Float64, n)
+        fill!(ej, 0.0)
         ej[idxs[b]] = 1.0
         col = collect(f(ej, compiled, t0f))
         for a in 1:m


### PR DESCRIPTION
## Summary

Performance work on the SAEM/MCEM estimation hot path — the shared per-individual
likelihood and the closed-form ODE solve, which also feed Laplace/FOCEI/GHQ/Pooled.
All changes are **bit-identical** (no numerical change) and verified **AD-safe under
both ForwardDiff and Enzyme**.

### Type stability
- `_loglikelihood_individual` returned `Any` for every model — the never-taken
  rowwise-RE branch unioned in `Any`, and for ODE models the preDE/formula RGFs and
  `_ll_solve_de`'s `Union{Nothing,NamedTuple}` accessor leak too. It now returns a
  concrete `T_el` via an AD-safe `convert(value, T)::T` boundary pin, de-boxing the
  likelihood in every caller (SAEM/MCEM E-step, Q accumulation, Laplace/FOCEI/GHQ/Pooled).
- `_laplace_logf_batch` / `_re_logpdf_batch` pinned the same way, keeping the
  differentiated M-step objective type-stable.

### Closed-form ODE solve allocation
- `ClosedFormLinearSolution.u`: `Vector{Vector{T}}` → `Matrix{T}` (state × time),
  filled column-by-column by a new in-place `_cf_propagate!` — one allocation instead
  of one state vector per grid point (the dominant closed-form allocation).
- The Jacobian-probe buffer is reused across the `A`-extraction columns.
- `_ll_solve_de` allocation drops **~19%** (M3 3440→2800 B, PK 4544→3696 B).

`convert(...)::T` is the AD-safe pattern: identity when the value is already `T`
(bit-identical), an AD-correct zero-partial lift otherwise, and it never throws — a bare
`::T` assertion would throw on a plain-`Float64`-under-`Dual` likelihood path.

## Verification
- **Golden bit-identical**: function values, ForwardDiff gradients, and fixed-seed serial
  SAEM / MCEM / Laplace / FOCEI fit params and trajectories.
- **ForwardDiff + Enzyme gates green** (0 failures): `enzyme_smoke`, `enzyme_compat_proxy`,
  `ad_random_effects`, `ad_model_full`, `ad_ode_solve`, `ad_differential_equation`,
  `closed_form_ode`, `crossing` (hybrid), `ode_callbacks` (events),
  `estimation_{saem,mcem,laplace,focei,cv}`, `data_simulation`.
- JuliaFormatter (sciml) and Aqua clean.

## Performance note (honest)
The SAEM/MCEM ODE hot loop is **compute-bound** — the analytic `exp`/`expm1` solve
arithmetic and the MH proposals dominate, not dispatch or allocation. These changes buy
~3–5% full-fit wall clock (M3 SAEM 0.283→0.276 s, PK 0.174→0.166 s); the type fixes alone
are wall-clock-neutral here. They land because they are correct, verified, free
(bit-identical), remove AD-unfriendly boxing (which matters more under Enzyme), and cut GC
pressure that compounds at scale/threaded. The one dramatic gap — MCEM ~100× slower than
SAEM — is structural (Turing MCMC E-step) and is a usage recommendation, not a code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
