### PR TITLE
refactor: unify optimizer bounds resolution + Laplace positional theta-merge

### DIFF
--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -606,6 +606,64 @@ function _validate_constant_names(fixed_set, constants::NamedTuple)
     return nothing
 end
 
+# Resolve the transformed free-parameter optimizer bounds shared by the fixed-effect
+# fit drivers (MLE/MAP/Pooled/GHQuadrature/Laplace/FOCEI and the SAEM/MCEM M-step).
+# Coerces user lb/ub (scalar / NamedTuple / ComponentArray / vector) onto the
+# free-name subset, falls back to the model hard bounds, and applies the
+# BlackBoxOptim finite-bounds + model-intersection + start-clamp rules.
+# `ignore_model_bounds`/`allow_bbo`/`emit_info` are args (not read off the method)
+# because SAEM/MCEM have no `ignore_model_bounds` field, FOCEI has no BBO support,
+# and Pooled suppresses the warning after refit round 1. Returns
+# (lb, ub, use_bounds, θ0_init).
+function _resolve_optim_bounds(fe, free_names, θ0_free_t, optimizer, user_lb, user_ub,
+        effective_constants::NamedTuple; ignore_model_bounds::Bool = false,
+        allow_bbo::Bool = true, emit_info::Bool = true,
+        method_label::AbstractString = "this method")
+    lower_t, upper_t = get_bounds_transformed(fe)
+    lower_vec = collect(_ca_subset(lower_t, free_names))
+    upper_vec = collect(_ca_subset(upper_t, free_names))
+    use_bounds = !ignore_model_bounds &&
+                 !(all(isinf, lower_vec) && all(isinf, upper_vec))
+    normalize_bound = function (bound, fallback)
+        bound === nothing && return fallback
+        if bound isa Number
+            length(fallback) == 1 ||
+                error("Scalar bounds are only valid when there is one free parameter.")
+            return [bound]
+        end
+        if bound isa ComponentArray || bound isa NamedTuple
+            b = bound isa ComponentArray ? bound : ComponentArray(bound)
+            return collect(_ca_subset(b, free_names))
+        end
+        return collect(bound)
+    end
+    user_bounds = user_lb !== nothing || user_ub !== nothing
+    if user_bounds && !isempty(keys(effective_constants)) && emit_info
+        @info "Bounds for constant parameters are ignored." constants=collect(keys(effective_constants))
+    end
+    lb = user_bounds ? normalize_bound(user_lb, lower_vec) : lower_vec
+    ub = user_bounds ? normalize_bound(user_ub, upper_vec) : upper_vec
+    use_bounds = use_bounds || user_bounds
+    is_bbo = allow_bbo && parentmodule(typeof(optimizer)) === OptimizationBBO
+    if is_bbo && !use_bounds
+        error("BlackBoxOptim methods require finite bounds. Add lower/upper bounds in " *
+              "@fixedEffects (on transformed scale) or pass them via " *
+              "$(method_label)(lb=..., ub=...). A quick helper is " *
+              "default_bounds_from_start(dm; margin=...).")
+    end
+    if is_bbo && !(all(isfinite, lb) && all(isfinite, ub))
+        error("BlackBoxOptim methods require finite lower and upper bounds for all free parameters.")
+    end
+    if is_bbo
+        lb = map((u, m) -> isfinite(m) ? max(u, m) : u, collect(lb), lower_vec)
+        ub = map((u, m) -> isfinite(m) ? min(u, m) : u, collect(ub), upper_vec)
+        θ0_init = clamp.(collect(θ0_free_t), lb, ub)
+    else
+        θ0_init = θ0_free_t
+    end
+    return lb, ub, use_bounds, θ0_init
+end
+
 function get_iterations(res::MethodResult)
     hasproperty(res, :iterations) ? res.iterations :
     error("iterations not available for this method.")

--- a/src/estimation/ghquadrature.jl
+++ b/src/estimation/ghquadrature.jl
@@ -380,44 +380,9 @@ function _fit_model_scalar(dm::DataModel, method::GHQuadrature, args...;
 
     # ── Bounds ───────────────────────────────────────────────────────────────
     optf = OptimizationFunction(obj, method.adtype)
-    lower_t, upper_t = get_bounds_transformed(fe)
-    lower_t_free = lower_t[free_names]
-    upper_t_free = upper_t[free_names]
-    lower_t_free_vec = collect(lower_t_free)
-    upper_t_free_vec = collect(upper_t_free)
-
-    use_bounds = !method.ignore_model_bounds &&
-                 !(all(isinf, lower_t_free_vec) && all(isinf, upper_t_free_vec))
-    user_bounds = method.lb !== nothing || method.ub !== nothing
-    if user_bounds && !isempty(keys(constants))
-        @info "Bounds for constant parameters are ignored." constants=collect(keys(constants))
-    end
-    if user_bounds
-        lb = method.lb
-        ub = method.ub
-        lb isa ComponentArray && (lb = lb[free_names])
-        ub isa ComponentArray && (ub = ub[free_names])
-    else
-        lb = lower_t_free_vec
-        ub = upper_t_free_vec
-    end
-    use_bounds = use_bounds || user_bounds
-
-    if parentmodule(typeof(method.optimizer)) === OptimizationBBO && !use_bounds
-        error("BlackBoxOptim methods require finite bounds. Add lower/upper bounds " *
-              "in @fixedEffects (on transformed scale) or pass them via " *
-              "GHQuadrature(lb=..., ub=...). A quick helper is " *
-              "default_bounds_from_start(dm; margin=...).")
-    end
-    if parentmodule(typeof(method.optimizer)) === OptimizationBBO
-        model_lb_v = lower_t_free_vec
-        model_ub_v = upper_t_free_vec
-        lb = map((u, m) -> isfinite(m) ? max(u, m) : u, collect(lb), model_lb_v)
-        ub = map((u, m) -> isfinite(m) ? min(u, m) : u, collect(ub), model_ub_v)
-        θ0_init = clamp.(collect(θ0_free_t), lb, ub)
-    else
-        θ0_init = θ0_free_t
-    end
+    lb, ub, use_bounds, θ0_init = _resolve_optim_bounds(
+        fe, free_names, θ0_free_t, method.optimizer, method.lb, method.ub, constants;
+        ignore_model_bounds = method.ignore_model_bounds, method_label = "GHQuadrature")
 
     prob = use_bounds ? OptimizationProblem(optf, θ0_init; lb = lb, ub = ub) :
            OptimizationProblem(optf, θ0_init)

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -2340,6 +2340,10 @@ function _fit_laplace_family(dm::DataModel, method, hmode::_HessMode, args, fit_
     θ0_free_t = θ0_t[free_names]
     axs_free = getaxes(θ0_free_t)
     axs_full = getaxes(θ_const_t)
+    # Positional free-into-full merge (Enzyme-safe; avoids the per-name setproperty!
+    # loop). free_idx/θ_const_t_vec are fit-constant, so compute them once here.
+    θ_const_t_vec = collect(θ_const_t)
+    free_idx = _free_idx(θ_const_t, θ0_free_t)
     has_penalty = !isempty(keys(penalty))
     # Optional user-supplied objective term, a function of the natural-scale θu.
     # Mirrors `penalty` exactly: added to both obj_only and obj_grad, no-op when
@@ -2358,10 +2362,7 @@ function _fit_laplace_family(dm::DataModel, method, hmode::_HessMode, args, fit_
         cached_obj !== nothing && return cached_obj
         T = eltype(θt_free)
         infT = convert(T, Inf)
-        θt_full = ComponentArray(T.(θ_const_t), axs_full)
-        for name in free_names
-            setproperty!(θt_full, name, getproperty(θt_free, name))
-        end
+        θt_full = _merge_free_into_full(θ_const_t_vec, free_idx, θt_free, axs_full)
         θu = inv_transform(θt_full)
         obj = _laplace_objective_only(
             dm, batch_infos, θu, const_cache, ll_cache, ebe_cache;
@@ -2388,10 +2389,7 @@ function _fit_laplace_family(dm::DataModel, method, hmode::_HessMode, args, fit_
         end
         T = eltype(θt_free)
         infT = convert(T, Inf)
-        θt_full = ComponentArray(T.(θ_const_t), axs_full)
-        for name in free_names
-            setproperty!(θt_full, name, getproperty(θt_free, name))
-        end
+        θt_full = _merge_free_into_full(θ_const_t_vec, free_idx, θt_free, axs_full)
         θu = inv_transform(θt_full)
         obj, grad_full, bstars = _laplace_objective_and_grad(
             dm, batch_infos, θu, const_cache, ll_cache, ebe_cache;
@@ -2452,45 +2450,10 @@ function _fit_laplace_family(dm::DataModel, method, hmode::_HessMode, args, fit_
             grad = obj_grad(θt, p)[2]
             G .= grad
         end)
-    lower_t, upper_t = get_bounds_transformed(fe)
-    lower_t_free = lower_t[free_names]
-    upper_t_free = upper_t[free_names]
-    use_bounds = !method.ignore_model_bounds &&
-                 !(all(isinf, lower_t_free) && all(isinf, upper_t_free))
-    user_bounds = method.lb !== nothing || method.ub !== nothing
-    if user_bounds && !isempty(keys(constants))
-        @info "Bounds for constant parameters are ignored." constants=collect(keys(constants))
-    end
-    if user_bounds
-        lb = method.lb
-        ub = method.ub
-        if lb isa ComponentArray
-            lb = lb[free_names]
-        end
-        if ub isa ComponentArray
-            ub = ub[free_names]
-        end
-    else
-        lb = lower_t_free
-        ub = upper_t_free
-    end
-    use_bounds = use_bounds || user_bounds
-    if allow_bbo && parentmodule(typeof(method.optimizer)) === OptimizationBBO &&
-       !use_bounds
-        error("BlackBoxOptim methods require finite bounds. Add lower/upper bounds in @fixedEffects (on transformed scale) or pass them via Laplace(lb=..., ub=...). A quick helper is default_bounds_from_start(dm; margin=...).")
-    end
-    if allow_bbo && parentmodule(typeof(method.optimizer)) === OptimizationBBO
-        # Intersect user-provided bounds with model hard bounds so BBO
-        # never proposes parameter values that violate model constraints.
-        # (BBO ignores x0 and uses a random population within [lb,ub].)
-        model_lb_v = collect(lower_t_free)
-        model_ub_v = collect(upper_t_free)
-        lb = map((u, m) -> isfinite(m) ? max(u, m) : u, collect(lb), model_lb_v)
-        ub = map((u, m) -> isfinite(m) ? min(u, m) : u, collect(ub), model_ub_v)
-        θ0_init = clamp.(collect(θ0_free_t), lb, ub)
-    else
-        θ0_init = θ0_free_t
-    end
+    lb, ub, use_bounds, θ0_init = _resolve_optim_bounds(
+        fe, free_names, θ0_free_t, method.optimizer, method.lb, method.ub, constants;
+        ignore_model_bounds = method.ignore_model_bounds, allow_bbo = allow_bbo,
+        method_label = "Laplace")
     prob = use_bounds ? OptimizationProblem(optf, θ0_init; lb = lb, ub = ub) :
            OptimizationProblem(optf, θ0_init)
     sol = Optimization.solve(prob, method.optimizer; method.optim_kwargs...)

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -1457,7 +1457,6 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
         mstep_constants = constants
         let q2_free_now = [n for n in q2_base_free_names if n ∉ keys(mstep_constants)]
             if !isempty(q2_free_now)
-                lower_t_q2_all, upper_t_q2_all = get_bounds_transformed(fe)
                 θt_q2 = ComponentArray(NamedTuple{Tuple(q2_free_now)}(
                     Tuple(getproperty(θt_full_curr, n) for n in q2_free_now)))
                 axs_q2 = getaxes(θt_q2)
@@ -1476,10 +1475,9 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
                     isfinite(Q2val) || return T(Inf)
                     return -Q2val
                 end
-                lb_q2 = collect(_ca_subset(lower_t_q2_all, q2_free_now))
-                ub_q2 = collect(_ca_subset(upper_t_q2_all, q2_free_now))
-                use_bounds_q2 = !(all(isinf, lb_q2) && all(isinf, ub_q2))
-                θ0_q2 = collect(θt_q2)
+                lb_q2, ub_q2, use_bounds_q2, θ0_q2 = _resolve_optim_bounds(
+                    fe, q2_free_now, collect(θt_q2), method.optimizer, nothing,
+                    nothing, NamedTuple(); allow_bbo = false)
                 optf_q2 = OptimizationFunction(obj_q2, method.adtype)
                 prob_q2 = use_bounds_q2 ?
                           OptimizationProblem(optf_q2, θ0_q2; lb = lb_q2, ub = ub_q2) :
@@ -1542,38 +1540,10 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
         end
 
         optf = OptimizationFunction(obj_only, method.adtype)
-        lower_t, upper_t = get_bounds_transformed(fe)
-
-        lower_t_free_iter = _ca_subset(lower_t, free_names_q1)
-        upper_t_free_iter = _ca_subset(upper_t, free_names_q1)
-        lower_t_free_vec = collect(lower_t_free_iter)
-        upper_t_free_vec = collect(upper_t_free_iter)
-        use_bounds = !(all(isinf, lower_t_free_vec) && all(isinf, upper_t_free_vec))
-        user_bounds = method.lb !== nothing || method.ub !== nothing
-        if user_bounds && !isempty(keys(constants))
-            @info "Bounds for constant parameters are ignored." constants=collect(keys(constants))
-        end
-        if user_bounds
-            lb_m = method.lb
-            ub_m = method.ub
-            if lb_m isa ComponentArray
-                lb_m = _ca_subset(lb_m, free_names_q1)
-            end
-            if ub_m isa ComponentArray
-                ub_m = _ca_subset(ub_m, free_names_q1)
-            end
-            lb_m = lb_m === nothing ? lower_t_free_vec : collect(lb_m)
-            ub_m = ub_m === nothing ? upper_t_free_vec : collect(ub_m)
-        else
-            lb_m = lower_t_free_vec
-            ub_m = upper_t_free_vec
-        end
-        use_bounds = use_bounds || user_bounds
-        if parentmodule(typeof(method.optimizer)) === OptimizationBBO && !use_bounds
-            error("BlackBoxOptim methods require finite bounds. Add lower/upper bounds in @fixedEffects (on transformed scale) or pass them via MCEM(lb=..., ub=...). A quick helper is default_bounds_from_start(dm; margin=...).")
-        end
-        θ0_init = collect(θt_free_iter)
-        prob = use_bounds ? OptimizationProblem(optf, θ0_init; lb = lb_m, ub = ub_m) :
+        lb, ub, use_bounds, θ0_init = _resolve_optim_bounds(
+            fe, free_names_q1, collect(θt_free_iter), method.optimizer, method.lb,
+            method.ub, constants; method_label = "MCEM")
+        prob = use_bounds ? OptimizationProblem(optf, θ0_init; lb = lb, ub = ub) :
                OptimizationProblem(optf, θ0_init)
 
         sol = Optimization.solve(prob, method.optimizer; method.optim_kwargs...)

--- a/src/estimation/mle.jl
+++ b/src/estimation/mle.jl
@@ -138,57 +138,9 @@ function _fit_no_re(dm::DataModel, method;
     end
 
     optf = OptimizationFunction(obj, method.adtype)
-    lower_t, upper_t = get_bounds_transformed(fe)
-    lower_t_free = _ca_subset(lower_t, free_names)
-    upper_t_free = _ca_subset(upper_t, free_names)
-    lower_t_free_vec = collect(lower_t_free)
-    upper_t_free_vec = collect(upper_t_free)
-    use_bounds = !method.ignore_model_bounds &&
-                 !(all(isinf, lower_t_free_vec) && all(isinf, upper_t_free_vec))
-    normalize_bound = function (bound, fallback)
-        if bound === nothing
-            return fallback
-        elseif bound isa Number
-            length(fallback) == 1 ||
-                error("Scalar bounds are only valid when there is one free parameter.")
-            return [bound]
-        end
-        if bound isa ComponentArray || bound isa NamedTuple
-            bound_ca = bound isa ComponentArray ? bound : ComponentArray(bound)
-            bound_ca = _ca_subset(bound_ca, free_names)
-            return collect(bound_ca)
-        end
-        return collect(bound)
-    end
-    user_bounds = method.lb !== nothing || method.ub !== nothing
-    if user_bounds && !isempty(keys(constants))
-        @info "Bounds for constant parameters are ignored." constants=collect(keys(constants))
-    end
-    if user_bounds
-        lb = normalize_bound(method.lb, lower_t_free_vec)
-        ub = normalize_bound(method.ub, upper_t_free_vec)
-    else
-        lb = lower_t_free_vec
-        ub = upper_t_free_vec
-    end
-    use_bounds = use_bounds || user_bounds
-    if parentmodule(typeof(method.optimizer)) === OptimizationBBO && !use_bounds
-        error("BlackBoxOptim methods require finite bounds. Add lower/upper bounds in @fixedEffects (on transformed scale) or pass them via MLE(lb=..., ub=...). A quick helper is default_bounds_from_start(dm; margin=...).")
-    end
-    if parentmodule(typeof(method.optimizer)) === OptimizationBBO &&
-       !(all(isfinite, lb) && all(isfinite, ub))
-        error("BlackBoxOptim methods require finite lower and upper bounds for all free parameters.")
-    end
-    if parentmodule(typeof(method.optimizer)) === OptimizationBBO
-        # Intersect user-provided bounds with model hard bounds so BBO
-        # never proposes parameter values that violate model constraints.
-        # (BBO ignores x0 and uses a random population within [lb,ub].)
-        lb = map((u, m) -> isfinite(m) ? max(u, m) : u, collect(lb), lower_t_free_vec)
-        ub = map((u, m) -> isfinite(m) ? min(u, m) : u, collect(ub), upper_t_free_vec)
-        θ0_init = clamp.(collect(θ0_free_t), lb, ub)
-    else
-        θ0_init = θ0_free_t
-    end
+    lb, ub, use_bounds, θ0_init = _resolve_optim_bounds(
+        fe, free_names, θ0_free_t, method.optimizer, method.lb, method.ub, constants;
+        ignore_model_bounds = method.ignore_model_bounds, method_label = "MLE")
     prob = use_bounds ? OptimizationProblem(optf, θ0_init; lb = lb, ub = ub) :
            OptimizationProblem(optf, θ0_init)
     sol = Optimization.solve(prob, method.optimizer; method.optim_kwargs...)

--- a/src/estimation/pooled.jl
+++ b/src/estimation/pooled.jl
@@ -1116,47 +1116,10 @@ function _pooled_solve(dm::DataModel, method, θ_start_u::ComponentArray,
     end
 
     optf = OptimizationFunction(obj, method.adtype)
-    lower_t, upper_t = get_bounds_transformed(fe)
-    lower_t_free = _ca_subset(lower_t, free_names)
-    upper_t_free = _ca_subset(upper_t, free_names)
-    lower_t_free_vec = collect(lower_t_free)
-    upper_t_free_vec = collect(upper_t_free)
-    use_bounds = !method.ignore_model_bounds &&
-                 !(all(isinf, lower_t_free_vec) && all(isinf, upper_t_free_vec))
-    normalize_bound = function (bound, fallback)
-        bound === nothing && return fallback
-        bound isa Number && (length(fallback) == 1 ||
-            error("Scalar bounds are only valid when there is one free parameter.");
-        return [bound])
-        if bound isa ComponentArray || bound isa NamedTuple
-            b = bound isa ComponentArray ? bound : ComponentArray(bound)
-            b = _ca_subset(b, free_names)
-            return collect(b)
-        end
-        return collect(bound)
-    end
-    user_bounds = method.lb !== nothing || method.ub !== nothing
-    if user_bounds && !isempty(keys(merged_constants)) && info_bounds
-        @info "Bounds for constant parameters are ignored." constants=collect(keys(merged_constants))
-    end
-    lb = user_bounds ? normalize_bound(method.lb, lower_t_free_vec) : lower_t_free_vec
-    ub = user_bounds ? normalize_bound(method.ub, upper_t_free_vec) : upper_t_free_vec
-    use_bounds = use_bounds || user_bounds
-    if parentmodule(typeof(method.optimizer)) === OptimizationBBO && !use_bounds
-        error("BlackBoxOptim requires finite bounds. Pass them via Pooled(lb=..., ub=...) " *
-              "or use default_bounds_from_start(dm; margin=...).")
-    end
-    if parentmodule(typeof(method.optimizer)) === OptimizationBBO &&
-       !(all(isfinite, lb) && all(isfinite, ub))
-        error("BlackBoxOptim requires finite lower and upper bounds for all free parameters.")
-    end
-    if parentmodule(typeof(method.optimizer)) === OptimizationBBO
-        lb = map((u, m) -> isfinite(m) ? max(u, m) : u, collect(lb), lower_t_free_vec)
-        ub = map((u, m) -> isfinite(m) ? min(u, m) : u, collect(ub), upper_t_free_vec)
-        θ0_init = clamp.(collect(θ0_free_t), lb, ub)
-    else
-        θ0_init = θ0_free_t
-    end
+    lb, ub, use_bounds, θ0_init = _resolve_optim_bounds(
+        fe, free_names, θ0_free_t, method.optimizer, method.lb, method.ub, merged_constants;
+        ignore_model_bounds = method.ignore_model_bounds, emit_info = info_bounds,
+        method_label = "Pooled")
     prob = use_bounds ? OptimizationProblem(optf, θ0_init; lb = lb, ub = ub) :
            OptimizationProblem(optf, θ0_init)
     sol = Optimization.solve(prob, method.optimizer; method.optim_kwargs...)

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -3232,11 +3232,9 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
                     isfinite(Q2val) || return T(Inf)
                     return -Q2val
                 end
-                lower_t_q2, upper_t_q2 = get_bounds_transformed(fe)
-                lb_q2 = collect(_ca_subset(lower_t_q2, q2_free_now))
-                ub_q2 = collect(_ca_subset(upper_t_q2, q2_free_now))
-                use_bounds_q2 = !(all(isinf, lb_q2) && all(isinf, ub_q2))
-                θ0_q2 = collect(θt_q2)
+                lb_q2, ub_q2, use_bounds_q2, θ0_q2 = _resolve_optim_bounds(
+                    fe, q2_free_now, collect(θt_q2), method.optimizer, nothing,
+                    nothing, NamedTuple(); allow_bbo = false)
                 optf_q2 = OptimizationFunction(obj_q2, method.adtype)
                 prob_q2 = use_bounds_q2 ?
                           OptimizationProblem(optf_q2, θ0_q2; lb = lb_q2, ub = ub_q2) :
@@ -3354,36 +3352,9 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
             end
 
             optf = OptimizationFunction(obj_only, method.adtype)
-            lower_t, upper_t = get_bounds_transformed(fe)
-            lower_t_free = _ca_subset(lower_t, free_names_iter)
-            upper_t_free = _ca_subset(upper_t, free_names_iter)
-            lower_t_free_vec = collect(lower_t_free)
-            upper_t_free_vec = collect(upper_t_free)
-            use_bounds = !(all(isinf, lower_t_free_vec) && all(isinf, upper_t_free_vec))
-            user_bounds = method.lb !== nothing || method.ub !== nothing
-            if user_bounds && !isempty(keys(constants))
-                @info "Bounds for constant parameters are ignored." constants=collect(keys(constants))
-            end
-            if user_bounds
-                lb = method.lb
-                ub = method.ub
-                if lb isa ComponentArray
-                    lb = _ca_subset(lb, free_names_iter)
-                end
-                if ub isa ComponentArray
-                    ub = _ca_subset(ub, free_names_iter)
-                end
-                lb = lb === nothing ? lower_t_free_vec : collect(lb)
-                ub = ub === nothing ? upper_t_free_vec : collect(ub)
-            else
-                lb = lower_t_free_vec
-                ub = upper_t_free_vec
-            end
-            use_bounds = use_bounds || user_bounds
-            if parentmodule(typeof(method.optimizer)) === OptimizationBBO && !use_bounds
-                error("BlackBoxOptim methods require finite bounds. Add lower/upper bounds in @fixedEffects (on transformed scale) or pass them via SAEM(lb=..., ub=...). A quick helper is default_bounds_from_start(dm; margin=...).")
-            end
-            θ0_init = collect(θt_free)
+            lb, ub, use_bounds, θ0_init = _resolve_optim_bounds(
+                fe, free_names_iter, collect(θt_free), method.optimizer,
+                method.lb, method.ub, constants; method_label = "SAEM")
             prob = use_bounds ? OptimizationProblem(optf, θ0_init; lb = lb, ub = ub) :
                    OptimizationProblem(optf, θ0_init)
             if method.saem.suffstats !== nothing &&


### PR DESCRIPTION
## Summary

Follow-up to #76 — single-sources the last big cross-driver duplication in the estimation layer. **7 files, net −158 lines**, bit-identical (full estimator suite + Aqua green).

## `_resolve_optim_bounds`

The ~50-line "resolve transformed free-parameter bounds + BlackBoxOptim finite-bounds/intersection/clamp rules" block was copy-pasted across MLE, Pooled, GHQuadrature, Laplace/FOCEI, SAEM and MCEM — and had drifted. It's now one helper in `common.jl` with 8 call sites (MAP rides `_fit_no_re`).

**Why the drivers differed — and whether it was needed** (investigated before refactoring):

- **GHQuadrature → all drift.** It assigned `method.lb`/`ub` directly (no scalar / NamedTuple / one-sided coercion) and lacked the second all-finite BBO guard. Unifying is bit-identical for the suite (its only bounds test uses a full-keyed finite ComponentArray) and **closes a latent gap** — GHQuadrature now accepts scalar/NamedTuple/one-sided user bounds like MLE.
- **SAEM/MCEM → one real difference.** Their method structs have **no `ignore_model_bounds` field**, so it becomes a helper arg defaulting to `false` (reproduces current behavior exactly). Their Q1 M-step is the *same* operation and *does* consult user `lb`/`ub`; the Q2 dispersion sub-steps reuse the helper with `user_lb=nothing, allow_bbo=false`. Proven bit-identical (`σ`'s `EPSILON=0.0` → transformed bounds `(-Inf,+Inf)` → the intersection/clamp are no-ops).
- **Required knobs kept:** FOCEI has no BBO support (`allow_bbo=false`); Pooled suppresses the constants+bounds `@info` after refit round 1 (`emit_info`) and passes `merged_constants` (its auto-frozen params).

## Laplace θ-merge

Migrated Laplace/FOCEI's per-name `setproperty!` θ-merge in the hot objective closures (`obj_only` / `obj_grad`) to the positional `_merge_free_into_full` — Enzyme-safe, avoids per-eval dynamic dispatch. A dedup **and** a hot-path win. Laplace's exact-`==` goldens confirm it's bit-identical.

## Deliberately left deferred

The result-packer and `_solve_free_fixed` (`_fit_no_re` vs `_pooled_solve`) unifications — the investigation confirmed they genuinely diverge (incompatible result-struct shapes; different return contracts + cache ownership), so forcing them together buys little for real risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
