### PR TITLE
feat: exact 2nd-order ForwardDiff for :expm/:lie covariances + dedups

### DIFF
--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -606,6 +606,14 @@ function _validate_constant_names(fixed_set, constants::NamedTuple)
     return nothing
 end
 
+# True when the model's fixed effects declare at least one non-`Priorless` prior
+# (the priors-present check MAP/PooledMap require). Mirrors the previous inline logic.
+function _has_fixed_priors(fe)
+    priors = get_priors(fe)
+    return !isempty(keys(priors)) &&
+           any(!(getfield(priors, k) isa Priorless) for k in keys(priors))
+end
+
 # Resolve the transformed free-parameter optimizer bounds shared by the fixed-effect
 # fit drivers (MLE/MAP/Pooled/GHQuadrature/Laplace/FOCEI and the SAEM/MCEM M-step).
 # Coerces user lb/ub (scalar / NamedTuple / ComponentArray / vector) onto the

--- a/src/estimation/map.jl
+++ b/src/estimation/map.jl
@@ -79,9 +79,7 @@ function _fit_model(dm::DataModel, method::MAP, args...;
         theta_0_untransformed::Union{Nothing, ComponentArray} = nothing,
         store_data_model::Bool = true)
     fe = get_fixed(get_model(dm))
-    priors = get_priors(fe)
-    has_prior = !isempty(keys(priors)) &&
-                any(!(getfield(priors, k) isa Priorless) for k in keys(priors))
+    has_prior = _has_fixed_priors(fe)
     has_prior ||
         error("MAP requires priors on fixed effects. Define priors in @fixedEffects (e.g., RealNumber(...; prior=Normal(...))) or use MLE instead.")
 

--- a/src/estimation/pooled.jl
+++ b/src/estimation/pooled.jl
@@ -1221,9 +1221,7 @@ function _fit_model(dm::DataModel, method::PooledMap, args...;
           "Use MAP() for fixed-effects-only models.")
 
     fe = get_fixed(get_model(dm))
-    priors = get_priors(fe)
-    has_prior = !isempty(keys(priors)) &&
-                any(!(getfield(priors, k) isa Priorless) for k in keys(priors))
+    has_prior = _has_fixed_priors(fe)
     has_prior || error("PooledMap() requires priors on fixed effects. Define priors in " *
           "@fixedEffects (e.g. RealNumber(...; prior=Normal(...))) or use Pooled() instead.")
 

--- a/src/model/DifferentialEquation.jl
+++ b/src/model/DifferentialEquation.jl
@@ -745,9 +745,7 @@ macro DifferentialEquation(block)
     call_syms = Set([s
                      for s in call_syms
                      if !(isdefined(Base, s) || isdefined(@__MODULE__, s))])
-    var_syms = Set([s for s in var_syms if Base.isidentifier(s)])
-    skip_vars = Set([:Inf, :NaN, :nothing, :missing, :true, :false])
-    var_syms = Set([s for s in var_syms if !(s in skip_vars)])
+    var_syms = _macro_filter_var_syms(var_syms)
 
     var_syms_no_states = Set([s
                               for s in var_syms

--- a/src/model/Formulas.jl
+++ b/src/model/Formulas.jl
@@ -659,9 +659,7 @@ macro formulas(block)
                     for s in call_heads
                     if !(isdefined(Base, s) || isdefined(Distributions, s) ||
                          isdefined(@__MODULE__, s))])
-    var_syms = Set([s for s in var_syms if Base.isidentifier(s)])
-    skip_vars = Set([:Inf, :NaN, :nothing, :missing, :true, :false])
-    var_syms = Set([s for s in var_syms if !(s in skip_vars)])
+    var_syms = _macro_filter_var_syms(var_syms)
 
     crossing_specs = Expr[]
     for i in eachindex(det_names)

--- a/src/model/InitialDE.jl
+++ b/src/model/InitialDE.jl
@@ -91,9 +91,7 @@ macro initialDE(block)
     call_syms = Set([s
                      for s in call_syms
                      if !(isdefined(Base, s) || isdefined(@__MODULE__, s))])
-    var_syms = Set([s for s in var_syms if Base.isidentifier(s)])
-    skip_vars = Set([:Inf, :NaN, :nothing, :missing, :true, :false])
-    var_syms = Set([s for s in var_syms if !(s in skip_vars)])
+    var_syms = _macro_filter_var_syms(var_syms)
 
     meta = InitialDEMeta(collect(names))
     ir = InitialDEIR(

--- a/src/model/MacroUtils.jl
+++ b/src/model/MacroUtils.jl
@@ -104,6 +104,17 @@ function _macro_collect_property_bases(ex, out::Set{Symbol})
     return out
 end
 
+# Trailing var-symbol filter shared verbatim by @preDifferentialEquation,
+# @DifferentialEquation, @initialDE, and @formulas: drop non-identifiers and the
+# literal keyword symbols. The preceding delete!/call-symbol filters differ per
+# macro and stay inline at each call site.
+function _macro_filter_var_syms(var_syms::Set{Symbol})
+    var_syms = Set([s for s in var_syms if Base.isidentifier(s)])
+    skip_vars = Set([:Inf, :NaN, :nothing, :missing, :true, :false])
+    var_syms = Set([s for s in var_syms if !(s in skip_vars)])
+    return var_syms
+end
+
 function _macro_forbidden_symbol(ex)
     ex isa Symbol && (ex == :t || ex == :ξ) && return ex
     ex isa Expr || return nothing

--- a/src/model/PreDE.jl
+++ b/src/model/PreDE.jl
@@ -153,9 +153,7 @@ macro preDifferentialEquation(block)
                      for s in call_syms
                      if !(isdefined(Base, s) || isdefined(Distributions, s) ||
                           isdefined(@__MODULE__, s))])
-    var_syms = Set([s for s in var_syms if Base.isidentifier(s)])
-    skip_vars = Set([:Inf, :NaN, :nothing, :missing, :true, :false])
-    var_syms = Set([s for s in var_syms if !(s in skip_vars)])
+    var_syms = _macro_filter_var_syms(var_syms)
 
     # `sym in prop_syms` is decidable at macro-expansion time — emit the chosen
     # branch directly. (The old code carried the membership test into the generated

--- a/src/uq/common.jl
+++ b/src/uq/common.jl
@@ -396,6 +396,9 @@ function _hessian_from_objective(obj::Function,
     if backend_use == :forwarddiff
         try
             H = ForwardDiff.hessian(obj, x0)
+            all(isfinite, H) ||
+                error("ForwardDiff Hessian has non-finite entries (e.g. a NaN " *
+                      "covariance derivative at repeated eigenvalues).")
             return Matrix{Float64}(0.5 .* (H .+ H')), :forwarddiff
         catch err
             @warn "ForwardDiff Hessian failed in compute_uq; falling back to finite-difference Hessian from gradients." error=sprint(

--- a/src/utils/ParameterTranformations.jl
+++ b/src/utils/ParameterTranformations.jl
@@ -496,6 +496,38 @@ function expm_inverse(T::AbstractMatrix{<:Real})
     return Matrix(Symmetric(exp(Symmetric(T))))
 end
 
+# Recursively strip ForwardDiff.Dual levels to the underlying float (used only for the
+# non-differentiated scaling-and-squaring count in `_matexp`).
+_scalar_value(x::Real) = float(x)
+_scalar_value(x::ForwardDiff.Dual) = _scalar_value(ForwardDiff.value(x))
+
+# Matrix exponential dispatched on eltype: BLAS-exact `exp` for Blas floats (keeps the
+# value and single-level Fréchet paths bit-identical), and a Dual-generic scaling-and-
+# squaring Padé (Higham degree 13; only +, *, \, I) for Dual eltypes, which arise only at
+# 2nd+ ForwardDiff order (nested Hessian) where `exp(::Matrix{Dual})` has no BLAS method.
+_matexp(M::AbstractMatrix{<:LinearAlgebra.BlasFloat}) = exp(M)
+
+function _matexp(M::AbstractMatrix{<:Real})
+    b = (64764752532480000.0, 32382376266240000.0, 7771770303897600.0,
+        1187353796428800.0, 129060195264000.0, 10559470521600.0, 670442572800.0,
+        33522128640.0, 1323241920.0, 40840800.0, 960960.0, 16380.0, 182.0, 1.0)
+    nrm = opnorm(_scalar_value.(M), 1)
+    s = nrm > 5.371920351148152 ? ceil(Int, log2(nrm / 5.371920351148152)) : 0
+    A = M ./ 2.0^s
+    A2 = A * A
+    A4 = A2 * A2
+    A6 = A2 * A4
+    Uodd = A * (A6 * (b[14] * A6 + b[12] * A4 + b[10] * A2) +
+            b[8] * A6 + b[6] * A4 + b[4] * A2 + b[2] * I)
+    Veven = A6 * (b[13] * A6 + b[11] * A4 + b[9] * A2) +
+            b[7] * A6 + b[5] * A4 + b[3] * A2 + b[1] * I
+    P = (Veven - Uodd) \ (Veven + Uodd)
+    for _ in 1:s
+        P = P * P
+    end
+    return P
+end
+
 function _expm_frechet(A::AbstractMatrix{<:Real}, E::AbstractMatrix{<:Real})
     n = size(A, 1)
     size(A, 2) == n || error("A must be square.")
@@ -503,7 +535,7 @@ function _expm_frechet(A::AbstractMatrix{<:Real}, E::AbstractMatrix{<:Real})
     TT = promote_type(eltype(A), eltype(E))
     Z = zeros(TT, n, n)
     M = [Matrix{TT}(A) Matrix{TT}(E); Z Matrix{TT}(A)]
-    EM = exp(M)
+    EM = _matexp(M)
     return EM[1:n, 1:n], EM[1:n, (n + 1):(2n)]
 end
 
@@ -529,6 +561,29 @@ function expm_inverse(T::AbstractMatrix{ForwardDiff.Dual{
         Ek = 0.5 .* (Pk .+ Pk')                      # symmetric seed direction
         _, F = _expm_frechet(Sv, Ek)
         Matrix(Symmetric(F))                          # symmetric Fréchet derivative
+    end
+    out = Matrix{ForwardDiff.Dual{Tg, V, N}}(undef, n, n)
+    @inbounds for j in 1:n, i in 1:n
+        out[i, j] = ForwardDiff.Dual{Tg}(Mv[i, j], ntuple(k -> dMs[k][i, j], N)...)
+    end
+    return out
+end
+
+# Nested Duals (2nd+-order ForwardDiff, e.g. a Hessian through the transform): recurse on
+# the value (bottoming out at the Float64 eigen leaf, so the value stays bit-identical) and
+# take each partial via the Padé Fréchet derivative, whose inner matrix-exp routes through
+# the Dual-generic `_matexp`. Removes the finite-difference Hessian fallback for `:expm`.
+function expm_inverse(T::AbstractMatrix{ForwardDiff.Dual{
+        Tg, V, N}}) where {Tg, V <: ForwardDiff.Dual, N}
+    n = size(T, 1)
+    Tv = ForwardDiff.value.(T)
+    Sv = 0.5 .* (Tv .+ Tv')
+    Mv = expm_inverse(Tv)
+    dMs = ntuple(N) do k
+        Pk = ForwardDiff.partials.(T, k)
+        Ek = 0.5 .* (Pk .+ Pk')
+        _, F = _expm_frechet(Sv, Ek)
+        Matrix(Symmetric(F))
     end
     out = Matrix{ForwardDiff.Dual{Tg, V, N}}(undef, n, n)
     @inbounds for j in 1:n, i in 1:n
@@ -576,9 +631,9 @@ end
 # so the transformed vector is [λ (n) ; α (nA)] with nA = n(n-1)/2 (total n(n+1)/2).
 # The log-eigenvalues λ live on ℝ (eigenvalues stay positive) and can be box-bounded;
 # the rotation coefficients α are unbounded. `exp(A)` for antisymmetric A is a general
-# (non-symmetric) matrix exponential, so it goes through the generic Padé path under
-# ForwardDiff (no eigengap issue, unlike the symmetric `:expm` scale) and needs no
-# `Dual` specialization.
+# (non-symmetric) matrix exponential with no eigengap issue (unlike the symmetric `:expm`
+# scale); its single- and nested-Dual derivatives are built from the Padé Fréchet block
+# below (`_expm_frechet`, routed through the Dual-generic `_matexp`).
 
 # Recover n from the packed length L = n(n+1)/2.
 function _lie_dim(L::Int)
@@ -657,6 +712,36 @@ function liepsd_inverse(t::AbstractVector{ForwardDiff.Dual{
         dα = @view p[(n + 1):L]
         dAk = _lie_antisym(dα, n)
         _, dUk = _expm_frechet(Av, dAk)            # ∂exp(A)[dA]
+        dDk = Diagonal(exp.(λv) .* dλ)
+        dΣ = dUk * Dv * Uv' + Uv * dDk * Uv' + Uv * Dv * dUk'
+        Matrix(Symmetric(dΣ))
+    end
+    out = Matrix{ForwardDiff.Dual{Tg, V, N}}(undef, n, n)
+    @inbounds for j in 1:n, i in 1:n
+        out[i, j] = ForwardDiff.Dual{Tg}(Σv[i, j], ntuple(k -> dΣs[k][i, j], N)...)
+    end
+    return out
+end
+
+# Nested Duals (2nd+-order ForwardDiff): recurse on the value (bottoming out at the Float64
+# LAPACK leaf) and build each partial via the Padé Fréchet derivative through `_matexp`.
+function liepsd_inverse(t::AbstractVector{ForwardDiff.Dual{
+        Tg, V, N}}) where {Tg, V <: ForwardDiff.Dual, N}
+    L = length(t)
+    n = _lie_dim(L)
+    tv = ForwardDiff.value.(t)
+    Σv = liepsd_inverse(tv)
+    λv = @view tv[1:n]
+    αv = @view tv[(n + 1):L]
+    Av = _lie_antisym(αv, n)
+    Uv = _matexp(Av)
+    Dv = Diagonal(exp.(λv))
+    dΣs = ntuple(N) do k
+        p = ForwardDiff.partials.(t, k)
+        dλ = @view p[1:n]
+        dα = @view p[(n + 1):L]
+        dAk = _lie_antisym(dα, n)
+        _, dUk = _expm_frechet(Av, dAk)
         dDk = Diagonal(exp.(λv) .* dλ)
         dΣ = dUk * Dv * Uv' + Uv * dDk * Uv' + Uv * Dv * dUk'
         Matrix(Symmetric(dΣ))

--- a/test/transform_tests.jl
+++ b/test/transform_tests.jl
@@ -283,3 +283,42 @@ end
     @test isapprox(jac.v[2], fd2; rtol = 1e-5, atol = 1e-8)
     @test isapprox(jac.v[3], fd3; rtol = 1e-10)
 end
+
+@testset "matrix-exp transforms — 2nd-order ForwardDiff (nested Duals)" begin
+    # Regression: a Hessian through the :expm/:lie covariance transform flows nested Duals;
+    # this was NaN at repeated eigenvalues (Omega = I) for :expm and errored for :lie. The
+    # nested-Dual specialization makes both finite, symmetric, and exact to FD-of-gradient.
+    function fd_hess(f, x; h = 1e-6)
+        m = length(x)
+        H = zeros(m, m)
+        for j in 1:m
+            xp = copy(x)
+            xp[j] += h
+            xm = copy(x)
+            xm[j] -= h
+            H[:, j] = (ForwardDiff.gradient(f, xp) .- ForwardDiff.gradient(f, xm)) ./ (2h)
+        end
+        return 0.5 .* (H .+ H')
+    end
+
+    # BLAS passthrough must stay bit-identical to `exp` (value/gradient goldens rely on it).
+    A = [0.1 0.4; -0.4 0.2]
+    @test NoLimits._matexp(A) == exp(A)
+
+    n = 2
+    g_expm(v) = sum(abs2, NoLimits.expm_inverse(NoLimits._sym_from_upper(v, n)))
+    for v0 in ([0.0, 0.0, 0.0], [0.3, -0.2, 0.5])   # Omega = I (degenerate), off-degeneracy
+        H = ForwardDiff.hessian(g_expm, v0)
+        @test all(isfinite, H)
+        @test isapprox(H, H'; atol = 1e-10)
+        @test isapprox(H, fd_hess(g_expm, v0); rtol = 1e-6, atol = 1e-7)
+    end
+
+    h_lie(t) = sum(abs2, NoLimits.liepsd_inverse(t))
+    for t0 in ([0.0, 0.0, 0.0], [0.2, -0.1, 0.4])
+        H = ForwardDiff.hessian(h_lie, t0)
+        @test all(isfinite, H)
+        @test isapprox(H, H'; atol = 1e-10)
+        @test isapprox(H, fd_hess(h_lie, t0); rtol = 1e-6, atol = 1e-7)
+    end
+end


### PR DESCRIPTION
## Summary

Makes 2nd-order ForwardDiff **exact** for the `:expm`/`:lie` covariance transforms (fixing a latent bug along the way), plus two small dedups. **11 files, +156/−22.** Byte-neutral for all existing goldens; Aqua + format green.

## The bug (Tier 1)

The `:expm`/`:lie` transforms only had **single-level** Dual specializations of `expm_inverse`/`liepsd_inverse`. A 2nd-order ForwardDiff — the Wald / identifiability **Hessian** on a no-RE MLE/MAP/Pooled/GHQuadrature model with a PSD covariance (e.g. `y ~ MvNormal(μ, Ω)`, `Ω = RealPSDMatrix(...; scale=:expm)`) — fell through to the generic `exp(::Matrix)`:

- `:expm` at repeated eigenvalues (**Ω = I**, the default init *and* a common estimate) returns a **NaN** second-derivative *silently* (the symmetric-eigen matrix-function derivative divides by zero eigengaps).
- The exception-only `try/catch` in `compute_uq` doesn't catch NaN → **hard error or silent NaN standard errors** on a default path. (`:lie` errored → was already caught → FD fallback.)

**Fix:** treat a non-finite ForwardDiff Hessian as failure so `:expm` routes to the same graceful `:fd_gradient` fallback `:lie` already got. One line, byte-neutral.

## The enhancement (Tier 2)

Add a Dual-generic scaling-and-squaring Padé matrix-exp (`_matexp`, Higham degree 13, only `+ * \ I`) used **only** inside the Fréchet derivative, plus **disjoint** nested (`V<:ForwardDiff.Dual`) `expm_inverse`/`liepsd_inverse` specializations that recurse on the value (bottoming out at the Float64 eigen/LAPACK leaf) and build partials via the Padé-Fréchet. 2nd-order ForwardDiff is now **exact** for `:expm`/`:lie` — Hessian finite at Ω = I, matching FD-of-gradient to ~1e-11 — removing the finite-difference fallback and aligning with the ForwardDiff-first convention.

**Golden safety:** the existing single-level `V<:AbstractFloat` methods are untouched; `_matexp(::Matrix{<:BlasFloat}) === exp` (verified in-test), so the value and single-level-gradient paths are byte-identical. The Padé is entered only inside a nested Hessian, filling the previously-NaN/FD second-order block. New regression test (`transform_tests.jl`) asserts finite + symmetric + FD-matching nested Hessians for both scales at Ω = I and off-degeneracy. Aqua confirms the new `BlasFloat`-vs-`Real` and `AbstractFloat`-vs-`Dual` methods are unambiguous.

## Dedups

- `_has_fixed_priors(fe)` — the byte-identical "requires priors" check in MAP and PooledMap.
- `_macro_filter_var_syms` — the identifier-filter trio shared by the `@preDifferentialEquation`/`@DifferentialEquation`/`@initialDE`/`@formulas` builder macros (generated code unchanged).

Three other candidate dedups from the same sweep were investigated and **declined** as materially different (cv-vs-Laplace RE fallback: Float64-vs-generic-T + different vector shapes; the hot-path Laplace RE scaffold: RNG-order-sensitive divergent bodies; cv↔predict: cv fits with `store_data_model=false` so `_predict_*` would error) — not real duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
