### PR TITLE
test: fixture-affine batching + reuse fixtures in plotting tests

### DIFF
--- a/test/plot_cache_tests.jl
+++ b/test/plot_cache_tests.jl
@@ -28,11 +28,10 @@ end
 end
 
 @testset "Plot cache inherits constants_re from fit result" begin
-    dm = fx_recov_dm()
-    constants_re = (; η = (; B = 0.0))
-    res = fit_model(dm,
-        NoLimits.Laplace(; optim_kwargs = (maxiters = 2,));
-        constants_re = constants_re)
+    # fx_constre_laplace was fit with constants_re = (; η = (; B = 0.0)); the cache
+    # must inherit it and pin η(B) to 0.
+    res = fx_constre_laplace()
+    dm = fx_constre_dm()
 
     cache = build_plot_cache(res)
     @test cache isa PlotCache

--- a/test/plot_random_effects_tests.jl
+++ b/test/plot_random_effects_tests.jl
@@ -3,7 +3,6 @@ using NoLimits
 using CairoMakie
 using DataFrames
 using Distributions
-using Random
 using Turing
 
 # ── Shared fixtures: build each unique model type once so testsets share JIT compilation ──
@@ -229,10 +228,8 @@ end
 end
 
 @testset "plot_random_effects Laplace constants_re" begin
-    dm = _PRE_CONST_RE_DM
-    constants_re = (; η = (; B = 0.0))
-    res = fit_model(
-        dm, NoLimits.Laplace(; optim_kwargs = (maxiters = 2,)); constants_re = constants_re)
+    # fx_constre_laplace pins η(B) via constants_re = (; η = (; B = 0.0)).
+    res = fx_constre_laplace()
 
     p_dist = plot_random_effect_distributions(res)
     @test p_dist !== nothing
@@ -505,31 +502,10 @@ end
     @test plot_random_effect_pairplot(res) !== nothing
 end
 
-# ── Moved from coverage_gap_tests.jl ──────────────────────────────────────────
-# Prior-equipped scalar-RE model (fixed RE sd) for posterior-prediction paths.
-const _PRE_GAP_PRIOR_MODEL = @Model begin
-    @fixedEffects begin
-        a = RealNumber(0.2, prior = Normal(0.0, 1.0))
-        σ = RealNumber(0.3, scale = :log, prior = LogNormal(0.0, 0.5))
-    end
-    @covariates begin
-        t = Covariate()
-    end
-    @randomEffects begin
-        η = RandomEffect(Normal(0.0, 0.5); column = :ID)
-    end
-    @formulas begin
-        y ~ Normal(a + η, σ)
-    end
-end
-
 @testset "RE posterior prediction plots (MCMC)" begin
-    dm = DataModel(_PRE_GAP_PRIOR_MODEL, fx_re_df(); primary_id = :ID, time_col = :t)
-
-    res_mcmc = fit_model(dm,
-        NoLimits.MCMC(;
-            turing_kwargs = (n_samples = 20, n_adapt = 10, progress = false));
-        rng = Random.Xoshiro(1))
+    # fx_mcmc_re is a scalar-RE MCMC fit (priors, 20 samples) — enough for the
+    # default-mean and posterior-draw paths below.
+    res_mcmc = fx_mcmc_re()
     # default path -> _mcmc_random_effects_means
     @test plot_fits(res_mcmc) !== nothing
     # posterior-draw path -> _mcmc_drawn_params

--- a/test/plotting_functions_tests.jl
+++ b/test/plotting_functions_tests.jl
@@ -3,7 +3,6 @@ using NoLimits
 using DataFrames
 using Distributions
 using CairoMakie
-using Random
 using Turing: MH
 
 # Note: "plot_data and plot_fits basic", "plot_fits MCMC", "plot_fits VI"
@@ -90,12 +89,8 @@ end
 end
 
 @testset "plot_fits inherits constants_re from fit result" begin
-    constants_re = (; η = (; B = 0.0))
-    res = fit_model(fx_recov_dm(),
-        NoLimits.Laplace(; optim_kwargs = (maxiters = 2,));
-        constants_re = constants_re)
-
-    @test plot_fits(res) !== nothing
+    # fx_constre_laplace is a Laplace fit built with constants_re = (; η = (; B = 0.0)).
+    @test plot_fits(fx_constre_laplace()) !== nothing
 end
 
 @testset "plot_multistart_waterfall basic" begin
@@ -310,15 +305,9 @@ end
 end
 
 @testset "VI posterior-draw prediction plots (no RE)" begin
-    # Moved from coverage_gap_tests.jl. VI rejects random-effects models, so
-    # exercise the VI posterior-draw plot path (_vi_drawn_params) with a
-    # fixed-effects-only model + priors.
-    df = DataFrame(ID = repeat(1:4, inner = 3), t = repeat(0.0:2.0, 4),
-        y = [0.2 + 0.05 * i + 0.03 * j for i in 1:4 for j in 0:2])
-    dm = DataModel(fx_nore_prior_model(), df; primary_id = :ID, time_col = :t)
-    res = fit_model(dm, NoLimits.VI(;
-            turing_kwargs = (max_iter = 30, progress = false));
-        rng = Random.Xoshiro(3))
+    # VI rejects random-effects models; fx_vi is a fixed-effects-only VI fit that
+    # exercises the VI posterior-draw plot path (_vi_drawn_params).
+    res = fx_vi()
     @test plot_fits(res) !== nothing
     # posterior-draw band -> _vi_drawn_params
     @test plot_fits(res; plot_mcmc_quantiles = true, mcmc_draws = 5) !== nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,107 +9,111 @@ using Test
 # batches. Each subprocess includes fixtures.jl fresh (lazy/memoized), so the
 # only added cost is repeated `using NoLimits` (~tens of seconds per batch).
 #
-# Set NL_BATCHES to override the batch count (default below).
-
-# Ordered into fixture-affine contiguous blocks: batches are contiguous chunks
-# of this list and fixtures (fixtures.jl) memoize per subprocess, so files that
-# share fx_* models/fits should land in the same batch.
-const TEST_FILES = [
-    # ── B1: unit / AD (no fixtures) ──────────────────────────────────────────
-    "aqua_tests.jl",
-    "softtrees_tests.jl",
-    "ad_softtree.jl",
-    "ad_flow.jl",
-    "ad_random_effects.jl",
-    "ad_fixed_prede.jl",
-    "ad_differential_equation.jl",
-    "ad_ode_solve.jl",
-    "ad_model_full.jl",
-    "helpers_tests.jl",
-    "parameters_tests.jl",
-    "simplechains_nn_tests.jl",
-    "transform_tests.jl",
-    "fixed_effects_tests.jl",
-    "splines_tests.jl",
-    "covariates_tests.jl",
-    "random_effects_tests.jl",
-    "prede_tests.jl",
-    "differential_equation_tests.jl",
-    "ode_solve_tests.jl",
-    "closed_form_ode_tests.jl",
-    "formulas_tests.jl",
-    "initialde_tests.jl",
+# Batches ARE the fixture-affine groups below (one subprocess each). fixtures.jl
+# memoizes per subprocess, so keeping a group whole builds its shared fx_* models
+# and fits ONCE instead of once per straddling batch. Set NL_BATCHES to force a
+# flat N-way split instead (bounds per-process memory harder, but re-runs shared
+# fits across the split). Groups are capped near ~15 files so per-process
+# compiled-code memory stays within the known-good envelope.
+const TEST_GROUPS = [
+    # ── B1a: unit / AD (no fixtures) ─────────────────────────────────────────
+    ["aqua_tests.jl",
+        "softtrees_tests.jl",
+        "ad_softtree.jl",
+        "ad_flow.jl",
+        "ad_random_effects.jl",
+        "ad_fixed_prede.jl",
+        "ad_differential_equation.jl",
+        "ad_ode_solve.jl",
+        "ad_model_full.jl",
+        "helpers_tests.jl",
+        "parameters_tests.jl",
+        "simplechains_nn_tests.jl"],
+    # ── B1b: unit / AD (no fixtures) ─────────────────────────────────────────
+    ["transform_tests.jl",
+        "fixed_effects_tests.jl",
+        "splines_tests.jl",
+        "covariates_tests.jl",
+        "random_effects_tests.jl",
+        "prede_tests.jl",
+        "differential_equation_tests.jl",
+        "ode_solve_tests.jl",
+        "closed_form_ode_tests.jl",
+        "formulas_tests.jl",
+        "initialde_tests.jl"],
     # ── B2: model / data layer ───────────────────────────────────────────────
-    "model_macro_tests.jl",
-    "model_tests.jl",
-    "equation_display_tests.jl",
-    "data_model_tests.jl",
-    "identifiability_tests.jl",
-    "data_model_ode_tests.jl",
-    "summaries_data_model_tests.jl",
-    "summaries_model_tests.jl",
-    "summaries_fit_uq_tests.jl",
-    "summaries_parameter_comparison_tests.jl",
-    "compact_show_tests.jl",
-    "data_simulation_tests.jl",
-    "ode_callbacks_tests.jl",
-    "crossing_tests.jl",
-    "datasets_tests.jl",
+    ["model_macro_tests.jl",
+        "model_tests.jl",
+        "equation_display_tests.jl",
+        "data_model_tests.jl",
+        "identifiability_tests.jl",
+        "data_model_ode_tests.jl",
+        "summaries_data_model_tests.jl",
+        "summaries_model_tests.jl",
+        "summaries_fit_uq_tests.jl",
+        "summaries_parameter_comparison_tests.jl",
+        "compact_show_tests.jl",
+        "data_simulation_tests.jl",
+        "ode_callbacks_tests.jl",
+        "crossing_tests.jl",
+        "datasets_tests.jl"],
     # ── B3: plotting (shares fx_nore/re/ode/pois/bern/npf/npf2/recov + fits) ─
-    "plot_cache_tests.jl",
-    "plotting_functions_tests.jl",
-    "vpc_tests.jl",
-    "plot_observation_distributions_tests.jl",
-    "residual_plots_tests.jl",
-    "plot_random_effects_tests.jl",
-    "uq_plotting_tests.jl",
-    "integration_plotting.jl",
+    ["plot_cache_tests.jl",
+        "plotting_functions_tests.jl",
+        "vpc_tests.jl",
+        "plot_observation_distributions_tests.jl",
+        "residual_plots_tests.jl",
+        "plot_random_effects_tests.jl",
+        "uq_plotting_tests.jl",
+        "integration_plotting.jl"],
     # ── B4: estimation core (shares fx_nore/re/mg/mvn/mvnp/ode/pois/bern) ────
-    "estimation_common_tests.jl",
-    "complete_data_loglikelihood_tests.jl",
-    "accessors_tests.jl",
-    "serialization_tests.jl",
-    "estimation_mle_tests.jl",
-    "estimation_map_tests.jl",
-    "estimation_vi_tests.jl",
-    "estimation_mcmc_tests.jl",
-    "estimation_mcmc_re_tests.jl",
-    "estimation_laplace_tests.jl",
-    "estimation_focei_tests.jl",
-    "estimation_pooled_tests.jl",
-    "estimation_cv_tests.jl",
+    ["estimation_common_tests.jl",
+        "complete_data_loglikelihood_tests.jl",
+        "accessors_tests.jl",
+        "serialization_tests.jl",
+        "estimation_mle_tests.jl",
+        "estimation_map_tests.jl",
+        "estimation_vi_tests.jl",
+        "estimation_mcmc_tests.jl",
+        "estimation_mcmc_re_tests.jl",
+        "estimation_laplace_tests.jl",
+        "estimation_focei_tests.jl",
+        "estimation_pooled_tests.jl",
+        "estimation_cv_tests.jl"],
     # ── B5: EM / quadrature / UQ ─────────────────────────────────────────────
-    "estimation_mcem_tests.jl",
-    "estimation_mcem_is_tests.jl",
-    "estimation_saem_tests.jl",
-    "saem_mh_kernel_tests.jl",
-    "estimation_saem_autodetect_tests.jl",
-    "saem_schedule_tests.jl",
-    "saem_multichain_tests.jl",
-    "saem_sa_anneal_tests.jl",
-    "saem_var_lb_tests.jl",
-    "estimation_multistart_tests.jl",
-    "estimation_ghquadrature_tests.jl",
-    "extra_objective_tests.jl",
-    "uq_tests.jl",
-    "uq_edge_cases_tests.jl",
+    ["estimation_mcem_tests.jl",
+        "estimation_mcem_is_tests.jl",
+        "estimation_saem_tests.jl",
+        "saem_mh_kernel_tests.jl",
+        "estimation_saem_autodetect_tests.jl",
+        "saem_schedule_tests.jl",
+        "saem_multichain_tests.jl",
+        "saem_sa_anneal_tests.jl",
+        "saem_var_lb_tests.jl",
+        "estimation_multistart_tests.jl",
+        "estimation_ghquadrature_tests.jl",
+        "extra_objective_tests.jl",
+        "uq_tests.jl",
+        "uq_edge_cases_tests.jl"],
     # ── B6: HMM / Markov / stickbreak / Enzyme ───────────────────────────────
-    "hmm_continuous_tests.jl",
-    "hmm_discrete_time_tests.jl",
-    "hmm_estimation_method_matrix_tests.jl",
-    "hmm_mv_tests.jl",
-    "markov_observed_states_tests.jl",
-    "stickbreak_tests.jl",
-    "stickbreak_uq_natural_extension_tests.jl",
-    "ad_stickbreak_hmm.jl",
-    "continuous_transition_matrix_tests.jl",
-    "lie_psd_matrix_tests.jl",
     # Enzyme regression tests (merged from enzyme-compat). proxy = always-on,
     # ForwardDiff-only structural/numeric invariants; smoke = opt-in real Enzyme
     # gradients, no-op unless NOLIMITS_TEST_ENZYME=true (+ Julia>=1.12.5 + Enzyme).
-    "enzyme_compat_proxy_tests.jl",
-    "enzyme_smoke_tests.jl"
+    ["hmm_continuous_tests.jl",
+        "hmm_discrete_time_tests.jl",
+        "hmm_estimation_method_matrix_tests.jl",
+        "hmm_mv_tests.jl",
+        "markov_observed_states_tests.jl",
+        "stickbreak_tests.jl",
+        "stickbreak_uq_natural_extension_tests.jl",
+        "ad_stickbreak_hmm.jl",
+        "continuous_transition_matrix_tests.jl",
+        "lie_psd_matrix_tests.jl",
+        "enzyme_compat_proxy_tests.jl",
+        "enzyme_smoke_tests.jl"]
 ]
+
+const TEST_FILES = reduce(vcat, TEST_GROUPS)
 
 # --- Orchestrate sequential subprocess batches -----------------------------
 
@@ -128,11 +132,10 @@ else
     filter(in(Set(requested)), TEST_FILES)
 end
 
-const N_BATCHES = parse(Int, get(ENV, "NL_BATCHES", "6"))
-
-# Contiguous split of TEST_FILES into N_BATCHES near-equal chunks (order
-# preserved). Batches run sequentially, so the split only bounds per-process
-# memory — balance isn't needed for wall-clock.
+# Contiguous split of TEST_FILES into n near-equal chunks (order preserved).
+# Only used when NL_BATCHES forces a flat split; the default path batches by the
+# fixture-affine TEST_GROUPS instead. Batches run sequentially, so the split only
+# bounds per-process memory — balance isn't needed for wall-clock.
 function _chunks(items, n)
     n = min(n, length(items))
     q, r = divrem(length(items), n)
@@ -175,7 +178,15 @@ function _child_flags()
     flags
 end
 
-const _BATCHES = _chunks(_SELECTED_FILES, N_BATCHES)
+# Default: one batch per fixture-affine group (built-once fx_* per subprocess).
+# NL_BATCHES=N overrides with a flat N-way split of the selected files.
+const _NB = strip(get(ENV, "NL_BATCHES", ""))
+const _BATCHES = if isempty(_NB)
+    _sel = Set(_SELECTED_FILES)
+    filter(!isempty, [filter(in(_sel), g) for g in TEST_GROUPS])
+else
+    _chunks(_SELECTED_FILES, parse(Int, _NB))
+end
 const _PROJECT = dirname(Base.active_project())
 const _BATCH_SCRIPT = joinpath(@__DIR__, "run_batch.jl")
 

--- a/test/vpc_tests.jl
+++ b/test/vpc_tests.jl
@@ -110,26 +110,9 @@ end
 end
 
 @testset "plot_vpc MCMC random effects" begin
-    model = @Model begin
-        @fixedEffects begin
-            a = RealNumber(0.2, prior = Normal(0.0, 1.0))
-            σ = RealNumber(0.3, scale = :log, prior = LogNormal(0.0, 0.5))
-        end
-        @covariates begin
-            t = Covariate()
-        end
-        @randomEffects begin
-            η = RandomEffect(Normal(0.0, 0.5); column = :ID)
-        end
-        @formulas begin
-            y ~ Normal(a * t + η, σ)
-        end
-    end
-    df = DataFrame(ID = [1, 1, 2, 2, 3, 3], t = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
-        y = [0.1, 0.2, 0.0, -0.1, 0.05, 0.1])
-    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
-    res = fit_model(
-        dm, MCMC(; turing_kwargs = (n_samples = 10, n_adapt = 5, progress = false)))
+    # fx_mcmc_re is a scalar-RE MCMC fit (priors, 20 samples): exercises the
+    # MCMC-RE VPC branch incl. mcmc_draws/mcmc_warmup.
+    res = fx_mcmc_re()
     @test plot_vpc(res; n_simulations = 5, n_bins = 3, mcmc_draws = 5, mcmc_warmup = 3) !==
           nothing
 end


### PR DESCRIPTION
## What

Two test-suite changes driven by a ponytail audit of redundant fits. Both cut duplicated work without dropping a single assertion.

### 1. Batch by fixture-affine groups (`test/runtests.jl`)

`TEST_FILES` was already annotated into fixture-affine blocks `B1-B6`, but they were only comments: the batcher did a blind contiguous count-split into `NL_BATCHES=6`, which straddled the blocks. The plotting block split across two subprocesses and the estimation block across two, so their shared `fx_*` models/fits recompiled in each straddling batch (`fixtures.jl` memoizes per subprocess only).

- Promote the blocks into an explicit `TEST_GROUPS` structure; **batches = groups** by default (one subprocess each), so a group's shared `fx_*` fits build once.
- `B1` (fixture-free unit/AD) is split in two to keep the ~15-file per-process memory cap → 7 balanced batches, max 15 files (same memory envelope as before).
- `NL_TEST_FILES` still filters; `NL_BATCHES=N` now forces a flat N-way split as an escape hatch.

### 2. Plotting tests reuse fixtures instead of re-fitting (4 files)

A plot only needs *some* `FitResult` of the right shape, so re-compiling a bespoke model + estimator just to draw a figure was pure duplication. Six incidental inline fits now reuse fixtures already computed in the (now unified) plotting batch:

| Testset | now uses |
|---|---|
| `plot_fits` / `plot_random_effects` / `plot_cache` constants_re | `fx_constre_laplace()` |
| VI posterior-draw plots | `fx_vi()` |
| RE posterior prediction + `plot_vpc` MCMC RE | `fx_mcmc_re()` |

Also drops the now-dead `_PRE_GAP_PRIOR_MODEL` and two unused `using Random` imports.

## Impact

- **Net -42 lines**, six fewer fits compiled per plotting-batch run.
- **Zero assertions dropped** — every replacement preserves the testset's intent.

## Verification

- Batching logic checked in isolation: 7 batches (max 15 files), plotting/estimation blocks whole, `NL_TEST_FILES` and `NL_BATCHES` both work.
- Full plotting batch through `Pkg.test`: **339/339 pass** in 3m41s, running as a single subprocess.
- All changed files are JuliaFormatter v1 (sciml) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)