### PR TITLE
feat: logabsdetjac for all structured parameter scales

### DIFF
--- a/src/estimation/dev_api.jl
+++ b/src/estimation/dev_api.jl
@@ -595,23 +595,21 @@ export NLFreeLayout, free_parameter_layout, resolve_fitted_parameters
 
 Log absolute determinant of the Jacobian of the inverse parameter transform (unconstrained →
 natural) at the transformed point `θt` - the change-of-variables correction for a density
-placed on the unconstrained optimizer scale. Computed by differentiating the actual inverse
-map, so bounded `:logit` and mixed scales are handled exactly. Structured matrix/simplex
-scales (`:cholesky`/`:expm`/`:stickbreak`/`:stickbreakrows`/`:lograterows`/`:liepsd`) are not
-yet supported (their natural parametrization is higher-dimensional than the free vector).
+placed on the unconstrained optimizer scale. Summed block-by-block over fixed effects: scalar
+scales (`:identity`/`:log`/`:logit`/`:elementwise`) use their closed form, and the structured
+matrix/simplex scales (`:cholesky`/`:expm`/`:stickbreak`/`:stickbreakrows`/`:lograterows`/`:lie`)
+differentiate their minimal square inverse map. ForwardDiff-safe, including nested AD.
+
+For `:lie` with fixed eigenvalues the correction is chart-dependent (the fixed-eigenvalue
+submanifold is not axis-aligned); it is self-consistent for use as a change-of-variables term
+in a single optimization, but is not a chart-invariant number.
 """
 function logabsdetjac(it::InverseTransform, θt::ComponentArray)
-    structured = (:cholesky, :expm, :stickbreak, :stickbreakrows, :lograterows, :liepsd)
-    for spec in it.specs
-        spec.kind in structured &&
-            error("logabsdetjac is not yet implemented for the :$(spec.kind) scale " *
-                  "(supported: identity/log/logit/elementwise).")
-    end
     v = ComponentArrays.getdata(θt)
     isempty(v) && return zero(eltype(v))
-    ax = getaxes(θt)
-    J = ForwardDiff.jacobian(z -> ComponentArrays.getdata(it(ComponentArray(z, ax))), v)
-    size(J, 1) == size(J, 2) ||
-        error("logabsdetjac: non-square Jacobian ($(size(J))); a structured scale slipped through.")
-    return logabsdet(J)[1]
+    total = zero(eltype(v))
+    for spec in it.specs
+        total += _block_logabsdetjac(spec, getproperty(θt, spec.name))
+    end
+    return total
 end

--- a/src/utils/ParameterTranformations.jl
+++ b/src/utils/ParameterTranformations.jl
@@ -880,6 +880,175 @@ function _liepsd_forward_layout(Σ::AbstractMatrix{<:Real}, layout::LiePSDLayout
     return p_full[layout.free_idx]
 end
 
+# ── Change-of-variables: per-block log|det ∂(natural)/∂(free)| ────────────────
+
+_block_eltype(block) = block isa Number ? typeof(float(block)) : eltype(block)
+_block_scalars(block) = block isa Number ? (block,) : block
+_sum_block(block) = sum(_block_scalars(block))
+
+# vech: lower-triangular entries, column-major (n(n+1)/2 of them).
+_vech_lower(M::AbstractMatrix) = [M[i, j] for j in axes(M, 2) for i in j:size(M, 1)]
+
+# Dispatch one TransformSpec's block to its correction. Scalar scales use closed
+# forms; structured scales differentiate their minimal (square) inverse map.
+function _block_logabsdetjac(spec::TransformSpec, block)
+    kind = spec.kind
+    if kind === :identity
+        return zero(_block_eltype(block))
+    elseif kind === :log
+        return _sum_block(block)
+    elseif kind === :logit
+        return _logabsdetjac_logit(block)
+    elseif kind === :elementwise
+        return _logabsdetjac_elementwise(spec, block)
+    elseif kind === :cholesky
+        return _logabsdetjac_cholesky(block)
+    elseif kind === :expm
+        return _logabsdetjac_expm(block)
+    elseif kind === :stickbreak
+        return _logabsdetjac_stickbreak(block)
+    elseif kind === :stickbreakrows
+        return _logabsdetjac_stickbreakrows(block)
+    elseif kind === :lograterows
+        return _logabsdetjac_lograterows(block)
+    elseif kind === :lie
+        return _logabsdetjac_liepsd(spec, block)
+    else
+        error("logabsdetjac: unhandled scale :$(kind).")
+    end
+end
+
+# Scalar / diagonal closed forms. :log -> sum z (dexp/dz = exp z); :logit -> sum log sigma(1-sigma).
+function _logabsdetjac_logit(block)
+    s = zero(_block_eltype(block))
+    for z in _block_scalars(block)
+        sig = logit_inverse(z)
+        s += log(sig) + log(one(sig) - sig)
+    end
+    return s
+end
+
+function _logabsdetjac_elementwise(spec::TransformSpec, block)
+    mask = spec.mask
+    s = zero(_block_eltype(block))
+    @inbounds for j in eachindex(block)
+        m = mask[j]
+        if m === :log
+            s += block[j]
+        elseif m === :logit
+            sig = logit_inverse(block[j])
+            s += log(sig) + log(one(sig) - sig)
+        end
+    end
+    return s
+end
+
+# Rebuild a lower-triangular matrix from its column-major free coords (i >= j).
+function _lower_from_free(zf::AbstractVector{S}, n::Int) where {S}
+    T = zeros(S, n, n)
+    k = 1
+    @inbounds for j in 1:n
+        for i in j:n
+            T[i, j] = zf[k]
+            k += 1
+        end
+    end
+    return T
+end
+
+# :cholesky block is the n x n log-Cholesky factor; free coords = its lower triangle,
+# minimal natural = vech(Sigma). Square d x d map, differentiated with ForwardDiff.
+function _logabsdetjac_cholesky(block)
+    v = vec(collect(block))
+    n = isqrt(length(v))
+    n * n == length(v) ||
+        error("cholesky block length $(length(v)) is not a perfect square.")
+    T = reshape(v, n, n)
+    zf = [T[i, j] for j in 1:n for i in j:n]
+    f = z -> _vech_lower(cholesky_inverse(_lower_from_free(z, n)))
+    return logabsdet(ForwardDiff.jacobian(f, zf))[1]
+end
+
+# :expm block is the upper-tri vector of the symmetric matrix log Sigma; minimal
+# natural = vech(Sigma). Square map z -> vech(exp(sym T)), differentiated with ForwardDiff.
+function _logabsdetjac_expm(block)
+    zf = collect(block)
+    n = _lie_dim(length(zf))
+    f = z -> _upper_tri_vec(expm_inverse(_sym_from_upper(z, n)))
+    return logabsdet(ForwardDiff.jacobian(f, zf))[1]
+end
+
+# :stickbreak block is k-1 logits. The inverse map is lower-triangular, so the
+# correction has the closed form sum_i [log sigma_i + log(1-sigma_i) + sum_{j<i} log(1-sigma_j)].
+function _logabsdetjac_stickbreak(block)
+    T = promote_type(eltype(block), Float64)
+    total = zero(T)
+    logrem = zero(T)
+    @inbounds for i in eachindex(block)
+        sig = logit_inverse(T(block[i]))
+        total += log(sig) + log(one(T) - sig) + logrem
+        logrem += log(one(T) - sig)
+    end
+    return total
+end
+
+# :stickbreakrows block is n independent k=n simplex rows (row i at
+# ((i-1)(n-1)+1):(i(n-1))). Block-diagonal Jacobian -> sum of per-row stickbreak terms.
+function _logabsdetjac_stickbreakrows(block)
+    z = collect(block)
+    L = length(z)
+    n = round(Int, (1 + sqrt(1 + 4L)) / 2)
+    n * (n - 1) == L ||
+        error("stickbreakrows block length $L is not of the form n(n-1).")
+    k1 = n - 1
+    total = zero(promote_type(eltype(z), Float64))
+    @inbounds for i in 1:n
+        total += _logabsdetjac_stickbreak(view(z, ((i - 1) * k1 + 1):(i * k1)))
+    end
+    return total
+end
+
+# :lograterows block IS the free vector of n(n-1) log off-diagonal rates; the minimal
+# natural coords are exp.(block), Jacobian Diagonal(exp.(block)) -> correction = sum(block).
+_logabsdetjac_lograterows(block) = _sum_block(block)
+
+# Pick d vech indices so the minimal-natural map z(dim d) -> selected vech is square.
+function _liepsd_minimal_sel(n::Int, d::Int, layout, invmap, z)
+    layout === nothing && return collect(1:d)
+    within = Int[]
+    k = 1
+    for j in 1:n, i in j:n
+        layout.blocks[i] == layout.blocks[j] && push!(within, k)
+        k += 1
+    end
+    length(within) == d && return within
+    # General case (fixed eigenvalues): the submanifold is not axis-aligned, so pick d
+    # independent vech rows via column-pivoted QR on the value-Jacobian. The selection
+    # is a piecewise-constant integer set, so floatize (no derivative flows through it).
+    zf = Float64.(_scalar_value.(z))
+    Jfull = ForwardDiff.jacobian(t -> _vech_lower(invmap(t)), zf)
+    F = qr(Matrix(transpose(Jfull)), ColumnNorm())
+    return sort(F.p[1:d])
+end
+
+# :lie block. `spec.lie` carries the optional layout. Map z -> selected-vech(Sigma) is made
+# square by choosing d minimal-natural coords (all vech unstructured/block-diagonal;
+# a QR-pivoted subset for fixed eigenvalues). Differentiated with ForwardDiff.
+function _logabsdetjac_liepsd(spec::TransformSpec, block)
+    layout = spec.lie
+    z = collect(block)
+    invmap = layout === nothing ? liepsd_inverse :
+             (t -> _liepsd_inverse_layout(t, layout))
+    n = layout === nothing ? _lie_dim(length(z)) : layout.n
+    d = length(z)
+    sel = _liepsd_minimal_sel(n, d, layout, invmap, z)
+    f = t -> _vech_lower(invmap(t))[sel]
+    J = ForwardDiff.jacobian(f, z)
+    size(J, 1) == size(J, 2) ||
+        error("_logabsdetjac_liepsd: non-square minimal Jacobian $(size(J)).")
+    return logabsdet(J)[1]
+end
+
 function apply_inv_jacobian_T(
         it::InverseTransform, θt::ComponentArray, grad_u::ComponentArray)
     names = it.names

--- a/test/api_primitives_tests.jl
+++ b/test/api_primitives_tests.jl
@@ -366,25 +366,7 @@ end
         g = ForwardDiff.gradient(
             z -> logabsdetjac(it, ComponentArray(z, getaxes(θt))), collect(θt))
         @test all(isfinite, g)
-        # structured scale is not yet supported
-        m2 = @Model begin
-            @fixedEffects begin
-                Ω = RealPSDMatrix([1.0 0.0; 0.0 1.0], scale = :cholesky)
-                σ = RealNumber(0.5, scale = :log)
-            end
-            @covariates begin
-                t = Covariate()
-            end
-            @randomEffects begin
-                η = RandomEffect(MvNormal(zeros(2), Ω); column = :ID)
-            end
-            @formulas begin
-                y ~ Normal(η[1], σ)
-            end
-        end
-        fe2 = NoLimits.get_fixed(m2)
-        it2 = NoLimits.get_inverse_transform(fe2)
-        θt2 = NoLimits.get_transform(fe2)(NoLimits.get_θ0_untransformed(fe2))
-        @test_throws ErrorException logabsdetjac(it2, θt2)
+        # structured scales (cholesky/expm/stickbreak/stickbreakrows/lograterows/lie)
+        # are covered in test/logabsdetjac_tests.jl
     end
 end

--- a/test/logabsdetjac_tests.jl
+++ b/test/logabsdetjac_tests.jl
@@ -1,0 +1,203 @@
+using NoLimits
+using ComponentArrays
+using Distributions
+using LinearAlgebra
+using ForwardDiff
+using FiniteDifferences
+using NoLimits: _block_logabsdetjac, cholesky_inverse, expm_inverse, _sym_from_upper,
+                _upper_tri_vec, stickbreak_inverse, lograterows_inverse, liepsd_inverse,
+                _lie_dim
+using Test
+
+# Each golden compares logabsdetjac / _block_logabsdetjac to an INDEPENDENT central
+# finite-difference logabsdet of the minimal (square) natural map built from the public
+# inverse primitives (FD vs ForwardDiff are independent numerical routes), plus a
+# nested-AD finiteness probe.
+
+fdm = central_fdm(5, 1)
+vechL(M) = [M[i, j] for j in axes(M, 2) for i in j:size(M, 1)]
+function lower_from_free(z, n)
+    T = zeros(eltype(z), n, n)
+    k = 1
+    for j in 1:n, i in j:n
+        T[i, j] = z[k]
+        k += 1
+    end
+    return T
+end
+fd_ref(gmin, z) = logabsdet(FiniteDifferences.jacobian(fdm, gmin, collect(z))[1])[1]
+
+function _it_theta(fe)
+    it = NoLimits.get_inverse_transform(fe)
+    θt = NoLimits.get_transform(fe)(NoLimits.get_θ0_untransformed(fe))
+    return it, θt
+end
+_spec_for(it, name) = it.specs[findfirst(s -> s.name == name, it.specs)]
+
+@testset "logabsdetjac structured scales" begin
+    @testset "scalar closed forms still exact" begin
+        m = @Model begin
+            @fixedEffects begin
+                a = RealNumber(1.5, scale = :log)
+                p = RealNumber(0.3, scale = :logit, lower = 0.0, upper = 1.0)
+                c = RealNumber(0.7)
+            end
+            @covariates begin
+                t = Covariate()
+            end
+            @formulas begin
+                y ~ Normal(c, a)
+            end
+        end
+        it, θt = _it_theta(NoLimits.get_fixed(m))
+        @test logabsdetjac(it, θt)≈log(1.5) + log(0.3 * 0.7) atol=1e-10
+    end
+
+    @testset "cholesky" begin
+        m = @Model begin
+            @fixedEffects begin
+                Ω = RealPSDMatrix([1.3 0.2; 0.2 0.9], scale = :cholesky)
+                σ = RealNumber(0.5, scale = :log)
+            end
+            @covariates begin
+                t = Covariate()
+            end
+            @randomEffects begin
+                η = RandomEffect(MvNormal(zeros(2), Ω); column = :ID)
+            end
+            @formulas begin
+                y ~ Normal(η[1], σ)
+            end
+        end
+        it, θt = _it_theta(NoLimits.get_fixed(m))
+        spec = _spec_for(it, :Ω)
+        blk = collect(getproperty(θt, :Ω))  # flat n^2 log-Cholesky factor
+        n = 2
+        Tmat = reshape(blk, n, n)
+        gmin = z -> vechL(cholesky_inverse(lower_from_free(z, n)))
+        z0 = [Tmat[i, j] for j in 1:n for i in j:n]  # lower-tri free coords
+        @test _block_logabsdetjac(spec, blk)≈fd_ref(gmin, z0) atol=1e-6
+        @test logabsdetjac(it, θt)≈_block_logabsdetjac(spec, blk) + log(0.5) atol=1e-6
+        @test all(isfinite, ForwardDiff.gradient(z -> _block_logabsdetjac(spec, z), blk))
+    end
+
+    @testset "expm" begin
+        m = @Model begin
+            @fixedEffects begin
+                Ω = RealPSDMatrix([1.4 0.3; 0.3 1.1], scale = :expm)
+                σ = RealNumber(0.5, scale = :log)
+            end
+            @covariates begin
+                t = Covariate()
+            end
+            @randomEffects begin
+                η = RandomEffect(MvNormal(zeros(2), Ω); column = :ID)
+            end
+            @formulas begin
+                y ~ Normal(η[1], σ)
+            end
+        end
+        it, θt = _it_theta(NoLimits.get_fixed(m))
+        spec = _spec_for(it, :Ω)
+        blk = collect(getproperty(θt, :Ω))
+        n = _lie_dim(length(blk))
+        gmin = z -> _upper_tri_vec(expm_inverse(_sym_from_upper(z, n)))
+        @test _block_logabsdetjac(spec, blk)≈fd_ref(gmin, blk) atol=1e-6
+        @test all(isfinite, ForwardDiff.gradient(z -> _block_logabsdetjac(spec, z), blk))
+    end
+
+    @testset "stickbreak" begin
+        m = @Model begin
+            @fixedEffects begin
+                w = ProbabilityVector([0.2, 0.5, 0.3])
+                σ = RealNumber(0.5, scale = :log)
+            end
+            @covariates begin
+                t = Covariate()
+            end
+            @formulas begin
+                y ~ Normal(w[1], σ)
+            end
+        end
+        it, θt = _it_theta(NoLimits.get_fixed(m))
+        spec = _spec_for(it, :w)
+        blk = collect(getproperty(θt, :w))
+        k1 = length(blk)
+        gmin = z -> stickbreak_inverse(z)[1:k1]
+        @test _block_logabsdetjac(spec, blk)≈fd_ref(gmin, blk) atol=1e-6
+        @test all(isfinite, ForwardDiff.gradient(z -> _block_logabsdetjac(spec, z), blk))
+    end
+
+    @testset "stickbreakrows" begin
+        P = [0.7 0.2 0.1; 0.1 0.8 0.1; 0.2 0.3 0.5]
+        m = @Model begin
+            @fixedEffects begin
+                Tm = DiscreteTransitionMatrix(P)
+                σ = RealNumber(0.5, scale = :log)
+            end
+            @covariates begin
+                t = Covariate()
+            end
+            @formulas begin
+                y ~ Normal(σ, σ)
+            end
+        end
+        it, θt = _it_theta(NoLimits.get_fixed(m))
+        spec = _spec_for(it, :Tm)
+        blk = collect(getproperty(θt, :Tm))
+        n = spec.size[1]
+        k1 = n - 1
+        gmin = z -> vcat((stickbreak_inverse(z[((i - 1) * k1 + 1):(i * k1)])[1:k1]
+        for i in 1:n)...)
+        @test _block_logabsdetjac(spec, blk)≈fd_ref(gmin, blk) atol=1e-6
+        @test all(isfinite, ForwardDiff.gradient(z -> _block_logabsdetjac(spec, z), blk))
+    end
+
+    @testset "lograterows" begin
+        Q = [-0.5 0.3 0.2; 0.1 -0.4 0.3; 0.2 0.2 -0.4]
+        m = @Model begin
+            @fixedEffects begin
+                Qm = ContinuousTransitionMatrix(Q)
+                σ = RealNumber(0.5, scale = :log)
+            end
+            @covariates begin
+                t = Covariate()
+            end
+            @formulas begin
+                y ~ Normal(σ, σ)
+            end
+        end
+        it, θt = _it_theta(NoLimits.get_fixed(m))
+        spec = _spec_for(it, :Qm)
+        blk = collect(getproperty(θt, :Qm))
+        n = spec.size[1]
+        offdiag(M) = [M[i, j] for i in 1:n for j in 1:n if i != j]
+        gmin = z -> offdiag(lograterows_inverse(z, n))
+        @test _block_logabsdetjac(spec, blk)≈fd_ref(gmin, blk) atol=1e-6
+        @test _block_logabsdetjac(spec, blk)≈sum(blk) atol=1e-10  # closed form
+    end
+
+    @testset "lie (unstructured)" begin
+        m = @Model begin
+            @fixedEffects begin
+                Ω = RealLiePSDMatrix([1.3 0.2; 0.2 0.9], scale = :lie)
+                σ = RealNumber(0.5, scale = :log)
+            end
+            @covariates begin
+                t = Covariate()
+            end
+            @randomEffects begin
+                η = RandomEffect(MvNormal(zeros(2), Ω); column = :ID)
+            end
+            @formulas begin
+                y ~ Normal(η[1], σ)
+            end
+        end
+        it, θt = _it_theta(NoLimits.get_fixed(m))
+        spec = _spec_for(it, :Ω)
+        blk = collect(getproperty(θt, :Ω))
+        gmin = z -> vechL(liepsd_inverse(z))
+        @test _block_logabsdetjac(spec, blk)≈fd_ref(gmin, blk) atol=1e-6
+        @test all(isfinite, ForwardDiff.gradient(z -> _block_logabsdetjac(spec, z), blk))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,6 +110,7 @@ const TEST_GROUPS = [
         "ad_stickbreak_hmm.jl",
         "continuous_transition_matrix_tests.jl",
         "lie_psd_matrix_tests.jl",
+        "logabsdetjac_tests.jl",
         "enzyme_compat_proxy_tests.jl",
         "enzyme_smoke_tests.jl"]
 ]


### PR DESCRIPTION
## Summary

Extends the public change-of-variables primitive `logabsdetjac(it::InverseTransform, θt)` to **every** fixed-effect scale. Previously it errored on the structured scales (`:cholesky`/`:expm`/`:stickbreak`/`:stickbreakrows`/`:lograterows`/`:lie`); it now sums a per-block correction over `it.specs`.

This is the final follow-up to the method-developer API work (`feat/devapi-primitives`): a method author placing a density on the unconstrained optimizer scale now gets the correct Jacobian term for any parameterization, not just the scalar scales.

## What changed

- **`src/utils/ParameterTranformations.jl`**: per-block helpers. `_block_logabsdetjac(spec, block)` dispatches each block by scale:
  - scalar/diagonal (`:identity`/`:log`/`:logit`/`:elementwise`, `:lograterows`) use closed forms
  - `:cholesky`/`:expm`/`:stickbreak`/`:stickbreakrows`/`:lie` differentiate their **minimal square** inverse map (reshaping the structurally-padded storage down to its free coordinates first)
- **`src/estimation/dev_api.jl`**: `logabsdetjac` is now a per-block sum (was: error on any structured scale). Docstring updated.
- **`test/logabsdetjac_tests.jl`** (new, batch B6): each scale checked against an independent central finite-difference `logabsdet` of the same minimal map, plus a nested-AD finiteness probe.
- **`test/api_primitives_tests.jl`**: dropped the now-obsolete `@test_throws` for the cholesky model.

## Notes

- The `:logit` closed form `log σ + log(1−σ)` is exact because NoLimits' logit scale maps to (0,1) only (`logit_inverse(z) = sigmoid(z)`, no affine bounds term).
- For `:lie` **with fixed eigenvalues** the correction is chart-dependent (the fixed-eigenvalue submanifold is not axis-aligned): self-consistent as a change-of-variables term within a single optimization, but not a chart-invariant number. Documented in the docstring; the golden test covers the unstructured lie case.

## Testing

- Golden agreement vs finite differences per scale (max |Δ| ~1e-8).
- Full suite green: **7 batches, 4041 tests, 0 failures**. Aqua and JuliaFormatter (v1, sciml) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)