### PR TITLE
perf: union-narrow the individuals eltype instead of typejoining

### DIFF
--- a/src/data_model/DataModel.jl
+++ b/src/data_model/DataModel.jl
@@ -1452,7 +1452,11 @@ function DataModel(model,
     # type-stable, which Enzyme reverse mode requires: dynamic getfield on the abstract
     # eltype routes through Enzyme's runtime fallback, which cannot shadow-accumulate
     # into immutable structs (`setfield!: immutable struct ... cannot be changed`).
-    individuals = map(identity, individuals)
+    # A Union, not `map(identity, ...)`: subjects can differ in callback type (some have
+    # no dose events), and `map` widens to the typejoin `Individual{...} where CB`, which
+    # dispatches dynamically. `Union{T} === T`, so homogeneous data is unaffected.
+    individuals = isempty(individuals) ? individuals :
+                  convert(Vector{Union{unique(map(typeof, individuals))...}}, individuals)
     pairing = _build_pairing(individuals, model)
     id_index = Dict{Any, Int}((keys_sorted[i] => i) for i in eachindex(keys_sorted))
     row_groups = RowGroups(groups, obs_groups)

--- a/test/data_model_tests.jl
+++ b/test/data_model_tests.jl
@@ -1649,3 +1649,51 @@ end
     @test isequal(ind.series.obs.y, Union{Missing, Float64}[1.0, missing, 1.2])
     @test isequal(ind.series.obs.z, Union{Missing, Float64}[2.1, 2.0, missing])
 end
+
+# Subjects that differ in dose events get different concrete `Individual` types. `map`
+# would widen those to the typejoin `Individual{...} where CB`, which is abstract and
+# dispatches dynamically on every field access; a Union is union-split instead.
+@testset "individuals eltype stays union-split with mixed dosing" begin
+    model = @Model begin
+        @fixedEffects begin
+            ke = RealNumber(0.5, scale = :log)
+            σ = RealNumber(0.3, scale = :log)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η = RandomEffect(Normal(0.0, 1.0); column = :ID)
+        end
+        @DifferentialEquation begin
+            D(A) ~ -ke * exp(η) * A
+        end
+        @initialDE begin
+            A = 0.0
+        end
+        @formulas begin
+            y ~ Normal(A(t), σ)
+        end
+    end
+    # ID 1 and 2 are dosed; ID 3 never is, so its callbacks differ in type.
+    df = DataFrame(
+        ID = [1, 1, 1, 2, 2, 2, 3, 3],
+        t = [0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 1.0, 2.0],
+        EVID = [1, 0, 0, 1, 0, 0, 0, 0],
+        AMT = [10.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 0.0],
+        RATE = zeros(8),
+        CMT = ones(Int, 8),
+        y = Union{Missing, Float64}[missing, 1.0, 0.8, missing, 0.6, 0.4, 0.2, 0.1]
+    )
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t, evid_col = :EVID,
+        amt_col = :AMT, rate_col = :RATE, cmt_col = :CMT)
+    inds = get_individuals(dm)
+    E = eltype(inds)
+    @test length(unique(map(typeof, inds))) > 1      # the case actually arose
+    @test !isa(E, UnionAll)                          # not widened to the typejoin
+    @test isa(E, Union)
+    # Homogeneous data must still land on a single concrete type (Union{T} === T).
+    dm1 = DataModel(model, df[df.ID .<= 2, :]; primary_id = :ID, time_col = :t,
+        evid_col = :EVID, amt_col = :AMT, rate_col = :RATE, cmt_col = :CMT)
+    @test isconcretetype(eltype(get_individuals(dm1)))
+end


### PR DESCRIPTION
## Problem

`DataModel` construction ends with `individuals = map(identity, individuals)`. `map` widens with the **typejoin**, not a Union. When subjects differ in callback type — some dosed, some not — that yields the abstract `Vector{Individual{...} where CB}`, so every field access on an individual dispatches dynamically on the fit hot path.

`isconcretetype(eltype(get_individuals(dm)))` returns `false` for the `pheno_sd` tutorial model: 56 of 59 subjects carry a `DiscreteCallback`, 3 have no dose events, giving two concrete `Individual` types.

## Fix

Convert to `Vector{Union{...}}` so Julia union-splits. `Union{T} === T`, so homogeneous datasets keep exactly the concrete eltype the existing comment describes and that Enzyme reverse mode requires — that path is unchanged.

## Measurement

`laplace_marginal` on pheno: **0.0160 s → 0.0138 s, −13.7 %**.

Isolated with a controlled A/B — identical data and identical `Individual` objects, only the container's static type differing (`UnionAll` vs `Union`) — which gave −13.0 %. So the delta is dispatch, not noise or a different code path.

## Scope, honestly

Only **1 of 6** tutorial models is affected:

| Model | subjects | distinct callback types | eltype concrete |
|---|---:|---:|---|
| theophylline | 12 | 1 | yes |
| **pheno** | 59 | **2** | **no** |
| nimo | 12 | 1 | yes |
| wbc | 45 | 1 | yes |
| mavoglurant | 19 | 1 | yes |
| warfarin | 32 | 1 | yes |

So this is not a systemic hot-path win. It fires only on datasets with heterogeneous dosing — which is ordinary in real PK data, if not in tidy tutorial sets. The relative gain will also be smaller on ODE-heavy models, where per-individual work dwarfs a fixed dispatch overhead; pheno is a 1-state ODE, which flatters the ratio. I could not produce a second datapoint because every other model here is already concrete.

Worth taking as cheap hygiene rather than a performance push: it removes an abstract container the project's conventions forbid, and it makes the `DataModel` type independent of *which* subjects happen to carry events.

## Test

`data_model_tests.jl` builds a mixed-dosing dataset, asserts the heterogeneous case actually arose (`>1` concrete type), that the eltype is a `Union` and **not** a `UnionAll`, and that homogeneous data still lands on a single concrete type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
