### PR TITLE
fix: make the Hessian guard threshold relative, not an absolute jitter floor

### DIFF
--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -1597,22 +1597,18 @@ ctx::AbstractString = "", tctx = nothing) = inner_curvature(
     mode, dm, batch_info, θ, b, const_cache, cache,
     CurvatureWorkspace(ad_cache, bi); ctx = ctx, tctx = tctx)
 
-# The jitter `_laplace_cholesky_negH` will actually add. Shared with
-# `negH_definite_without_jitter` so the guard and the factorization agree on the threshold.
-function _effective_jitter(Hneg::AbstractMatrix, jitter, adaptive, scale_factor)
-    adaptive || return jitter
-    scale = mean(abs.(diag(Hneg)))
-    scale = isfinite(scale) ? scale : one(real(eltype(Hneg)))
-    return max(jitter, scale_factor * scale)
-end
-
 function _laplace_cholesky_negH(
         H::AbstractMatrix; jitter = 1e-6, max_tries = 6, growth = 10.0,
         adaptive = false, scale_factor = 0.0)
     n = size(H, 1)
     Hneg = Symmetric(-H)
     chol = nothing
-    jit = _effective_jitter(Hneg, jitter, adaptive, scale_factor)
+    jit = jitter
+    if adaptive
+        scale = mean(abs.(diag(Hneg)))
+        scale = isfinite(scale) ? scale : one(real(eltype(Hneg)))
+        jit = max(jit, scale_factor * scale)
+    end
     for _ in 1:max_tries
         chol = cholesky(Hneg + jit * I, check = false)
         chol.info == 0 && return (chol, jit)
@@ -1622,26 +1618,28 @@ function _laplace_cholesky_negH(
 end
 
 """
-    negH_definite_without_jitter(H; jitter=1e-6, adaptive=false, scale_factor=0.0) -> Bool
+    negH_definite_without_jitter(H; rtol=1e-8) -> Bool
 
-Is `-H` positive definite without the diagonal jitter that `_laplace_cholesky_negH`
-adds to force a Cholesky? Validity precondition for a Laplace/AGHQ marginal: if only the
-jitter makes it definite, the `-½·logdet(-H)` term measures the regularisation
-(posterior variance `~1/jitter`) instead of curvature and inflates the marginal past its
-exact ceiling `-n/2·log(2πσ²)`. Tested on primal values so the objective and its gradient
-agree on admissibility.
+Is `-H` positive definite with every curvature direction informative, i.e. without relying
+on the diagonal jitter `_laplace_cholesky_negH` adds to force a Cholesky? Validity
+precondition for a Laplace/AGHQ marginal: when a direction carries no curvature, the
+`-½·logdet(-H)` term measures the regularisation (posterior variance `~1/jitter`) rather
+than the data, and inflates the marginal past its exact ceiling `-n/2·log(2πσ²)`.
 
-`adaptive`/`scale_factor` must mirror what the protected `_laplace_cholesky_negH` call
-uses, so the threshold is the jitter actually added. With the adaptive default the test is
-scale-free (a curvature vs the problem's own diagonal scale); comparing against the bare
-`jitter` instead would make admissibility depend on the units of the data.
+The test is *relative* (`λmin > rtol·λmax`), so it is invariant to the units the data is
+recorded in. An absolute floor is not: comparing against the bare `jitter` makes the same
+posterior admissible in one unit system and degenerate in another, and comparing against
+the adaptive jitter `max(jitter, scale_factor·mean|diag|)` additionally rejects
+well-conditioned Hessians merely for having a large diagonal — which stalls the outer
+optimizer at its starting values. Applied to primal values so the objective and its
+gradient agree on admissibility.
 """
-function negH_definite_without_jitter(H::AbstractMatrix; jitter::Real = 1e-6,
-        adaptive::Bool = false, scale_factor::Real = 0.0)
+function negH_definite_without_jitter(H::AbstractMatrix; rtol::Real = 1e-8)
     size(H, 1) == 0 && return true
     Hneg = -_scalar_value.(H)
     all(isfinite, Hneg) || return false
-    return eigmin(Symmetric(Hneg)) > _effective_jitter(Hneg, jitter, adaptive, scale_factor)
+    λ = eigvals(Symmetric(Hneg))          # ascending; catches λmin <= 0 too
+    return first(λ) > rtol * last(λ)
 end
 
 function _laplace_logdet_negH(dm::DataModel,
@@ -1689,9 +1687,8 @@ function _laplace_logdet_negH(dm::DataModel,
         cache, ad_cache, bi; ctx = ctx, tctx = tctx)
     infT = convert(eltype(H), Inf)
     # Inf here makes the marginal -Inf, so the optimizer backtracks out of a degenerate
-    # region instead of climbing the jitter artifact. Same jitter the Cholesky below adds.
-    negH_definite_without_jitter(H; jitter = jitter, adaptive = adaptive,
-        scale_factor = scale_factor) || return (infT, H, nothing)
+    # region instead of climbing the jitter artifact.
+    negH_definite_without_jitter(H) || return (infT, H, nothing)
     chol, _ = _laplace_cholesky_negH(
         H; jitter = jitter, max_tries = max_tries, growth = growth,
         adaptive = adaptive, scale_factor = scale_factor)

--- a/src/estimation/remeasure.jl
+++ b/src/estimation/remeasure.jl
@@ -597,7 +597,7 @@ function build_centered_re_measure(
     H = _laplace_hessian_b(dm, batch_info, θu, b_star, const_cache, ll_cache, nothing, bi)
     # A jitter-only-definite -H would set the quadrature scale from the regularisation;
     # `nothing` routes the caller to MC sampling, which cannot exceed the ceiling.
-    negH_definite_without_jitter(H; jitter = jitter) || return nothing
+    negH_definite_without_jitter(H) || return nothing
     chol, _ = _laplace_cholesky_negH(H; jitter = jitter, max_tries = max_tries)
     (chol === nothing || chol.info != 0) && return nothing
     L = chol.L  # lower triangular, L*L' = -H

--- a/test/api_primitives_tests.jl
+++ b/test/api_primitives_tests.jl
@@ -579,61 +579,55 @@ struct APITestBayes <: NoLimits.FittingMethod end
     end
 end
 
-# The Laplace/AGHQ marginal is only defined at a genuine interior mode. If `-H` is
-# positive definite only because `jitter` was added, the `-½logdet(-H)` term is set by
-# the regularisation (~1/jitter) and inflates the marginal without bound -- it can then
-# exceed the exact ceiling -n/2·log(2πσ²) that the true marginal must respect.
+# The Laplace/AGHQ marginal is only defined at a genuine interior mode. If a curvature
+# direction is uninformative, the `-½logdet(-H)` term is set by the jitter (~1/jitter) and
+# inflates the marginal without bound -- it can then exceed the exact ceiling
+# -n/2·log(2πσ²) that the true marginal must respect. The test is relative, so the verdict
+# tracks the conditioning of `-H` and never the units the data is recorded in.
 @testset "negH_definite_without_jitter guards the Laplace marginal" begin
-    jit = 1e-6
     ok = NoLimits.negH_definite_without_jitter
 
     # -H = I is comfortably definite; H is the raw Hessian, so pass -I.
-    @test ok(-Matrix(1.0I, 3, 3); jitter = jit)
+    @test ok(-Matrix(1.0I, 3, 3))
     # Zero-dimensional batch: nothing to check.
-    @test ok(zeros(0, 0); jitter = jit)
+    @test ok(zeros(0, 0))
 
-    # Exactly the failure mode observed in practice: one eigenvalue at/below the jitter,
-    # so only the regularisation makes the Cholesky succeed.
-    for λ in (0.0, jit / 10, jit)
-        H = -Matrix(Diagonal([1.0, 1.0, λ]))
-        @test !ok(H; jitter = jit)
+    # A direction with no curvature relative to the rest: only the jitter would make the
+    # Cholesky succeed, so the log-det would measure the regularisation.
+    for lam in (0.0, 1e-14, 1e-10)
+        @test !ok(-Matrix(Diagonal([1.0, 1.0, lam])))
     end
-    # Just above the jitter must still pass, so the guard is not over-eager.
-    @test ok(-Matrix(Diagonal([1.0, 1.0, 10 * jit])); jitter = jit)
+    # Small but informative curvature must pass, so the guard is not over-eager.
+    @test ok(-Matrix(Diagonal([1.0, 1.0, 1e-4])))
 
     # Indefinite (b* is a saddle, not a maximum) and non-finite entries are rejected.
-    @test !ok(-Matrix(Diagonal([1.0, -2.0])); jitter = jit)
-    @test !ok(-Matrix(Diagonal([1.0, NaN])); jitter = jit)
+    @test !ok(-Matrix(Diagonal([1.0, -2.0])))
+    @test !ok(-Matrix(Diagonal([1.0, NaN])))
 
     # Duals are judged on their primal values, so the objective and its gradient agree
     # about which points are admissible.
-    @test !ok(ForwardDiff.Dual.(-Matrix(Diagonal([1.0, 1.0, 0.0])), 1.0); jitter = jit)
-    @test ok(ForwardDiff.Dual.(-Matrix(1.0I, 3, 3), 1.0); jitter = jit)
+    @test !ok(ForwardDiff.Dual.(-Matrix(Diagonal([1.0, 1.0, 0.0])), 1.0))
+    @test ok(ForwardDiff.Dual.(-Matrix(1.0I, 3, 3), 1.0))
 
     # The jittered Cholesky *succeeds* on the singular case -- which is exactly why the
     # determinant alone cannot be trusted and this predicate is needed. A healthy -H is
     # untouched and still gives the exact log-det.
     Hbad = -Matrix(Diagonal([1.0, 1.0, 0.0]))
-    cbad, _ = NoLimits._laplace_cholesky_negH(Hbad; jitter = jit)
+    cbad, _ = NoLimits._laplace_cholesky_negH(Hbad; jitter = 1e-6)
     @test cbad !== nothing && cbad.info == 0
-    @test !ok(Hbad; jitter = jit)
-    cok, _ = NoLimits._laplace_cholesky_negH(-Matrix(Diagonal([2.0, 3.0])); jitter = jit)
+    @test !ok(Hbad)
+    cok, _ = NoLimits._laplace_cholesky_negH(-Matrix(Diagonal([2.0, 3.0])); jitter = 1e-6)
     @test 2 * sum(log, diag(cok.U))≈log(6.0) rtol=1e-6
 
-    # The threshold has to be the jitter the protected Cholesky actually adds. With the
-    # adaptive jitter that Laplace/FOCEI use by default, that makes the verdict depend on
-    # the conditioning of -H rather than on the units the data happens to be in.
-    Hfine = -Matrix(Diagonal([1.0, 1.0, 1e-4]))   # cond 1e4
-    Hdeg = -Matrix(Diagonal([1.0, 1.0, 1e-9]))    # cond 1e9
-    for s in (1.0, 1e3, 1e6)
-        @test ok(s .* Hfine; jitter = jit, adaptive = true, scale_factor = jit)
-        @test !ok(s .* Hdeg; jitter = jit, adaptive = true, scale_factor = jit)
+    # Unit-invariance: the verdict follows conditioning, not scale. A relative threshold
+    # gives this for free; both absolute floors previously tried did not.
+    Hfine = -Matrix(Diagonal([1.0, 1.0, 1e-4]))    # cond 1e4  -> informative
+    Hdeg = -Matrix(Diagonal([1.0, 1.0, 1e-12]))    # cond 1e12 -> degenerate
+    for s in (1e-6, 1.0, 1e3, 1e6)
+        @test ok(s .* Hfine)
+        @test !ok(s .* Hdeg)
     end
-    # Against the bare jitter the degenerate matrix is accepted once the data is scaled up
-    # -- the unit-dependence the shared effective jitter removes.
-    @test ok(1e6 .* Hdeg; jitter = jit)
-    @test !ok(1e6 .* Hdeg; jitter = jit, adaptive = true, scale_factor = jit)
-    # Guard and factorization derive the threshold from the same helper.
-    @test NoLimits._effective_jitter(-(1e6 .* Hdeg), jit, true, jit)≈2e6 / 3 * jit rtol=1e-6
-    @test NoLimits._effective_jitter(-(1e6 .* Hdeg), jit, false, jit) == jit
+    # Scaling a well-conditioned -H up must not make it inadmissible: that over-rejection
+    # is what stalled the pheno fit at its starting values.
+    @test ok(1e6 .* -Matrix(1.0I, 3, 3))
 end


### PR DESCRIPTION
Follow-up to #85. The degenerate-Hessian guard was correct in intent but used the wrong threshold, and it over-rejected.

## Problem

The guard tested `λmin(-H)` against the jitter `_laplace_cholesky_negH` would add. Under the Laplace/FOCEI defaults (`adaptive_jitter = true`, `jitter_scale = 1e-6`) that is `max(jitter, scale_factor·mean|diag(-H)|)` — a threshold that **grows with the magnitude of the Hessian**. A perfectly well-conditioned `-H` with a large diagonal was rejected, and the outer optimizer could not move off its starting values.

Measured on `pheno_sd`:

| | −2LL | Ω[1,1] | tv | warm |
|---|--:|--:|--:|--:|
| before the guard existed | 1035.2 | 0.155 | +0.364 | ~19 s |
| **with the absolute floor** | **1143.83** | **1.013** (init 1.0) | **−0.5076** (init −0.511) | **1.1 s** |
| with this fix | 1035.30 / 1035.22 | 0.155 / 0.161 | +0.367 / +0.364 | 39 s / 16 s |

FOCEI and Laplace returning byte-identical objectives was the tell — both bailed at the same early point rather than converging.

## Fix

Relative threshold: `λmin > rtol·λmax`, `rtol = 1e-8`.

This keeps the property the adaptive comparison was introduced for — **unit-invariance**, since a condition number is scale-free by construction — without inflating with the problem's magnitude. It rejects exactly what it should: directions carrying no curvature *relative to the rest of the Hessian*. Rescaling a dataset now gives the same verdict, which neither absolute floor could guarantee (the bare `jitter` was unit-dependent in one direction, the adaptive jitter over-rejected in the other).

`_effective_jitter` is inlined back into `_laplace_cholesky_negH`, now its only caller.

## Tests

Rewritten to assert the invariant rather than a specific threshold: a cond-1e4 Hessian stays admissible and a cond-1e12 one stays rejected across scalings from 1e-6 to 1e6, and scaling a well-conditioned `-H` up by 1e6 must stay admissible — the case that stalled pheno. Zero-curvature directions (`0.0`, `1e-14`, `1e-10` against unit diagonal), indefinite and non-finite Hessians are still rejected, and the jittered Cholesky is still shown *succeeding* on the singular case, which is why the predicate is needed at all.

1112 assertions green across Laplace, FOCEI, SAEM, MCEM, GHQuadrature, UQ, CV and the dev-API primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
