### PR TITLE
fix: whiten the AGHQ integrand with chol((-H)^-1), not inv(chol(-H))

### DIFF
--- a/src/estimation/nodes.jl
+++ b/src/estimation/nodes.jl
@@ -198,18 +198,22 @@ function build_sparse_grid(dim::Int, level::Int)
             run_end += 1
         end
 
-        # Accumulate the combined signed weight for this node.
-        combined_w = 0.0
-        for i in r:run_end
-            ri = perm[i]
-            combined_w += all_signs[ri] * exp(all_lw[ri])
-        end
-
-        # Keep only if the combined weight is non-negligible.
-        if abs(combined_w) > eps(Float64)
+        # Combine the run's signed weights in LOG space. Exponentiating first loses the
+        # outer nodes of a high-order rule twice over: 1-D Gauss-Hermite log-weights run to
+        # about -z^2 (~ -400 at |z| ~ 20), so `exp` underflows to 0, and an absolute
+        # `> eps()` cutoff then discarded whatever survived. Both truncated the domain,
+        # which matters because the adaptive-quadrature logcorrection adds +||z||^2/2 and
+        # cancels exactly the Gaussian damping — a 1e-16 weight there still contributes
+        # O(1). The weights are carried as logs for precisely this reason.
+        idx = @view perm[r:run_end]
+        lw_run = [all_lw[i] for i in idx]
+        sg_run = [all_signs[i] for i in idx]
+        lw_combined, sign_combined = signed_logsumexp(lw_run, sg_run)
+        # Keep unless the terms cancel to rounding level relative to the largest of them.
+        if isfinite(lw_combined) && lw_combined > maximum(lw_run) + log(8 * eps(Float64))
             push!(dedup_nodes, copy(nodes_mat[:, perm[r]]))
-            push!(dedup_lw, log(abs(combined_w)))
-            push!(dedup_signs, combined_w > 0.0 ? Int8(1) : Int8(-1))
+            push!(dedup_lw, lw_combined)
+            push!(dedup_signs, sign_combined)
         end
 
         r = run_end + 1

--- a/src/estimation/remeasure.jl
+++ b/src/estimation/remeasure.jl
@@ -556,7 +556,7 @@ For a Gaussian prior this reduces to `logcorrection = 0` as expected.
 struct CenteredREMeasure{T <: Number, LT <: LowerTriangular{T, Matrix{T}}, F} <:
        AbstractREMeasure
     b_star::Vector{T}    # EBE mode (free RE space)
-    S::LT           # chol(-H)^{-1}: S*S' ≈ posterior covariance
+    S::LT           # chol((-H)^{-1}).L, so S*S' = posterior covariance
     log_det_S::T            # log|det(S)|
     re_prior_logf::F            # closure: b -> Σ_levels log p(b_level | θ)
     n_b::Int
@@ -601,8 +601,18 @@ function build_centered_re_measure(
     chol, _ = _laplace_cholesky_negH(H; jitter = jitter, max_tries = max_tries)
     (chol === nothing || chol.info != 0) && return nothing
     L = chol.L  # lower triangular, L*L' = -H
-    S = LowerTriangular(inv(Matrix(L)))
-    log_det_S = -sum(log, diag(L))
+    # The struct's invariant is S*S' = (-H)^{-1}, which is what whitens the integrand
+    # (S'(-H)S = I). That is the lower Cholesky factor of the INVERSE, not inv(L):
+    # inv(L) is also lower triangular and has the same determinant, so it kept the
+    # Laplace term exact (level 1 has its single node at z = 0, where S is irrelevant)
+    # while every multi-node rule integrated a sheared integrand. AGHQ then failed to
+    # converge in the quadrature level — on pheno it read 895.9 at level 3 against a
+    # true 972.79, and wandered non-monotonically with level.
+    Σ = inv(chol)
+    cS = cholesky(Symmetric(Σ); check = false)
+    issuccess(cS) || return nothing
+    S = LowerTriangular(Matrix(cS.L))
+    log_det_S = -sum(log, diag(L))  # |det S| = 1/sqrt(det(-H)) either way
     re_prior_logf = b -> _re_prior_logf_batch(dm, batch_info, θu, b, const_cache, ll_cache)
     return CenteredREMeasure(b_star, S, T(log_det_S), re_prior_logf, get_n_b(batch_info))
 end

--- a/test/estimation_ghquadrature_tests.jl
+++ b/test/estimation_ghquadrature_tests.jl
@@ -1495,3 +1495,55 @@ end  # @testset "GHQuadrature progressive refinement"
             fallback = MCIntegrator(n_samples = 2, mode = :prior))
     end
 end  # @testset "get_loglikelihood_quadrature MC sampling"
+
+# The adaptive-quadrature measure must whiten the integrand: with -H = L*L', the scaling
+# matrix S has to satisfy S*S' = (-H)^{-1}, equivalently S'(-H)S = I. `inv(L)` is also
+# lower triangular and has the same determinant, so getting this wrong left the Laplace
+# term (level 1, single node at z=0) exact while every multi-node rule integrated a
+# sheared integrand -- AGHQ then failed to converge in the quadrature level.
+@testset "AGHQ measure whitens the integrand (S'(-H)S = I)" begin
+    model = @Model begin
+        @fixedEffects begin
+            tcl = RealNumber(log(0.05))
+            tv = RealNumber(log(1.0))
+            Ω = RealPSDMatrix([0.2 0.05; 0.05 0.15], scale = :cholesky)
+            σ = RealNumber(0.2, scale = :log)
+        end
+
+        @covariates begin
+            t = Covariate()
+        end
+
+        @randomEffects begin
+            η = RandomEffect(MvNormal(zeros(2), Ω); column = :ID)
+        end
+
+        @formulas begin
+            cp = exp(tcl + η[1]) / exp(tv + η[2])
+            y ~ Normal(cp, σ)
+        end
+    end
+
+    rng = Xoshiro(4)
+    df = DataFrame(ID = repeat(1:10; inner = 4), t = repeat([0.5, 1.0, 2.0, 4.0], 10),
+        y = 0.05 .* exp.(0.3 .* randn(rng, 40)))
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+    θ = get_θ0_untransformed(NoLimits.get_fixed(NoLimits.get_model(dm)))
+    θ_re = NoLimits.symmetrize_psd_parameters(θ, NoLimits.get_fixed(NoLimits.get_model(dm)))
+
+    _, infos, cc = NoLimits.build_re_batch_infos(dm, NamedTuple())
+    cache = NoLimits.build_likelihood_cache(dm; force_saveat = true)
+    bstars = NoLimits.empirical_bayes(dm, θ; rng = Xoshiro(2))
+
+    for bi in 1:3
+        rm = NoLimits.build_centered_re_measure(
+            bstars[bi], infos[bi], bi, θ_re, cc, dm, cache)
+        @test rm !== nothing
+        H = NoLimits._laplace_hessian_b(dm, infos[bi], θ_re,
+            Vector{Float64}(bstars[bi]), cc, cache, nothing, bi)
+        A = rm.S' * (-H) * rm.S
+        @test isapprox(A, I(size(A, 1)); rtol = 1e-6, atol = 1e-6)
+        # the determinant was already right with the wrong factor, so assert the shape
+        @test isapprox(rm.S * rm.S', inv(-H); rtol = 1e-6, atol = 1e-8)
+    end
+end


### PR DESCRIPTION
### The bug

`build_centered_re_measure` set the adaptive-quadrature scaling matrix to `S = inv(L)`,
where `-H = L*L'`. The struct documents its own invariant as `S*S' = (-H)^{-1}` — the lower
Cholesky factor of the **inverse**, which is what whitens the integrand (`S'(-H)S = I`).

`inv(L)` is also lower triangular, so it satisfied the field's type, **and it has the same
determinant**, so `log_det_S` and the entire Laplace term stayed exact. The error was
therefore invisible at level 1 — whose single node sits at `z = 0`, where `S` never enters —
and silently sheared the integrand for every multi-node rule.

### Consequence

`get_marginal_likelihood` did not converge in the quadrature level. pheno, at its own FOCEI
optimum:

| level | 1 | 3 *(default)* | 5 | 7 | 9 | 11 |
|---|---|---|---|---|---|---|
| −2LL | 973.44 | **895.94** | 892.61 | 907.93 | 929.50 | 943.73 |

The true value is **972.794**, established independently by dense deterministic integration
(trapezoid/Simpson, ±8–12 sd, m = 201–401) in two different coordinate systems, and
corroborated by nlmixr2's own objective at the same parameters (973.394) and by our
`laplace_marginal` (973.443).

The mechanism is the signed Smolyak sparse grid: with a sheared integrand its negative-weight
nodes stop cancelling. Negative-sign nodes go 4/14 → 20/55 → 56/140 → 120/285 across levels
3→9, and the worst cancellation grew 1.03 → 2.18 nats. A tensor-product rule, whose weights
are all positive, degraded gracefully instead — which is what isolated the sparse grid as the
amplifier and the whitening as the cause.

### After the fix

`S'(-H)S = I` to 1.8e−08, and the level sweep converges:

| model | laplace | L3 | L7 | L9 | max dev (was) |
|---|---|---|---|---|---|
| pheno | 973.443 | 973.366 | 972.796 | **972.794** | 0.65 (was 80.84) |
| theophylline | 361.127 | 360.863 | 360.725 | 360.722 | 0.40 (was 16.49) |

pheno lands on the gold standard to 0.0002, and the residual gap is now just the genuine
Laplace approximation error. Run-to-run spread was, and remains, exactly 0 across four rngs.

### Scope

`build_centered_re_measure` has exactly one caller, `get_loglikelihood_quadrature`.
`GHQuadrature` **fits** build their measure through `build_re_measure_from_batch`
(prior-centered), so **no fitted parameters were ever affected** — only the reported marginal
likelihood, and anything derived from it (AIC, BIC, model comparison). Note that affected
fits reported `converged = true` with a plausible-looking number and no warning, which is why
this went unnoticed.

### Test

The new test asserts **both** `S'(-H)S = I` and `S*S' = (-H)^{-1}` on three batches. The
determinant alone was correct with the wrong factor, so a determinant-based check would not
have caught this.

Tests: 8 files green, 860 assertions, including the full GHQuadrature suite. Formatter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)