### PR TITLE
fix: two defects in the Laplace/FOCEI analytic outer gradient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@
 
 ### Bug fixes
 
+- The analytic outer gradient of the `Laplace` and `FOCEI` marginal objectives was wrong,
+  which made a gradient-based outer optimizer perform far worse than the derivative-free
+  default instead of better. Two independent causes, both invisible to `LN_BOBYQA`:
+  - A positive-definite `-H` was factorized with the Cholesky `jitter` added
+    unconditionally rather than only as a rescue. With the default
+    `adaptive_jitter = true, jitter_scale = 1e-6` that jitter is proportional to
+    `mean|diag(-H)|`, so the objective was `logdet(-H + δ(θ,b)·I)` while the analytic
+    gradient differentiated it as if `δ` were constant, and the same regularized factor was
+    reused for the implicit `db*/dθ` solve. On a badly scaled start `δ` reached 9% of
+    `λmin(-H)`. `-H` is now factorized untouched whenever it is definite, so the objective
+    is the actual Laplace marginal and its gradient is consistent with it. The jitter
+    keywords are retained and still rescue an indefinite `-H`. This also makes the AGHQ
+    quadrature scale, the conditional-covariance draws behind VPC/CV, and the inner Newton
+    step exact rather than regularized.
+  - `db*/dθ` was obtained by solving with whatever curvature the log-det term used. Under
+    `FOCEI`/FOCE that is the Fisher-information surrogate, but `b*` is the mode of
+    `log f`, so the implicit function theorem requires the exact inner Hessian. The
+    surrogate is within ~1% of it, yet the correction it feeds is a difference of large
+    nearly-cancelling terms, so the outer gradient came out wrong by up to 240%. FOCEI/FOCE
+    now solve that system with the exact Hessian, falling back to the surrogate if the
+    exact `-H` is indefinite. `Laplace` is unaffected and pays nothing; the FOCEI objective
+    stays first-order and only its gradient costs ~1.4% more.
 - Laplace- and FOCEI-based marginal likelihoods no longer report values obtained from a
   degenerate empirical-Bayes Hessian. When `-H` at the EB mode was positive definite only
   because the Cholesky `jitter` had been added, the `-½·logdet(-H)` term was set by the

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -1593,9 +1593,16 @@ ctx::AbstractString = "", tctx = nothing) = inner_curvature(
 function _laplace_cholesky_negH(
         H::AbstractMatrix; jitter = 1e-6, max_tries = 6, growth = 10.0,
         adaptive = false, scale_factor = 0.0)
-    n = size(H, 1)
     Hneg = Symmetric(-H)
-    chol = nothing
+    # Un-jittered first. Any jitter surviving into the returned factor makes the
+    # log-determinant a function of `jit` as well as of θ and b, while
+    # `_laplace_grad_batch` differentiates logdet(-H + jit*I) as if `jit` were constant
+    # and uses the same factor for db*/dθ, which needs the unregularised Hessian. With
+    # the adaptive jitter (jit ≈ scale_factor·mean|diag(-H)|) that error is large enough
+    # to break a gradient-based outer optimizer. Regularisation stays as a fallback for a
+    # genuinely indefinite -H, where the alternative is no factor at all.
+    chol = cholesky(Hneg, check = false)
+    chol.info == 0 && return (chol, zero(jitter))
     jit = jitter
     if adaptive
         scale = mean(abs.(diag(Hneg)))
@@ -1884,9 +1891,28 @@ function _laplace_grad_batch(dm::DataModel,
         grad_logdet_b = buf.grad_logdet_b
     end
 
-    # db*/dθ = (-H)^{-1} * ∂g/∂θ
-    #Hneg = Symmetric(-H)
-    dbdθ = chol \ Gθ
+    # db*/dθ = (-H_exact)^{-1} ∂g/∂θ. The implicit function theorem differentiates the
+    # stationarity condition ∇_b logf(b*, θ) = 0, which is a property of logf alone, so the
+    # EXACT inner Hessian is required even when the logdet term uses a surrogate curvature.
+    # FOCEI's Fisher information is within ~1% of the exact Hessian on pheno, but the
+    # correction it feeds below is a difference of large nearly-cancelling terms, so that 1%
+    # showed up as a 240% error in the outer gradient — enough to make a gradient-based outer
+    # optimizer diverge while the derivative-free default was unaffected.
+    chol_b = chol
+    if !(hmode isa _ExactHess)
+        H_ex = try
+            _laplace_hessian_b(dm, batch_info, θ, b, const_cache, cache, ad_cache, bi;
+                ctx = "dbdtheta", tctx = tctx0)
+        catch err
+            _is_numeric_error(err) ? nothing : rethrow(err)
+        end
+        if H_ex !== nothing && negH_definite_without_jitter(H_ex)
+            c, _ = _laplace_cholesky_negH(H_ex; jitter = jitter, max_tries = max_tries,
+                growth = growth, adaptive = adaptive, scale_factor = scale_factor)
+            (c === nothing || c.info != 0) || (chol_b = c)
+        end
+    end
+    dbdθ = chol_b \ Gθ
     corr = vec(grad_logdet_b' * dbdθ)
     grad = grad_logf .- 0.5 .* (grad_logdet_θ .+ corr)
     return (logf = logf, logdet = logdet, grad = ComponentArray(grad, axs))
@@ -1986,11 +2012,16 @@ random effects.
 - `multistart_grad_tol`: gradient tolerance for multistart refinement.
 - `multistart_max_rounds::Int = 1`: maximum multistart refinement rounds.
 - `multistart_sampling::Symbol = :lhs`: inner multistart sampling strategy (`:lhs` or `:random`).
-- `jitter::Float64 = 1e-6`: initial diagonal jitter added to ensure Hessian PD.
+- `jitter::Float64 = 1e-6`: diagonal jitter used to rescue a Cholesky of `-H` that fails
+  without it. A positive-definite `-H` is always factorized untouched, so on a healthy
+  problem none of the jitter keywords has any effect: a jitter that survived into the
+  factor would bias `logdet(-H)` and make the analytic outer gradient inconsistent with
+  the objective, since the gradient treats the jitter as constant.
 - `max_tries::Int = 6`: maximum attempts to regularize the Hessian.
 - `jitter_growth::Float64 = 10.0`: multiplicative growth factor for jitter on each retry.
-- `adaptive_jitter::Bool = true`: whether to adapt jitter magnitude based on scale.
-- `jitter_scale::Float64 = 1e-6`: scale for the adaptive jitter.
+- `adaptive_jitter::Bool = true`: scale the rescue jitter by `mean|diag(-H)|` so it is
+  unit-invariant. Only consulted when the un-jittered Cholesky has already failed.
+- `jitter_scale::Float64 = 1e-6`: proportionality factor for the adaptive jitter.
 - `use_trace_logdet_grad::Bool = true`: use trace estimator for log-determinant gradient.
 - `use_hutchinson::Bool = false`: use Hutchinson estimator instead of Cholesky for log-det.
 - `hutchinson_n::Int = 8`: number of Rademacher vectors for the Hutchinson estimator.

--- a/src/uq/wald.jl
+++ b/src/uq/wald.jl
@@ -23,8 +23,28 @@ function _finalize_wald_uqresult(fe, θ_hat_t, θ_hat_u, free_names, active_idx,
         draws_n[i, :] .= coords_u_i[active_idx]
     end
 
+    # A Wald draw is Gaussian on the TRANSFORMED scale, so pushing it through the inverse
+    # transform can overflow when a coordinate is weakly identified: `exp` of a wide
+    # log-Cholesky draw is `Inf`, and `Inf - Inf` is `NaN`. Those rows used to flow straight into
+    # the natural-scale covariance and quantiles, so `get_uq_vcov()` returned an all-NaN matrix
+    # (its default is `scale = :natural`) and the intervals threw on quantiles of NaN. The
+    # transformed-scale covariance is unaffected and stays exact; only the natural-scale
+    # summaries drop the offending rows, and the count is reported so it cannot pass unnoticed.
+    finite_rows = [all(isfinite, @view(draws_n[i, :])) for i in 1:size(draws_n, 1)]
+    n_nonfinite = count(!, finite_rows)
+    n_nonfinite == length(finite_rows) &&
+        error("Wald natural-scale summaries unavailable: all $(n_nonfinite) draws overflowed " *
+              "when mapped to the natural scale, which means the estimate is only weakly " *
+              "identified in at least one coordinate. The transformed-scale covariance is " *
+              "still available via get_uq_vcov(uq; scale = :transformed).")
+    n_nonfinite > 0 &&
+        @warn "Excluding non-finite Wald draws from the natural-scale summaries." n_nonfinite n_total=length(finite_rows)
+    # `draws_n` itself is kept whole: `get_uq_draws` should report what was drawn, and a user
+    # inspecting the draws should see the overflow rather than find rows silently missing.
+    draws_n_fin = n_nonfinite > 0 ? draws_n[finite_rows, :] : draws_n
+
     intervals_t = _intervals_from_draws(draws_t, level)
-    intervals_n = _intervals_from_draws(draws_n, level)
+    intervals_n = _intervals_from_draws(draws_n_fin, level)
 
     ext = _extend_natural_stickbreak(fe, free_names, active_names, active_kinds,
         est_n, draws_n, intervals_n)
@@ -32,8 +52,10 @@ function _finalize_wald_uqresult(fe, θ_hat_t, θ_hat_u, free_names, active_idx,
     est_n_use = ext !== nothing ? ext[2] : est_n
     draws_n_use = ext !== nothing ? ext[3] : draws_n
     intervals_n_use = ext !== nothing ? ext[4] : intervals_n
-    Vn_use = draws_n_use !== nothing ? _cov_from_draws(draws_n_use) :
-             _cov_from_draws(draws_n)
+    # Covariance from the finite rows only, of whatever the stickbreak extension produced.
+    Vn_src = draws_n_use !== nothing ? draws_n_use : draws_n
+    Vn_rows = [all(isfinite, @view(Vn_src[i, :])) for i in 1:size(Vn_src, 1)]
+    Vn_use = _cov_from_draws(all(Vn_rows) ? Vn_src : Vn_src[Vn_rows, :])
 
     diag = merge(
         (;
@@ -46,6 +68,7 @@ function _finalize_wald_uqresult(fe, θ_hat_t, θ_hat_u, free_names, active_idx,
         (;
             pseudo_inverse = pseudo_inverse,
             n_draws = n_draws,
+            n_draws_nonfinite_natural = n_nonfinite,
             n_active_parameters = length(active_idx),
             coordinate_transforms = active_kinds
         ),

--- a/src/uq/wald.jl
+++ b/src/uq/wald.jl
@@ -216,6 +216,14 @@ function _compute_uq_wald_no_re(res::FitResult;
         fd_rel_step = fd_rel_step,
         fd_max_tries = fd_max_tries)
     H_active = 0.5 .* (H_active .+ H_active')
+    # `pinv` of a non-finite matrix returns all-NaN without throwing, so without this the caller
+    # gets NaN standard errors and no explanation. Same principle as rejecting a jitter-only
+    # definite Hessian: report that the covariance is unavailable rather than fabricate one.
+    all(isfinite, H_active) ||
+        error("Wald covariance unavailable: the objective Hessian at the estimate is not " *
+              "finite (backend $(backend_used)). The fit is at a point where the marginal " *
+              "is not differentiable - typically a degenerate random-effect covariance or an " *
+              "unconverged fit. Check the fit converged, or use method = :profile / :mcmc.")
 
     bread = try
         pseudo_inverse ? pinv(H_active) : inv(H_active)

--- a/test/api_primitives_tests.jl
+++ b/test/api_primitives_tests.jl
@@ -619,6 +619,20 @@ end
     cok, _ = NoLimits._laplace_cholesky_negH(-Matrix(Diagonal([2.0, 3.0])); jitter = 1e-6)
     @test 2 * sum(log, diag(cok.U))≈log(6.0) rtol=1e-6
 
+    # A positive-definite -H must be factorised untouched, whatever the jitter settings. The
+    # default `adaptive_jitter` is proportional to mean|diag(-H)|, so on a wide spectrum it
+    # inflated the log-det of a perfectly healthy Hessian (0.51 nats here). That biased the
+    # marginal AND broke the analytic outer gradient, which treats the jitter as constant --
+    # invisible to the derivative-free default optimizer, fatal to a gradient-based one.
+    Hwide = -Matrix(Diagonal([1e6, 1e6, 1.0]))
+    for kw in ((; adaptive = true, scale_factor = 1e-6),
+        (; adaptive = false, scale_factor = 0.0))
+        cw, jitw = NoLimits._laplace_cholesky_negH(Hwide; jitter = 1e-6, kw...)
+        @test cw.info == 0
+        @test iszero(jitw)
+        @test 2 * sum(log, diag(cw.U))≈logdet(-Hwide) rtol=1e-12
+    end
+
     # Unit-invariance: the verdict follows conditioning, not scale. A relative threshold
     # gives this for free; both absolute floors previously tried did not.
     Hfine = -Matrix(Diagonal([1.0, 1.0, 1e-4]))    # cond 1e4  -> informative

--- a/test/estimation_laplace_tests.jl
+++ b/test/estimation_laplace_tests.jl
@@ -96,6 +96,84 @@ end
     _laplace_grad_matches_fd(fx_mg_dm(); rtol = 2e-3, atol = 2e-3)
 end
 
+# The outer gradient the OPTIMIZER receives: on the transformed free-parameter scale, at the
+# package defaults, for a given curvature. Distinct from `_laplace_grad_matches_fd` above in
+# three ways that each hid a defect:
+#   * transformed scale, so a `RealPSDMatrix` is covered (perturbing Ω[1,2] on the natural
+#     scale breaks symmetry and the Cholesky fails, so the natural-scale check cannot);
+#   * `method.hessian` verbatim, i.e. the default ADAPTIVE jitter rather than a fixed one;
+#   * parameterised by curvature, so FOCEI/FOCE's Fisher information is checked too.
+function _outer_grad_matches_fd_t(dm, method, hmode; rtol, h = 3e-4)
+    fe = NoLimits.get_fixed(NoLimits.get_model(dm))
+    layout = NoLimits.free_parameter_layout(fe)
+    inner = NoLimits._resolve_inner_options(method.inner, dm)
+    ms = NoLimits._resolve_multistart_options(method.multistart, inner)
+    _, binfos, const_cache = NoLimits._build_re_batch_infos(dm, NamedTuple())
+    llc = build_ll_cache(dm; force_saveat = true)
+    kw = (; inner = inner, hessian = method.hessian, cache_opts = method.cache,
+        multistart = ms, serialization = SciMLBase.EnsembleSerial(), hmode = hmode)
+    fresh() = NoLimits._init_laplace_eval_cache(length(binfos), Float64)
+    θu_of = θt -> layout.inv_transform(NoLimits._merge_free_into_full(
+        layout.θ_const_t_vec, layout.free_idx,
+        ComponentArray(collect(θt), layout.axs), layout.axs_full))
+    obj = θt -> NoLimits._laplace_objective_only(dm, binfos, θu_of(θt), const_cache,
+        llc, fresh(); rng = Random.Xoshiro(0), kw...)
+
+    θt0 = collect(layout.θ0_free_t)
+    θt_full = NoLimits._merge_free_into_full(layout.θ_const_t_vec, layout.free_idx,
+        layout.θ0_free_t, layout.axs_full)
+    _, g_u, _ = NoLimits._laplace_objective_and_grad(dm, binfos, θu_of(θt0), const_cache,
+        llc, fresh(); rng = Random.Xoshiro(0), kw...)
+    g_t = NoLimits.apply_inv_jacobian_T(layout.inv_transform, θt_full, g_u)
+    g_free = similar(layout.θ0_free_t)
+    for name in layout.free_names
+        setproperty!(g_free, name, getproperty(g_t, name))
+    end
+    fd = map(eachindex(θt0)) do i
+        θp = copy(θt0)
+        θp[i] += h
+        θm = copy(θt0)
+        θm[i] -= h
+        (obj(θp) - obj(θm)) / (2h)
+    end
+    @test all(isfinite, collect(g_free))
+    @test isapprox(collect(g_free), fd; rtol = rtol)
+end
+
+@testset "outer gradient matches FD at the defaults (nonlinear in η)" begin
+    # Nonlinear in η, so the Fisher-information curvature genuinely differs from the exact
+    # Hessian (~4-6% here). Every pre-existing gradient check uses a model LINEAR in η with a
+    # Gaussian outcome, where the two coincide exactly and a surrogate curvature is right by
+    # accident -- which is why FOCEI's db*/dθ term could use the wrong one unnoticed.
+    df = DataFrame(ID = repeat(1:5, inner = 4), t = repeat(0.0:3.0, 5),
+        y = [1.35, 1.10, 0.92, 0.81, 1.62, 1.28, 1.05, 0.90,
+            1.18, 0.99, 0.85, 0.74, 1.90, 1.47, 1.19, 1.02,
+            1.05, 0.88, 0.77, 0.68])
+    model = @Model begin
+        @fixedEffects begin
+            a = RealNumber(0.3)
+            b = RealNumber(0.25, scale = :log)
+            σ = RealNumber(0.08, scale = :log)
+            Ω = RealPSDMatrix([1.0 0.95; 0.95 1.0], scale = :cholesky)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η = RandomEffect(MvNormal(zeros(2), Ω); column = :ID)
+        end
+        @formulas begin
+            y ~ Normal(exp(a + η[1]) * exp(-exp(b + η[2]) * t), σ)
+        end
+    end
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+    _outer_grad_matches_fd_t(dm, NoLimits.Laplace(), NoLimits._ExactHess(); rtol = 2e-3)
+    _outer_grad_matches_fd_t(
+        dm, NoLimits.FOCEI(), NoLimits._FOCEIHess(true); rtol = 2e-3)
+    _outer_grad_matches_fd_t(dm, NoLimits.FOCEI(interaction = false),
+        NoLimits._FOCEIHess(false); rtol = 2e-3)
+end
+
 @testset "Laplace batching with constant RE levels" begin
     dm = fx_mg_dm()
     @test length(get_batches(dm)) == 2

--- a/test/uq_tests.jl
+++ b/test/uq_tests.jl
@@ -271,15 +271,15 @@ end
     for (scale, n_coords, seed) in ((:cholesky, 3, 31), (:expm, 3, 32), (:lie, 3, 33))
         model = _uq_psd_re_model(scale)
         dm = DataModel(model, _uq_psd_re_df(); primary_id = :ID, time_col = :t)
-        # The default outer optimizer (NLopt.LN_BOBYQA) is derivative-free and
-        # unconstrained; on this weakly-identified PSD covariance it wanders into a
-        # degenerate region and the Wald vcov comes out NaN. Pin the gradient-based
-        # LBFGS these finiteness/symmetry checks were calibrated against.
+        # This PSD covariance is weakly identified, so the Wald Hessian is only finite at a
+        # properly converged estimate - at a degenerate point it is NaN and `compute_uq` now
+        # says so rather than returning NaN silently. The step cap is what keeps the fit out of
+        # that region; a 2-iteration fit used to land somewhere usable only because the
+        # unconditional Hessian jitter was regularising the log-det.
         res = fit_model(dm,
             NoLimits.Laplace(;
                 optimizer = OptimizationOptimJL.LBFGS(
-                    linesearch = LineSearches.BackTracking()),
-                optim_kwargs = (maxiters = 2,)))
+                    linesearch = LineSearches.BackTracking(maxstep = 1.0))))
 
         uq = compute_uq(res; method = :wald, pseudo_inverse = true,
             n_draws = 40, rng = Random.Xoshiro(seed))

--- a/test/uq_tests.jl
+++ b/test/uq_tests.jl
@@ -257,12 +257,18 @@ function _uq_psd_re_model(scale::Symbol)
     end
 end
 
+# 12 subjects x 3 observations. A 2x2 random-effect covariance has 3 free coordinates and
+# cannot be identified from the 3 subjects this fixture used to carry, so its Wald Hessian was
+# near-singular by construction: the test passed only because a 2-iteration fit and the
+# unconditional Cholesky jitter together kept it away from the boundary. With the covariance
+# actually identified, the Hessian exists and the testset asserts what it is named for - that
+# Wald works in every PSD scale - rather than a knife-edge.
 function _uq_psd_re_df()
-    return DataFrame(
-        ID = [:A, :A, :B, :B, :C, :C],
-        t = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
-        y = [0.1, 0.2, 0.0, -0.1, 0.15, 0.18]
-    )
+    ids = [Symbol("S", i) for i in 1:12]
+    y = [0.10, 0.21, 0.32, 0.02, -0.08, -0.15, 0.15, 0.19, 0.27, -0.05, 0.04, 0.11,
+        0.22, 0.30, 0.41, -0.12, -0.06, 0.01, 0.08, 0.17, 0.25, 0.31, 0.36, 0.44,
+        -0.02, 0.06, 0.14, 0.18, 0.24, 0.29, 0.05, 0.12, 0.20, -0.09, -0.01, 0.07]
+    return DataFrame(ID = repeat(ids; inner = 3), t = repeat([0.0, 1.0, 2.0], 12), y = y)
 end
 
 @testset "UQ Wald for Laplace with PSD fixed covariance (cholesky/expm/lie)" begin


### PR DESCRIPTION
Swapping the derivative-free default outer optimizer for a gradient-based one made `Laplace`/`FOCEI` fits much **worse** instead of better (pheno Laplace: 973 → 8157). Two independent causes, both invisible to `LN_BOBYQA` because it never asks for a gradient.

## 1. The Hessian jitter was unconditional and scale-proportional

`_laplace_cholesky_negH` added the jitter on the *first* attempt rather than as a rescue. With the default `adaptive_jitter = true, jitter_scale = 1e-6` it is proportional to `mean|diag(-H)|`, so the objective was `logdet(-H + δ(θ,b)·I)` while the analytic gradient differentiated it as if `δ` were constant — and the same regularised factor was reused for the implicit `db*/dθ` solve. On pheno's published start `δ` reached **9% of `λmin(-H)`**.

A positive-definite `-H` is now factorised untouched. The jitter keywords still rescue an indefinite one. This also makes the AGHQ quadrature scale, the VPC/CV conditional-covariance draws and the inner Newton step exact rather than regularised.

## 2. `db*/dθ` solved with the wrong Hessian under FOCEI

`b*` is the mode of `log f`, so the implicit function theorem requires the **exact** inner Hessian. The code solved with whatever curvature the log-det term used — under FOCEI/FOCE that is the Fisher-information surrogate. The surrogate is within **~1%** of the exact Hessian, yet the correction it feeds is a difference of large nearly-cancelling terms, so the outer gradient came out wrong by up to **240%**.

FOCEI/FOCE now solve that system with the exact Hessian, falling back to the surrogate if the exact `-H` is indefinite. `Laplace` is unaffected and pays nothing (the branch resolves at compile time); the FOCEI objective stays first-order and only its gradient costs ~1.4% more.

## Verification

Worst relative error of the outer gradient against central differences, on the transformed scale, at each model's published inits — all six benchmark models, both methods:

| model | Laplace before | after | FOCEI before | after |
|---|--:|--:|--:|--:|
| theophylline | 7.39e-5 | 2.13e-5 | **2.23e0** | **3.78e-5** |
| pheno | **3.04e-2** | **5.50e-5** | **7.83e-2** | **5.29e-6** |
| nimo | 2.04e-1 | 2.04e-1 | 6.35e-2 | 6.22e-2 |
| wbc | 1.21e0 | 1.21e0 | 1.09e0 | 7.63e-1 |
| mavoglurant | 2.50e-2 | 2.50e-2 | **4.14e-1** | **3.78e-2** |
| warfarin | 5.13e0 | 5.10e0 | 1.15e0 | 5.96e-1 |

Read the columns separately: defect 1 has a **narrow** blast radius (the Laplace column moves only on pheno, 550×), while defect 2 affects **all six** models — 59000× on theophylline, whose LBFGS symptom was +0.0, i.e. the bug was invisible from the outside.

Rows that still read large are a limitation of the *measurement*, not the gradient: on stiff-ODE objectives the finite-difference reference disagrees with **itself** by 23–120% across step sizes. Tightening ODE tolerances to the right level (model-dependent, non-monotone) certifies every one of the six: wbc `1e-10` → 1.68e-5 (8/8 coords), nimo `1e-9` → 1.77e-4 (12/12), mavoglurant `1e-11` → 2.96e-4 (9/9), warfarin `1e-10` → 6.34e-4 (19/19).

`LN_BOBYQA` fits are undisturbed: Laplace 973.441 → 973.440, FOCEI 973.394 → 973.393 on pheno, with fitted parameters agreeing to 3–4 decimals. No existing result is invalidated.

## Why it shipped, and the tests added

Every pre-existing gradient check uses a model **linear in η with a Gaussian outcome**, where `H_FI ≡ H_exact` identically and the curvature is well conditioned — so both a surrogate curvature and a scale-proportional jitter are correct by accident. `_laplace_grad_matches_fd` additionally passes `adaptive = false`, so the default configuration was never checked at all.

Two tests added; run against this branch's parent they produce **6 failures**:
- a jitter-invariance check on a positive-definite `-H` (log-det error 0.511 before, exact after);
- `_outer_grad_matches_fd_t`, which differentiates on the **transformed** scale (so a `RealPSDMatrix` is covered at all — a natural-scale perturbation breaks symmetry and returns NaN), uses `method.hessian` verbatim so the adaptive jitter is live, and is parameterised by curvature so FOCEI and FOCE are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)