### PR TITLE
perf: gradient-based outer optimizer by default, preconditioning everywhere, finite infeasible wall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,17 @@
   covariance when the objective Hessian at the estimate contains non-finite entries, which
   `pinv` otherwise propagates into every reported quantity.
 
+- `GHQuadrature` no longer throws `MethodError: no method matching Float64(::ForwardDiff.Dual)`
+  when its outer optimizer uses automatic differentiation. `batch_loglik_ghq` took its
+  accumulator element type from the random-effects measure alone, on the assumption that a
+  Dual-tagged `θ` always yields a Dual-valued measure. That fails for a random effect declared
+  with fixed hyperparameters (e.g. `RandomEffect(Normal(0.0, 1.0))`), whose measure carries no
+  `θ` and stays `Float64` while the conditional log-likelihoods being summed into it are Dual.
+  The accumulator is now promoted against `θ` as well. The bug predates this release but was
+  unreachable while the default outer optimizer was derivative-free; it would have surfaced as
+  soon as the default became gradient-based. Non-AD fits and models whose measure does depend
+  on `θ` are bit-unchanged, since `promote_type` is the identity in both cases.
+
 ### Other changes
 
 - All nine optimization-based methods (`MLE`, `MAP`, `Laplace`, `FOCEI`, `GHQuadrature`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,37 @@
   changes the length and layout of the transformed vector, of `get_flat_names`, and of
   Wald UQ coordinates for `RealPSDMatrix(scale = :cholesky)` parameters.
 
+- Wald UQ no longer returns `NaN` natural-scale summaries when a transformed-scale draw
+  overflows. `wald_uq` draws from a Gaussian on the transformed scale and pushes each draw
+  through the inverse transform; for a covariance parameter that transform is exponential, so
+  a wide-but-legitimate transformed covariance (`max(diag) ~ 1e12` for `:cholesky` and
+  `:lie`, versus `~1e4` for `:expm`) sends draws to `Inf`, and a single one poisoned every
+  natural-scale interval, standard error and correlation. Non-finite draws are now excluded
+  from the natural-scale summaries with a warning naming how many were dropped, recorded in
+  the new `n_draws_nonfinite_natural` diagnostic, and an error is raised only if every draw
+  is non-finite. `get_uq_draws` still returns all requested draws untouched. The
+  transformed-scale summaries were never affected.
+- `wald_uq` now errors with an actionable message instead of producing a silently meaningless
+  covariance when the objective Hessian at the estimate contains non-finite entries, which
+  `pinv` otherwise propagates into every reported quantity.
+
 ### Other changes
+
+- All nine optimization-based methods (`MLE`, `MAP`, `Laplace`, `FOCEI`, `GHQuadrature`,
+  `SAEM`, `MCEM`, `Pooled`, `PooledMap`) now precondition the outer problem by default,
+  via a new `precondition::Bool = true` keyword. The optimizer works in a scaled offset
+  `θ_transformed = θ0 + s .* z` and therefore always starts from `z = 0`, with `s = 1` for
+  coordinates already in log/logit space and `s = max(abs(θ0), 1)` for genuinely
+  natural-scale `:identity` coordinates. This removes a failure mode in which a coordinate
+  whose starting value was near zero could not move at all, because several optimizers size
+  their initial trial step relative to `abs(x0)`. Set `precondition = false` to optimize the
+  transformed vector directly, which reproduces earlier results bit-for-bit. With
+  preconditioning on, the optimizer object returned by `get_raw` works in `z`; `get_params`
+  is unaffected. `SAEM` and `MCEM` re-anchor `θ0` at the current iterate each M-step.
+- Optimization-based methods that can return a non-finite objective now hand the optimizer a
+  large finite value derived from the best objective seen so far, rather than `Inf`. A line
+  search cannot read a slope from `Inf`, so an overflowing trial step used to abort the fit at
+  its starting value; it now backtracks out of the infeasible region.
 
 - `Laplace` and `FOCEI` now document that a gradient-based outer optimizer must cap its
   line-search step. With the outer gradient corrected (see above) it is usable, and on the widest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@
 
 ### Other changes
 
+- `Laplace` and `FOCEI` now document that a gradient-based outer optimizer must cap its
+  line-search step. With the outer gradient corrected (see above) it is usable, and on the widest
+  benchmark model it beats the derivative-free default by ~536 `-2LL` units - but the gradient's
+  coordinates can span four orders of magnitude at a poorly scaled start, so an uncapped unit
+  first step overflows into the region where the marginal is not finite. `BackTracking(maxstep =
+  1.0)`, the convention the inner optimizer has always used, takes `pheno_sd` from `-2LL` 6038 to
+  973.44 (the BOBYQA optimum) and converges in 91 s instead of exhausting `maxiters` in 623 s.
+  Finite `lb`/`ub` are an alternative - they route through `Fminbox`, whose barrier keeps
+  iterates interior - but are ~300x slower for the same answer. Do not combine a step cap with a
+  shrunken `alphaguess`; the two starve each other.
 - `FOCEI` accepts BlackBoxOptim optimizers, on the same terms as `Laplace`: finite bounds
   on every free parameter are required and the start is clamped into the box.
 - `Optimization` is capped below 5.7. Optimization 5.7.0 stopped exporting the

--- a/docs/src/estimation/focei.md
+++ b/docs/src/estimation/focei.md
@@ -115,11 +115,12 @@ jitter controls, caching, and bounds all behave identically. The only addition i
 `interaction::Bool=true`. See the [Laplace](laplace.md) page for the full description of
 the shared option groups, and the [`FOCEI`](@ref) API entry for the complete keyword list.
 
-As with `Laplace`, the default **outer** fixed-effects optimizer is the derivative-free
-`NLopt.LN_BOBYQA()` (capped at `maxiters=1000` function evaluations), while the inner EB
-optimization defaults to `OptimizationOptimJL.LBFGS`. NLopt optimizers interpret
-`optim_kwargs.maxiters` as a cap on the number of function *evaluations* (`maxeval`); reaching
-it yields `retcode = MaxIters` (reported as not converged).
+As with `Laplace`, both the **outer** fixed-effects optimizer and the inner EB optimization
+default to `OptimizationOptimJL.LBFGS(linesearch=LineSearches.BackTracking(maxstep=1.0))`, and
+the outer problem is preconditioned by default (`precondition=true`). If you switch the outer
+optimizer to NLopt, note that NLopt interprets `optim_kwargs.maxiters` as a cap on the number of
+function *evaluations* (`maxeval`); reaching it yields `retcode = MaxIters` (reported as not
+converged).
 
 ```julia
 using NoLimits

--- a/docs/src/estimation/laplace.md
+++ b/docs/src/estimation/laplace.md
@@ -53,7 +53,7 @@ res = fit_model(dm, NoLimits.Laplace(; optim_kwargs=(maxiters=100,)))
 
 ## Constructor Options
 
-The `Laplace` constructor exposes options that control the outer fixed-effects optimization, the inner EB optimization, Hessian stabilization, and the computational strategy for log-determinant gradients. Most users will only need to adjust a few of these; the defaults are chosen to work well across a range of model types.
+The `Laplace` constructor exposes options that control the outer fixed-effects optimization, the inner EB optimization, Hessian stabilization, and the computational strategy for log-determinant gradients. Most users will only need to adjust a few of these; the defaults are chosen to work well across a range of model types. The values in the example below are illustrative overrides, not the shipped defaults - see *Repository-verified behavior* further down for those.
 
 ```julia
 using Optimization
@@ -126,8 +126,9 @@ Practical implications:
 
 - Outer optimizer (`optimizer`, `optim_kwargs`, `adtype`)
   - Runs once at the top level.
-  - Can use derivative-free methods (default `NLopt.LN_BOBYQA()`), local gradient methods, or global methods.
-  - Note: NLopt optimizers interpret `optim_kwargs.maxiters` as a cap on the number of function *evaluations* (`maxeval`), not outer iterations; reaching it yields `retcode = MaxIters` (reported as not converged).
+  - Defaults to the local-gradient `OptimizationOptimJL.LBFGS(linesearch=LineSearches.BackTracking(maxstep=1.0))`. Derivative-free methods (e.g. `NLopt.LN_BOBYQA()`) and global methods are also supported.
+  - The line-search step cap matters: an uncapped unit first step can overshoot into the region where the marginal is not finite. Keep `maxstep` if you substitute another line search.
+  - Note: if you switch to an NLopt optimizer, it interprets `optim_kwargs.maxiters` as a cap on the number of function *evaluations* (`maxeval`), not outer iterations; reaching it yields `retcode = MaxIters` (reported as not converged).
   - If using BlackBoxOptim (`OptimizationBBO.*`), finite bounds are required.
 - Inner optimizer (`inner_optimizer`, `inner_kwargs`, `inner_adtype`, `inner_grad_tol`)
   - Runs repeatedly across batches and across outer iterations.
@@ -136,7 +137,7 @@ Practical implications:
 
 Repository-verified behavior:
 
-- Default outer optimizer is `NLopt.LN_BOBYQA()` (capped at `maxiters=1000` function evaluations); the default inner optimizer is `OptimizationOptimJL.LBFGS(...)`.
+- Default outer optimizer is `OptimizationOptimJL.LBFGS(linesearch=LineSearches.BackTracking(maxstep=1.0))`; the default inner optimizer is the same. The outer problem is preconditioned by default (`precondition=true`), so the optimizer works in a scaled offset that starts at zero; see the [`Laplace`](@ref) API entry.
 - Outer BlackBoxOptim is supported with finite bounds (`lb`, `ub`); without bounds, an error is raised.
 
 Examples:
@@ -148,7 +149,7 @@ using OptimizationBBO
 using LineSearches
 
 # 1) Local-gradient LBFGS for both outer and inner
-#    (the outer default is the derivative-free NLopt.LN_BOBYQA(); this overrides it with LBFGS)
+#    (close to the defaults; the shipped default also caps the line search with maxstep=1.0)
 laplace_local = NoLimits.Laplace(;
     optimizer=OptimizationOptimJL.LBFGS(linesearch=LineSearches.BackTracking()),
     inner_optimizer=OptimizationOptimJL.LBFGS(linesearch=LineSearches.BackTracking()),

--- a/docs/src/tutorials/fixed-effects-nonlinear-mle-map.md
+++ b/docs/src/tutorials/fixed-effects-nonlinear-mle-map.md
@@ -239,7 +239,7 @@ Covariate descriptive statistics (observation rows)
 
 ## Step 4: Fit with MLE and MAP
 
-Each `fit_model` call runs the default L-BFGS optimizer from the declared initial values. (L-BFGS is the default numerical optimizer for `MLE`, `MAP`, and the EM/quadrature methods; the marginal-likelihood random-effects methods [`Laplace`](../estimation/laplace.md) and [`FOCEI`](../estimation/focei.md) instead default their *outer* fixed-effects optimization to the derivative-free `NLopt.LN_BOBYQA()`.) MLE and MAP differ only in the objective: MLE uses the log-likelihood, MAP adds the log-prior, which can stabilize weakly identified parameters (see [MLE / MAP](../estimation/mle.md)).
+Each `fit_model` call runs the default L-BFGS optimizer from the declared initial values. (L-BFGS with a step-capped backtracking line search is the default numerical optimizer for every optimization-based method, including the marginal-likelihood random-effects methods [`Laplace`](../estimation/laplace.md) and [`FOCEI`](../estimation/focei.md).) MLE and MAP differ only in the objective: MLE uses the log-likelihood, MAP adds the log-prior, which can stabilize weakly identified parameters (see [MLE / MAP](../estimation/mle.md)).
 
 ```julia
 res_mle = fit_model(dm, mle_method; serialization=serialization, rng=Random.Xoshiro(41))

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -903,6 +903,27 @@ function _precondition_scale(model, free_names, θ0_free_t)
     return s
 end
 
+# Single definition of the optimizer reparameterization θt = θ0_pc + s_pc .* z, shared by every
+# numerical driver. `on = false` makes both maps the identity, so a fit is bit-identical to one
+# from before preconditioning existed. Note `z_from_θt` is also the bounds map: mapping `lb`/`ub`
+# is the same affine operation, so no driver hand-writes the formula a second time.
+# One return path on purpose — a two-branch return would make the closure types a Union at every
+# call site and put a dynamic dispatch inside the objective.
+function _precondition_maps(model, free_names, θ0_free_t, axs, on::Bool)
+    T = eltype(θ0_free_t)
+    θ0_pc = on ? collect(θ0_free_t) : zeros(T, length(θ0_free_t))
+    s_pc = on ? _precondition_scale(model, free_names, θ0_free_t) :
+           ones(T, length(θ0_free_t))
+    θt_from_z = z -> ComponentArray(
+        θ0_pc .+ s_pc .* (z isa ComponentArray ? ComponentArrays.getdata(z) : z), axs)
+    z_from_θt = θt -> (collect(θt) .- θ0_pc) ./ s_pc
+    return θ0_pc, s_pc, θt_from_z, z_from_θt
+end
+
+# `fit_fixed_effects` and `fit_laplace_family` are public and accept arbitrary user
+# `FittingMethod`s, which need not carry the field.
+@inline _precondition_on(method) = hasproperty(method, :precondition) && method.precondition
+
 function get_iterations(res::MethodResult)
     hasproperty(res, :iterations) ? res.iterations :
     error("iterations not available for this method.")

--- a/src/estimation/dev_api.jl
+++ b/src/estimation/dev_api.jl
@@ -795,7 +795,7 @@ end
 """
     optimize_parameters(f_natural, ctx::FitContext;
                         θ_start=initial_parameters(ctx),
-                        optimizer=LBFGS(linesearch=BackTracking()),
+                        optimizer=LBFGS(linesearch=BackTracking(maxstep=1.0)),
                         adtype=AutoForwardDiff(), optim_kwargs=NamedTuple())
         -> (θ̂::ComponentArray, sol)
 
@@ -815,7 +815,7 @@ in `f_natural`. Do-block friendly:
 """
 function optimize_parameters(f_natural, ctx::FitContext;
         θ_start::ComponentArray = initial_parameters(ctx),
-        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking()),
+        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking(maxstep = 1.0)),
         adtype = Optimization.AutoForwardDiff(),
         optim_kwargs::NamedTuple = NamedTuple())
     dm = ctx.dm

--- a/src/estimation/focei.jl
+++ b/src/estimation/focei.jl
@@ -666,6 +666,9 @@ Supported outcome families: `Normal`, `LogNormal`, `Laplace`, `Cauchy`, `Exponen
 Markov / Markov outcome models and any family without a registered Fisher information are
 not supported — use [`Laplace`](@ref) for those.
 
+A gradient-based outer optimizer must cap its line-search step; see the `optimizer` entry in
+[`Laplace`](@ref) for why and for the measured numbers.
+
 Keyword arguments mirror [`Laplace`](@ref) (including `precondition`); the only
 addition is `interaction::Bool=true`.
 """
@@ -685,7 +688,8 @@ struct FOCEI{O, K, A, IO, HO, CO, MS, L, U} <: FittingMethod
 end
 
 function FOCEI(; interaction::Bool = true,
-        optimizer = NLopt.LN_BOBYQA(),
+        optimizer = OptimizationOptimJL.LBFGS(
+            linesearch = LineSearches.BackTracking(maxstep = 1.0)),
         optim_kwargs = (; maxiters = 1000),
         adtype = Optimization.AutoForwardDiff(),
         inner_options = nothing,

--- a/src/estimation/ghquadrature.jl
+++ b/src/estimation/ghquadrature.jl
@@ -21,7 +21,7 @@ using LineSearches
                  inner_options, inner_optimizer, inner_kwargs, inner_adtype,
                  inner_grad_tol, multistart_options, multistart_n, multistart_k,
                  multistart_grad_tol, multistart_max_rounds, multistart_sampling,
-                 lb, ub, ignore_model_bounds) <: FittingMethod
+                 lb, ub, ignore_model_bounds, precondition) <: FittingMethod
 
 Sparse-grid (Smolyak) quadrature for NLME marginal likelihood estimation.
 
@@ -57,6 +57,13 @@ forward pass: the objective is fully differentiable by `AutoForwardDiff`.
   falls back to model-declared bounds.
 - `ignore_model_bounds::Bool = false`: if `true`, model-declared parameter
   bounds are ignored (user-supplied `lb`/`ub` still apply).
+- `precondition::Bool = true`: optimize the scaled offset `z` with
+  `θ_transformed = θ0 + s .* z`, so every fit starts at `z = 0` and no coordinate can be
+  frozen by an unlucky starting value. `s` is 1 for any coordinate already in log/logit
+  space and `max(abs(θ0), 1)` for a genuinely natural-scale `:identity` coordinate. Set
+  `false` to optimize the transformed vector directly, which reproduces pre-0.2 results
+  bit-for-bit. Note that with preconditioning on, the optimizer object behind
+  [`get_raw`](@ref) works in `z`; [`get_params`](@ref) always returns the usual scales.
 """
 struct GHQuadrature{LV, O, K, A, IO, MS, L, U} <: FittingMethod
     level::LV   # Int (isotropic) or NamedTuple (anisotropic per-RE-group)

--- a/src/estimation/ghquadrature.jl
+++ b/src/estimation/ghquadrature.jl
@@ -149,7 +149,7 @@ function _ghq_batch_ll(dm::DataModel,
             η_i = _build_eta_ind(dm, i, info, empty_b, const_cache, θu_re)
             lli = _loglikelihood_individual(dm, i, θu_re, η_i, ll_cache)
             !isfinite(lli) && return T(-Inf)
-            total += T(lli)
+            total += convert(T, lli)
         end
         const_ll = _const_re_prior_logf(dm, info, θu_re, const_cache, ll_cache)
         !isfinite(const_ll) && return T(-Inf)
@@ -344,7 +344,9 @@ function _fit_model_scalar(dm::DataModel, method::GHQuadrature, args...;
                         Threads.atomic_or!(bad, true)
                         results[bi] = zero(T)
                     else
-                        results[bi] = T(bll)
+                        # `convert`, not `T(bll)`: when `T` is a Dual and `bll` is the same
+                        # Dual type, the constructor tries `Float64(::Dual)` and throws.
+                        results[bi] = convert(T, bll)
                     end
                 end
             end

--- a/src/estimation/ghquadrature.jl
+++ b/src/estimation/ghquadrature.jl
@@ -68,6 +68,7 @@ struct GHQuadrature{LV, O, K, A, IO, MS, L, U} <: FittingMethod
     lb::L
     ub::U
     ignore_model_bounds::Bool
+    precondition::Bool
 end
 
 function GHQuadrature(;
@@ -88,7 +89,8 @@ function GHQuadrature(;
         multistart_sampling = :lhs,
         lb = nothing,
         ub = nothing,
-        ignore_model_bounds = false
+        ignore_model_bounds = false,
+        precondition = true
 )
     inner = inner_options === nothing ?
             LaplaceInnerOptions(
@@ -98,8 +100,8 @@ function GHQuadrature(;
          LaplaceMultistartOptions(multistart_n, multistart_k, multistart_grad_tol,
         multistart_max_rounds, multistart_sampling) :
          multistart_options
-    GHQuadrature(
-        level, optimizer, optim_kwargs, adtype, inner, ms, lb, ub, ignore_model_bounds)
+    GHQuadrature(level, optimizer, optim_kwargs, adtype, inner, ms, lb, ub,
+        ignore_model_bounds, precondition)
 end
 
 # ---------------------------------------------------------------------------
@@ -302,8 +304,12 @@ function _fit_model_scalar(dm::DataModel, method::GHQuadrature, args...;
     free_idx = layout.free_idx
     θ_const_t_vec = layout.θ_const_t_vec
 
-    function obj(θt, p)
-        θt_free = θt isa ComponentArray ? θt : ComponentArray(θt, axs_free)
+    # The optimizer works on the preconditioned offset z; everything below stays on θt.
+    θ0_pc, s_pc, _θt_from_z, _z_from_θt = _precondition_maps(
+        get_model(dm), free_names, θ0_free_t, axs_free, _precondition_on(method))
+
+    function obj(z, p)
+        θt_free = _θt_from_z(z)
         T = eltype(θt_free)
         infT = convert(T, Inf)
 
@@ -356,12 +362,16 @@ function _fit_model_scalar(dm::DataModel, method::GHQuadrature, args...;
         fe, free_names, θ0_free_t, method.optimizer, method.lb, method.ub, constants;
         ignore_model_bounds = method.ignore_model_bounds, method_label = "GHQuadrature")
 
-    prob = use_bounds ? OptimizationProblem(optf, θ0_init; lb = lb, ub = ub) :
-           OptimizationProblem(optf, θ0_init)
+    z0 = _z_from_θt(θ0_init)
+    lb_z = _z_from_θt(lb)
+    ub_z = _z_from_θt(ub)
+    prob = use_bounds ? OptimizationProblem(optf, z0; lb = lb_z, ub = ub_z) :
+           OptimizationProblem(optf, z0)
     sol = Optimization.solve(prob, method.optimizer; method.optim_kwargs...)
 
     # ── Extract solution ─────────────────────────────────────────────────────
-    θ_hat_t_raw = sol.u
+    # Mapped back here so both consumers below (the post-hoc EB modes and `FitParameters`) see θt.
+    θ_hat_t_raw = _θt_from_z(sol.u)
     θ_hat_t_free = θ_hat_t_raw isa ComponentArray ?
                    θ_hat_t_raw : ComponentArray(θ_hat_t_raw, axs_free)
     θ_hat_t = _merge_free_into_full(
@@ -416,7 +426,7 @@ function _fit_model(dm::DataModel, method::GHQuadrature, args...;
         inner = GHQuadrature(lv,
             method.optimizer, method.optim_kwargs, method.adtype,
             method.inner, method.multistart, method.lb, method.ub,
-            method.ignore_model_bounds)
+            method.ignore_model_bounds, method.precondition)
         res = _fit_model_scalar(dm, inner, args...; theta_0_untransformed = θ0, kwargs...)
         θ0 = get_params(res; scale = :untransformed)
     end

--- a/src/estimation/ghquadrature.jl
+++ b/src/estimation/ghquadrature.jl
@@ -72,7 +72,7 @@ end
 
 function GHQuadrature(;
         level = 3,  # Int or NamedTuple for anisotropic levels
-        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking()),
+        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking(maxstep = 1.0)),
         optim_kwargs = NamedTuple(),
         adtype = Optimization.AutoForwardDiff(),
         inner_options = nothing,

--- a/src/estimation/kernel.jl
+++ b/src/estimation/kernel.jl
@@ -100,10 +100,10 @@ function batch_loglik_ghq(
     R = size(sgrid.nodes, 2)
     θ_re = _symmetrize_psd_params(θ, get_fixed(get_model(dm)))
 
-    # Determine accumulator element type from the RE measure.
-    # When θ carries ForwardDiff.Dual tags, re_measure.μ has Dual elements,
-    # so T = Dual. The Array{T} allocation handles type promotion.
-    T = eltype(re_measure)
+    # Accumulator element type. The RE measure alone is not enough: a random effect declared
+    # with fixed hyperparameters (e.g. `Normal(0.0, 1.0)`) carries no θ, so its measure stays
+    # Float64 while the conditional log-likelihoods below are Dual under AD. Promote against θ.
+    T = promote_type(eltype(re_measure), eltype(θ_re))
 
     a_vals = Vector{T}(undef, R)
 
@@ -135,7 +135,7 @@ function batch_loglik_ghq(
                 valid = false
                 break
             end
-            cond += T(lli)
+            cond += convert(T, lli)
         end
 
         a_vals[r] = if valid

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -598,7 +598,7 @@ function _laplace_sample_b0s_impl(dm::DataModel,
                             error("Expected scalar random effect for $(re), got vector of length $(length(v)).")
                         v = v[1]
                     end
-                    b0s[i][first(r)] = T(v)
+                    b0s[i][first(r)] = convert(T, v)
                 end
             else
                 draws = (sampling === :lhs &&
@@ -610,7 +610,7 @@ function _laplace_sample_b0s_impl(dm::DataModel,
                 for i in 1:n
                     v = draws[i]
                     if v isa Number
-                        b0s[i][r] .= T(v)
+                        b0s[i][r] .= convert(T, v)
                     else
                         vv = vec(v)
                         length(vv) == dim ||

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -1981,7 +1981,7 @@ end
               multistart_grad_tol, multistart_max_rounds, multistart_sampling,
               jitter, max_tries, jitter_growth, adaptive_jitter, jitter_scale,
               use_trace_logdet_grad, use_hutchinson, hutchinson_n, theta_tol,
-              lb, ub) <: FittingMethod
+              lb, ub, precondition) <: FittingMethod
 
 Laplace approximation with Empirical Bayes Estimates (EBE) for random-effects models.
 The outer optimizer maximizes the Laplace-approximated marginal likelihood over the

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -1989,18 +1989,34 @@ fixed effects, while the inner optimizer computes per-individual MAP estimates o
 random effects.
 
 # Keyword Arguments
-- `optimizer`: outer Optimization.jl optimizer. Defaults to `NLopt.LN_BOBYQA()`
-  (derivative-free; requires a stopping criterion, supplied by the default `maxiters`).
-  It was the most reliable choice across a six-model tutorial benchmark, but it can
-  stall on a correlated `RealPSDMatrix` block whose optimum sits near the
-  positive-definite boundary - on `pheno_sd` it stopped ~140 `-2LL` units short,
-  leaving one covariance entry at its initial value. If a covariance estimate comes
-  back suspiciously close to its start, retry with
-  `optimizer = OptimizationOptimJL.NelderMead()` or `NLopt.LN_SBPLX()` and compare
-  marginal likelihoods via [`get_marginal_likelihood`](@ref). Neither alternative is a
-  safe blanket default: on the same benchmark NelderMead lost ~800 `-2LL` units on a
-  16-compartment PBPK model and diverged on a joint PK/PD fit, and SBPLX ran a
-  proportional-error parameter away to a degenerate optimum on a myelosuppression model.
+- `optimizer`: outer Optimization.jl optimizer. Defaults to
+  `OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking(maxstep = 1.0))`, which uses
+  the analytic marginal gradient.
+
+  **The `maxstep` cap is load-bearing, not decoration.** The gradient is exact, but its
+  coordinates can span four orders of magnitude at a poorly scaled start - on `pheno_sd`, where
+  `add_err` starts at 0.1 against data in the 5-50 range, the `add_err` coordinate is ~4e4
+  against 6-49 for the rest. An uncapped unit first step overflows into the region where the
+  marginal is not finite and the fit fails (`-2LL` 6038 against 973.44 with the cap). Keep the
+  cap if you swap the line search. Two things that do *not* work: combining the cap with a
+  shrunken `alphaguess`, and `alphaguess = InitialStatic(scaled = true)` on its own - the latter
+  terminates after 6 iterations on `warfarin`, 378 `-2LL` units short.
+
+  Measured against the previous `NLopt.LN_BOBYQA()` default across six published tutorial models
+  x both methods (12 fits, AGHQ marginal `-2LL`, warm timings): **better or equal likelihood on
+  11 of 12 cells, net 573 units better, and 1.8-5.9x faster on 11 of 12** (median 2.9x, total
+  939 s -> 470 s). The gains concentrate on the hardest models - `warfarin` Laplace by 522 units,
+  `mavoglurant` Laplace by 24, `nimo` by 9-20 - which is where a derivative-free search over many
+  correlated coordinates struggles most. The one cell where the old default wins is `mavoglurant`
+  FOCEI, by 7.9 units, and it is 3.6x slower there.
+
+  `NLopt.LN_BOBYQA()` remains a reasonable fallback if a fit misbehaves, being derivative-free
+  and needing no step control; it requires a stopping criterion, supplied by the default
+  `maxiters`. `OptimizationOptimJL.NelderMead()` and `NLopt.LN_SBPLX()` are also available but
+  neither is safe as a blanket choice: on the same benchmark NelderMead lost ~800 `-2LL` units on
+  a 16-compartment PBPK model and diverged on a joint PK/PD fit, and SBPLX ran a
+  proportional-error parameter away to a degenerate optimum on a myelosuppression model. Compare
+  candidates with [`get_marginal_likelihood`](@ref), which is method-independent.
 - `optim_kwargs::NamedTuple = (; maxiters = 1000)`: keyword arguments for the outer `solve` call.
 - `adtype`: AD backend for the outer optimizer. Defaults to `AutoForwardDiff()`.
 - `inner_optimizer`: inner optimizer for computing EBE modes. Defaults to `LBFGS`.
@@ -2055,7 +2071,8 @@ struct Laplace{O, K, A, IO, HO, CO, MS, L, U} <: FittingMethod
 end
 
 function Laplace(;
-        optimizer = NLopt.LN_BOBYQA(),
+        optimizer = OptimizationOptimJL.LBFGS(
+            linesearch = LineSearches.BackTracking(maxstep = 1.0)),
         optim_kwargs = (; maxiters = 1000),
         adtype = Optimization.AutoForwardDiff(),
         inner_options = nothing,
@@ -2457,19 +2474,10 @@ function _fit_laplace_family(dm::DataModel, method, hmode::_HessMode, args, fit_
         ComponentArray(zeros(T0, length(θ0_free_t)), axs_free),
         false)
 
-    # The optimizer works on the preconditioned offset z (see `_precondition_scale`);
-    # everything downstream of these two maps stays on the transformed θ scale.
-    # `precondition = false` makes both maps the identity, i.e. the optimizer sees the
-    # raw transformed vector exactly as it did before preconditioning existed.
-    θ0_pc = method.precondition ? collect(θ0_free_t) :
-            zeros(eltype(θ0_free_t), length(θ0_free_t))
-    s_pc = method.precondition ? _precondition_scale(get_model(dm), free_names, θ0_free_t) :
-           ones(eltype(θ0_free_t), length(θ0_free_t))
-    function _θt_from_z(z)
-        ComponentArray(
-            θ0_pc .+ s_pc .* (z isa ComponentArray ? ComponentArrays.getdata(z) : z), axs_free)
-    end
-    _z_from_θt(θt) = (collect(θt) .- θ0_pc) ./ s_pc
+    # The optimizer works on the preconditioned offset z; everything downstream of these two
+    # maps stays on the transformed θ scale.
+    θ0_pc, s_pc, _θt_from_z, _z_from_θt = _precondition_maps(
+        get_model(dm), free_names, θ0_free_t, axs_free, _precondition_on(method))
 
     function obj_only(z, p)
         θt_free = _θt_from_z(z)
@@ -2571,8 +2579,8 @@ function _fit_laplace_family(dm::DataModel, method, hmode::_HessMode, args, fit_
         ignore_model_bounds = method.ignore_model_bounds, allow_bbo = allow_bbo,
         method_label = "Laplace")
     z0 = _z_from_θt(θ0_init)
-    lb_z = (collect(lb) .- θ0_pc) ./ s_pc
-    ub_z = (collect(ub) .- θ0_pc) ./ s_pc
+    lb_z = _z_from_θt(lb)
+    ub_z = _z_from_θt(ub)
     prob = use_bounds ? OptimizationProblem(optf, z0; lb = lb_z, ub = ub_z) :
            OptimizationProblem(optf, z0)
     sol = Optimization.solve(prob, method.optimizer; method.optim_kwargs...)

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -2474,6 +2474,19 @@ function _fit_laplace_family(dm::DataModel, method, hmode::_HessMode, args, fit_
         ComponentArray(zeros(T0, length(θ0_free_t)), axs_free),
         false)
 
+    # Infeasible points are reported as a large FINITE value, not `Inf`. A line search cannot
+    # interpolate through a non-finite function value - `BackTracking(order = 3)` fits a cubic
+    # through its trial values - so it abandons the search instead of shrinking the step, and the
+    # optimizer stops at iteration 1 with a descent step still available. Measured on pheno: the
+    # `Inf` return stops five different gradient optimizers dead, while a finite wall reaches
+    # BOBYQA's optimum exactly. Anchored on the last feasible objective so it is always well
+    # above anything attainable, whatever the model's scale.
+    wall_ref = Ref{Union{Nothing, T0}}(nothing)
+    function _infeasible(::Type{T}) where {T}
+        wall_ref[] === nothing ? T(1e10) :
+        T(wall_ref[] + abs(wall_ref[]) + 1e6)
+    end
+
     # The optimizer works on the preconditioned offset z; everything downstream of these two
     # maps stays on the transformed θ scale.
     θ0_pc, s_pc, _θt_from_z, _z_from_θt = _precondition_maps(
@@ -2485,7 +2498,6 @@ function _fit_laplace_family(dm::DataModel, method, hmode::_HessMode, args, fit_
             obj_cache, θt_free, method.cache.theta_tol)
         cached_obj !== nothing && return cached_obj
         T = eltype(θt_free)
-        infT = convert(T, Inf)
         θt_full = _merge_free_into_full(θ_const_t_vec, free_idx, θt_free, axs_full)
         θu = inv_transform(θt_full)
         obj = _laplace_objective_only(
@@ -2497,9 +2509,10 @@ function _fit_laplace_family(dm::DataModel, method, hmode::_HessMode, args, fit_
             rng = rng,
             serialization = serialization,
             hmode = hmode)
-        !isfinite(obj) && return infT
+        !isfinite(obj) && return _infeasible(T)
         has_penalty && (obj += _penalty_value(θu, penalty))
         has_extra && (obj += extra_objective(θu))
+        obj isa T0 && isfinite(obj) && (wall_ref[] = obj)
         _laplace_obj_cache_set_obj!(obj_cache, θt_free, obj)
         return obj
     end

--- a/src/estimation/map.jl
+++ b/src/estimation/map.jl
@@ -9,7 +9,8 @@ using Random
 using LineSearches
 
 """
-    MAP(; optimizer, optim_kwargs, adtype, lb, ub, ignore_model_bounds) <: FittingMethod
+    MAP(; optimizer, optim_kwargs, adtype, lb, ub, ignore_model_bounds,
+    precondition) <: FittingMethod
 
 Maximum A Posteriori estimation for models without random effects.
 Requires prior distributions on at least one free fixed effect.
@@ -25,6 +26,13 @@ Requires prior distributions on at least one free fixed effect.
 - `ub`: upper bounds on the transformed parameter scale, or `nothing`.
 - `ignore_model_bounds::Bool = false`: when `true`, ignore bounds declared in
   `@fixedEffects` unless explicit `lb`/`ub` are passed.
+- `precondition::Bool = true`: optimize the scaled offset `z` with
+  `θ_transformed = θ0 + s .* z`, so every fit starts at `z = 0` and no coordinate can be
+  frozen by an unlucky starting value. `s` is 1 for any coordinate already in log/logit
+  space and `max(abs(θ0), 1)` for a genuinely natural-scale `:identity` coordinate. Set
+  `false` to optimize the transformed vector directly, which reproduces pre-0.2 results
+  bit-for-bit. Note that with preconditioning on, the optimizer object behind
+  [`get_raw`](@ref) works in `z`; [`get_params`](@ref) always returns the usual scales.
 """
 struct MAP{O, K, A, L, U} <: FittingMethod
     optimizer::O

--- a/src/estimation/map.jl
+++ b/src/estimation/map.jl
@@ -33,6 +33,7 @@ struct MAP{O, K, A, L, U} <: FittingMethod
     lb::L
     ub::U
     ignore_model_bounds::Bool
+    precondition::Bool
 end
 
 function MAP(;
@@ -41,8 +42,9 @@ function MAP(;
         adtype = Optimization.AutoForwardDiff(),
         lb = nothing,
         ub = nothing,
-        ignore_model_bounds = false)
-    MAP(optimizer, optim_kwargs, adtype, lb, ub, ignore_model_bounds)
+        ignore_model_bounds = false,
+        precondition = true)
+    MAP(optimizer, optim_kwargs, adtype, lb, ub, ignore_model_bounds, precondition)
 end
 
 # MAPResult is a StandardOptimizationResult{:map} alias + constructor (see common.jl).

--- a/src/estimation/map.jl
+++ b/src/estimation/map.jl
@@ -36,7 +36,7 @@ struct MAP{O, K, A, L, U} <: FittingMethod
 end
 
 function MAP(;
-        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking()),
+        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking(maxstep = 1.0)),
         optim_kwargs = NamedTuple(),
         adtype = Optimization.AutoForwardDiff(),
         lb = nothing,

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -149,7 +149,7 @@ end
            ebe_grad_tol, ebe_multistart_n, ebe_multistart_k, ebe_multistart_max_rounds,
            ebe_multistart_sampling, ebe_rescue_on_high_grad, ebe_rescue_multistart_n,
            ebe_rescue_multistart_k, ebe_rescue_max_rounds, ebe_rescue_grad_tol,
-           ebe_rescue_multistart_sampling, lb, ub) <: FittingMethod
+           ebe_rescue_multistart_sampling, lb, ub, precondition) <: FittingMethod
 
 Monte Carlo Expectation-Maximization for random-effects models. At each EM iteration the
 E-step draws random effects; the M-step maximizes the Monte Carlo Q-function over the
@@ -193,6 +193,13 @@ fixed effects.
   `ebe_rescue_multistart_sampling`: rescue multistart settings when an EBE mode has a
   high gradient norm. Disabled by default.
 - `lb`, `ub`: bounds on the transformed fixed-effect scale, or `nothing`.
+- `precondition::Bool = true`: optimize the scaled offset `z` with
+  `θ_transformed = θ0 + s .* z`, so every fit starts at `z = 0` and no coordinate can be
+  frozen by an unlucky starting value. `s` is 1 for any coordinate already in log/logit
+  space and `max(abs(θ0), 1)` for a genuinely natural-scale `:identity` coordinate. Set
+  `false` to optimize the transformed vector directly, which reproduces pre-0.2 results
+  bit-for-bit. Note that with preconditioning on, the optimizer object behind
+  [`get_raw`](@ref) works in `z`; [`get_params`](@ref) always returns the usual scales.
 """
 struct MCEM{O, K, A, ES, EO, EB, ER, L, U} <: FittingMethod
     optimizer::O

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -208,6 +208,7 @@ struct MCEM{O, K, A, ES, EO, EB, ER, L, U} <: FittingMethod
     progress::Bool
     store_diagnostics::Bool
     diagnostics_every::Int
+    precondition::Bool
 end
 
 function MCEM(;
@@ -245,7 +246,8 @@ function MCEM(;
         lb = nothing,
         ub = nothing,
         store_diagnostics::Bool = false,
-        diagnostics_every::Int = 1
+        diagnostics_every::Int = 1,
+        precondition::Bool = true
 )
     diagnostics_every >= 1 ||
         error("MCEM: diagnostics_every must be ≥ 1. Got: $diagnostics_every")
@@ -266,7 +268,7 @@ function MCEM(;
         ebe_rescue_multistart_k, ebe_rescue_max_rounds,
         ebe_rescue_grad_tol, ebe_rescue_multistart_sampling)
     MCEM(optimizer, optim_kwargs, adtype, e_step_actual, em, ebe, ebe_rescue,
-        lb, ub, verbose, progress, store_diagnostics, diagnostics_every)
+        lb, ub, verbose, progress, store_diagnostics, diagnostics_every, precondition)
 end
 
 # MCEMResult is a StandardOptimizationResult{:mcem} alias (see common.jl).
@@ -1446,9 +1448,13 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
                 θt_q2 = ComponentArray(NamedTuple{Tuple(q2_free_now)}(
                     Tuple(getproperty(θt_full_curr, n) for n in q2_free_now)))
                 axs_q2 = getaxes(θt_q2)
-                function obj_q2(ψt, p)
-                    any(isnan, ψt) && return eltype(ψt)(Inf)
-                    ψt_ca = ψt isa ComponentArray ? ψt : ComponentArray(ψt, axs_q2)
+                # Anchored at the CURRENT iterate, not the initial theta: the anchor's job is to
+                # put the start at z = 0, and the free set is not invariant across EM iterations.
+                _, _, _q2_from_z, _z_from_q2 = _precondition_maps(
+                    get_model(dm), q2_free_now, θt_q2, axs_q2, _precondition_on(method))
+                function obj_q2(z, p)
+                    any(isnan, z) && return eltype(z)(Inf)
+                    ψt_ca = _q2_from_z(z)
                     T = eltype(ψt_ca)
                     θt_full_q2 = ComponentArray(T.(collect(θt_full_curr)), axs_full)
                     for name in q2_free_now
@@ -1465,13 +1471,17 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
                     fe, q2_free_now, collect(θt_q2), method.optimizer, nothing,
                     nothing, NamedTuple(); allow_bbo = false)
                 optf_q2 = OptimizationFunction(obj_q2, method.adtype)
+                z0_q2 = _z_from_q2(θ0_q2)
                 prob_q2 = use_bounds_q2 ?
-                          OptimizationProblem(optf_q2, θ0_q2; lb = lb_q2, ub = ub_q2) :
-                          OptimizationProblem(optf_q2, θ0_q2)
+                          OptimizationProblem(optf_q2, z0_q2;
+                    lb = _z_from_q2(lb_q2), ub = _z_from_q2(ub_q2)) :
+                          OptimizationProblem(optf_q2, z0_q2)
                 sol_q2 = Optimization.solve(
                     prob_q2, method.optimizer; method.optim_kwargs...)
                 if all(isfinite, sol_q2.u)
-                    θt_q2_opt = ComponentArray(sol_q2.u, axs_q2)
+                    # Mapped back before it is frozen into `mstep_constants` as a natural-scale
+                    # value; a missed back-map here yields plausible wrong numbers, not an error.
+                    θt_q2_opt = _q2_from_z(sol_q2.u)
                     θt_full_q2_opt = ComponentArray(collect(θt_full_curr), axs_full)
                     for name in q2_free_now
                         setproperty!(θt_full_q2_opt, name, getproperty(θt_q2_opt, name))
@@ -1496,10 +1506,17 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
             Tuple(getproperty(θt_full_curr, n) for n in free_names_q1)))
         axs_free_iter = getaxes(θt_free_iter)
 
+        # Anchored at the current iterate, as for Q2 above.
+        _, _, _θt_from_z, _z_from_θt = _precondition_maps(
+            get_model(dm), free_names_q1, θt_free_iter, axs_free_iter,
+            _precondition_on(method))
+        # Keyed on θt, not z, and the cache must stay INSIDE this loop: with a per-iteration
+        # anchor, z = 0 means a different θt each iteration, so a hoisted cache would return
+        # iteration 1's objective forever and report instant convergence with no error.
         obj_cache = (θ = Ref{Any}(nothing), obj = Ref{Any}(nothing))
-        function obj_only(θt, p)
-            any(isnan, θt) && return Inf
-            θt_free_loc = θt isa ComponentArray ? θt : ComponentArray(θt, axs_free_iter)
+        function obj_only(z, p)
+            any(isnan, z) && return Inf
+            θt_free_loc = _θt_from_z(z)
             θt_vec = θt_free_loc
             use_cache = !(eltype(θt_free_loc) <: ForwardDiff.Dual)
             if use_cache && obj_cache.θ[] !== nothing &&
@@ -1529,8 +1546,10 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
         lb, ub, use_bounds, θ0_init = _resolve_optim_bounds(
             fe, free_names_q1, collect(θt_free_iter), method.optimizer, method.lb,
             method.ub, constants; method_label = "MCEM")
-        prob = use_bounds ? OptimizationProblem(optf, θ0_init; lb = lb, ub = ub) :
-               OptimizationProblem(optf, θ0_init)
+        z0 = _z_from_θt(θ0_init)
+        prob = use_bounds ?
+               OptimizationProblem(optf, z0; lb = _z_from_θt(lb), ub = _z_from_θt(ub)) :
+               OptimizationProblem(optf, z0)
 
         sol = Optimization.solve(prob, method.optimizer; method.optim_kwargs...)
 
@@ -1540,9 +1559,7 @@ function _fit_model(dm::DataModel, method::MCEM, args...;
             θu_new = θu_curr
             Q_new = Q_prev
         else
-            θ_hat_t_raw = sol.u
-            θ_hat_t_free = θ_hat_t_raw isa ComponentArray ? θ_hat_t_raw :
-                           ComponentArray(θ_hat_t_raw, axs_free_iter)
+            θ_hat_t_free = _θt_from_z(sol.u)
 
             θt_full_new = ComponentArray(eltype(θ_hat_t_free).(θ_const_t_q1), axs_full_q1)
             for name in free_names_q1

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -211,7 +211,7 @@ struct MCEM{O, K, A, ES, EO, EB, ER, L, U} <: FittingMethod
 end
 
 function MCEM(;
-        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking()),
+        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking(maxstep = 1.0)),
         optim_kwargs = (; iterations = 50, g_abstol = 1e-4, f_reltol = 1e-6),
         adtype = Optimization.AutoForwardDiff(),
         e_step = nothing,
@@ -228,7 +228,7 @@ function MCEM(;
         atol_Q = 1e-4,
         consecutive_params = 3,
         convergence_window::Int = 20,
-        ebe_optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking()),
+        ebe_optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking(maxstep = 1.0)),
         ebe_optim_kwargs = NamedTuple(),
         ebe_adtype = Optimization.AutoForwardDiff(),
         ebe_grad_tol = :auto,

--- a/src/estimation/mle.jl
+++ b/src/estimation/mle.jl
@@ -37,7 +37,7 @@ struct MLE{O, K, A, L, U} <: FittingMethod
 end
 
 function MLE(;
-        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking()),
+        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking(maxstep = 1.0)),
         optim_kwargs = NamedTuple(),
         adtype = Optimization.AutoForwardDiff(),
         lb = nothing,

--- a/src/estimation/mle.jl
+++ b/src/estimation/mle.jl
@@ -11,7 +11,8 @@ using LineSearches
 using OptimizationBBO
 
 """
-    MLE(; optimizer, optim_kwargs, adtype, lb, ub, ignore_model_bounds) <: FittingMethod
+    MLE(; optimizer, optim_kwargs, adtype, lb, ub, ignore_model_bounds,
+    precondition) <: FittingMethod
 
 Maximum Likelihood Estimation for models without random effects.
 
@@ -26,6 +27,13 @@ Maximum Likelihood Estimation for models without random effects.
 - `ub`: upper bounds on the transformed parameter scale, or `nothing`.
 - `ignore_model_bounds::Bool = false`: if `true`, ignore the bounds declared in
   `@fixedEffects` (explicit `lb`/`ub` still apply).
+- `precondition::Bool = true`: optimize the scaled offset `z` with
+  `θ_transformed = θ0 + s .* z`, so every fit starts at `z = 0` and no coordinate can be
+  frozen by an unlucky starting value. `s` is 1 for any coordinate already in log/logit
+  space and `max(abs(θ0), 1)` for a genuinely natural-scale `:identity` coordinate. Set
+  `false` to optimize the transformed vector directly, which reproduces pre-0.2 results
+  bit-for-bit. Note that with preconditioning on, the optimizer object behind
+  [`get_raw`](@ref) works in `z`; [`get_params`](@ref) always returns the usual scales.
 """
 struct MLE{O, K, A, L, U} <: FittingMethod
     optimizer::O

--- a/src/estimation/mle.jl
+++ b/src/estimation/mle.jl
@@ -34,6 +34,7 @@ struct MLE{O, K, A, L, U} <: FittingMethod
     lb::L
     ub::U
     ignore_model_bounds::Bool
+    precondition::Bool
 end
 
 function MLE(;
@@ -42,8 +43,9 @@ function MLE(;
         adtype = Optimization.AutoForwardDiff(),
         lb = nothing,
         ub = nothing,
-        ignore_model_bounds = false)
-    MLE(optimizer, optim_kwargs, adtype, lb, ub, ignore_model_bounds)
+        ignore_model_bounds = false,
+        precondition = true)
+    MLE(optimizer, optim_kwargs, adtype, lb, ub, ignore_model_bounds, precondition)
 end
 
 # FrequentistResult is a StandardOptimizationResult{:frequentist} alias + constructor (see common.jl).
@@ -96,8 +98,12 @@ function _fit_no_re(dm::DataModel, method;
     θ0_free_t = layout.θ0_free_t
     cache = build_ll_cache(dm; ode_args = ode_args, ode_kwargs = ode_kwargs,
         serialization = serialization, force_saveat = true)
-    function obj(θt, p)
-        v_free = θt isa ComponentArray ? ComponentArrays.getdata(θt) : θt
+    # The optimizer works on the preconditioned offset z. No explicit gradient is supplied here,
+    # so `adtype` differentiates through the affine map and applies the chain rule itself.
+    θ0_pc, s_pc, _θt_from_z, _z_from_θt = _precondition_maps(
+        get_model(dm), free_names, θ0_free_t, layout.axs, _precondition_on(method))
+    function obj(z, p)
+        v_free = ComponentArrays.getdata(_θt_from_z(z))
         T = eltype(v_free)
         infT = convert(T, Inf)
         θt_full = _merge_free_into_full(θ_const_t_vec, free_idx, v_free, axs_full)
@@ -114,12 +120,15 @@ function _fit_no_re(dm::DataModel, method;
     lb, ub, use_bounds, θ0_init = _resolve_optim_bounds(
         fe, free_names, θ0_free_t, method.optimizer, method.lb, method.ub, constants;
         ignore_model_bounds = method.ignore_model_bounds, method_label = "MLE")
-    prob = use_bounds ? OptimizationProblem(optf, θ0_init; lb = lb, ub = ub) :
-           OptimizationProblem(optf, θ0_init)
+    z0 = _z_from_θt(θ0_init)
+    lb_z = _z_from_θt(lb)
+    ub_z = _z_from_θt(ub)
+    prob = use_bounds ? OptimizationProblem(optf, z0; lb = lb_z, ub = ub_z) :
+           OptimizationProblem(optf, z0)
     sol = Optimization.solve(prob, method.optimizer; method.optim_kwargs...)
 
     summary = FitSummary(sol.objective, sol.retcode == SciMLBase.ReturnCode.Success,
-        resolve_fitted_parameters(layout, sol.u), NamedTuple())
+        resolve_fitted_parameters(layout, _θt_from_z(sol.u)), NamedTuple())
     diagnostics = FitDiagnostics(
         (;), (optimizer = method.optimizer,), (retcode = sol.retcode,), NamedTuple())
     niter = hasproperty(sol, :stats) && hasproperty(sol.stats, :iterations) ?

--- a/src/estimation/pooled.jl
+++ b/src/estimation/pooled.jl
@@ -67,7 +67,7 @@ struct Pooled{O, K, A, L, U} <: FittingMethod
 end
 
 function Pooled(;
-        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking()),
+        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking(maxstep = 1.0)),
         optim_kwargs = NamedTuple(),
         adtype = Optimization.AutoForwardDiff(),
         lb = nothing,
@@ -111,7 +111,7 @@ struct PooledMap{O, K, A, L, U} <: FittingMethod
 end
 
 function PooledMap(;
-        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking()),
+        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking(maxstep = 1.0)),
         optim_kwargs = NamedTuple(),
         adtype = Optimization.AutoForwardDiff(),
         lb = nothing,

--- a/src/estimation/pooled.jl
+++ b/src/estimation/pooled.jl
@@ -15,7 +15,8 @@ using Statistics
 
 """
     Pooled(; optimizer, optim_kwargs, adtype, lb, ub, ignore_model_bounds,
-           force_free, refreeze_check, identifiable_only, n_probes, mc_draws) <: FittingMethod
+           force_free, refreeze_check, identifiable_only, n_probes, mc_draws,
+           precondition) <: FittingMethod
 
 Pooled estimation for models with random effects. Each individual's random effects are
 set to the **plug-in value of their RE distribution** (mean, falling back to median; a
@@ -41,6 +42,13 @@ evaluated.
 - `adtype`: AD backend. Defaults to `AutoForwardDiff()`.
 - `lb`/`ub`: bounds on the transformed scale, or `nothing` to use model-declared bounds.
 - `ignore_model_bounds::Bool = false`: ignore bounds declared in `@fixedEffects`.
+- `precondition::Bool = true`: optimize the scaled offset `z` with
+  `θ_transformed = θ0 + s .* z`, so every fit starts at `z = 0` and no coordinate can be
+  frozen by an unlucky starting value. `s` is 1 for any coordinate already in log/logit
+  space and `max(abs(θ0), 1)` for a genuinely natural-scale `:identity` coordinate. Set
+  `false` to optimize the transformed vector directly, which reproduces pre-0.2 results
+  bit-for-bit. Note that with preconditioning on, the optimizer object behind
+  [`get_raw`](@ref) works in `z`; [`get_params`](@ref) always returns the usual scales.
 - `force_free::Vector{Symbol} = Symbol[]`: parameter names exempt from auto-freezing.
 - `refreeze_check::Symbol = :warn`: post-fit sensitivity re-check at the optimum;
   `:warn` records violations in the notes, `:refit` unfreezes violators and continues
@@ -89,7 +97,8 @@ end
 
 """
     PooledMap(; optimizer, optim_kwargs, adtype, lb, ub, ignore_model_bounds,
-              force_free, refreeze_check, identifiable_only, n_probes, mc_draws) <: FittingMethod
+              force_free, refreeze_check, identifiable_only, n_probes, mc_draws,
+              precondition) <: FittingMethod
 
 Like [`Pooled`](@ref), but adds the log-prior of the fixed effects to the objective
 (MAP on the data likelihood with RE plugged in at their distributional means). Requires

--- a/src/estimation/pooled.jl
+++ b/src/estimation/pooled.jl
@@ -64,6 +64,7 @@ struct Pooled{O, K, A, L, U} <: FittingMethod
     identifiable_only::Bool
     n_probes::Int
     mc_draws::Int
+    precondition::Bool
 end
 
 function Pooled(;
@@ -77,12 +78,13 @@ function Pooled(;
         refreeze_check::Symbol = :warn,
         identifiable_only::Bool = true,
         n_probes::Int = 3,
-        mc_draws::Int = 256)
+        mc_draws::Int = 256,
+        precondition::Bool = true)
     refreeze_check in (:warn, :refit) || error("refreeze_check must be :warn or :refit.")
     n_probes >= 1 || error("n_probes must be >= 1.")
     mc_draws >= 1 || error("mc_draws must be >= 1.")
     return Pooled(optimizer, optim_kwargs, adtype, lb, ub, ignore_model_bounds,
-        force_free, refreeze_check, identifiable_only, n_probes, mc_draws)
+        force_free, refreeze_check, identifiable_only, n_probes, mc_draws, precondition)
 end
 
 """
@@ -108,6 +110,7 @@ struct PooledMap{O, K, A, L, U} <: FittingMethod
     identifiable_only::Bool
     n_probes::Int
     mc_draws::Int
+    precondition::Bool
 end
 
 function PooledMap(;
@@ -121,12 +124,13 @@ function PooledMap(;
         refreeze_check::Symbol = :warn,
         identifiable_only::Bool = true,
         n_probes::Int = 3,
-        mc_draws::Int = 256)
+        mc_draws::Int = 256,
+        precondition::Bool = true)
     refreeze_check in (:warn, :refit) || error("refreeze_check must be :warn or :refit.")
     n_probes >= 1 || error("n_probes must be >= 1.")
     mc_draws >= 1 || error("mc_draws must be >= 1.")
     return PooledMap(optimizer, optim_kwargs, adtype, lb, ub, ignore_model_bounds,
-        force_free, refreeze_check, identifiable_only, n_probes, mc_draws)
+        force_free, refreeze_check, identifiable_only, n_probes, mc_draws, precondition)
 end
 
 # PooledResult is a StandardOptimizationResult{:pooled} alias + constructor (see common.jl).
@@ -1073,8 +1077,14 @@ function _pooled_solve(dm::DataModel, method, θ_start_u::ComponentArray,
     free_idx = _free_idx(θ_const_t, θ0_free_t)
     θ_const_t_vec = collect(θ_const_t)
     axs_full = getaxes(θ_const_t)
-    function obj(θt, p)
-        v_free = θt isa ComponentArray ? ComponentArrays.getdata(θt) : θt
+    # Built here, not in `_fit_pooled`: the refit loop re-derives the free set each round, so a
+    # hoisted scale vector would be stale from round 2 and silently misaligned against the
+    # coordinates. The frozen-set DETECTION above stays on raw transformed coordinates - scaling
+    # it would change which parameters get frozen, which is a semantic change, not a port.
+    θ0_pc, s_pc, _θt_from_z, _z_from_θt = _precondition_maps(
+        get_model(dm), free_names, θ0_free_t, axs, _precondition_on(method))
+    function obj(z, p)
+        v_free = ComponentArrays.getdata(_θt_from_z(z))
         T = eltype(v_free)
         infT = convert(T, Inf)
         θt_full = _merge_free_into_full(θ_const_t_vec, free_idx, v_free, axs_full)
@@ -1100,11 +1110,14 @@ function _pooled_solve(dm::DataModel, method, θ_start_u::ComponentArray,
         fe, free_names, θ0_free_t, method.optimizer, method.lb, method.ub, merged_constants;
         ignore_model_bounds = method.ignore_model_bounds, emit_info = info_bounds,
         method_label = "Pooled")
-    prob = use_bounds ? OptimizationProblem(optf, θ0_init; lb = lb, ub = ub) :
-           OptimizationProblem(optf, θ0_init)
+    z0 = _z_from_θt(θ0_init)
+    lb_z = _z_from_θt(lb)
+    ub_z = _z_from_θt(ub)
+    prob = use_bounds ? OptimizationProblem(optf, z0; lb = lb_z, ub = ub_z) :
+           OptimizationProblem(optf, z0)
     sol = Optimization.solve(prob, method.optimizer; method.optim_kwargs...)
 
-    θ_hat_t_raw = sol.u
+    θ_hat_t_raw = _θt_from_z(sol.u)
     θ_hat_t_free = θ_hat_t_raw isa ComponentArray ?
                    θ_hat_t_raw : ComponentArray(θ_hat_t_raw, axs)
     T = eltype(θ_hat_t_free)

--- a/src/estimation/re_batch.jl
+++ b/src/estimation/re_batch.jl
@@ -302,17 +302,17 @@ function build_eta_individual(dm::DataModel,
                 if const_mask[id]
                     if info.is_scalar
                         v = const_scalars[id]
-                        vals[gi] = T(v)
+                        vals[gi] = convert(T, v)
                     else
                         v = const_vectors[id]
-                        vals[gi] = T.(v)
+                        vals[gi] = convert.(T, v)
                     end
                 else
                     v = _re_value_from_b(info, id, b)
                     v === nothing &&
                         error("Missing random effect value for $(re) level $(cache.re_index[ri].levels[id]).")
                     if info.is_scalar
-                        vals[gi] = T(v)
+                        vals[gi] = convert(T, v)
                     else
                         vals[gi] = Vector{T}(v)
                     end

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -415,6 +415,7 @@ struct SAEM{O, K, A, SO, L, U} <: FittingMethod
     saem::SO
     lb::L
     ub::U
+    precondition::Bool
 end
 
 function SAEM(;
@@ -488,7 +489,8 @@ function SAEM(;
         store_obsLL::Bool = false,
         obsLL_every::Int = 1,
         store_diagnostics::Bool = false,
-        diagnostics_every::Int = 1)
+        diagnostics_every::Int = 1,
+        precondition::Bool = true)
     q_store_max >= 1 ||
         error("SAEM: q_store_max must be ≥ 1. Got: $q_store_max")
     0 <= q_store_min <= q_store_max ||
@@ -533,7 +535,7 @@ function SAEM(;
         sa_anneal_fn,
         auto_var_lb, var_lb_value, max_estep_retries, retry_mcmc_steps,
         store_obsLL, obsLL_every, store_diagnostics, diagnostics_every)
-    SAEM(optimizer, optim_kwargs, adtype, saem, lb, ub)
+    SAEM(optimizer, optim_kwargs, adtype, saem, lb, ub, precondition)
 end
 
 # SAEMResult is a StandardOptimizationResult{:saem} alias (see common.jl).
@@ -3197,9 +3199,13 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
                 # would box them (`Core.Box`) inside every objective evaluation.
                 θt_full_q2_base = θt_full_curr
                 axs_full_q2 = axs_full_iter
-                function obj_q2(ψt, p)
-                    any(isnan, ψt) && return eltype(ψt)(Inf)
-                    ψt_ca = ψt isa ComponentArray ? ψt : ComponentArray(ψt, axs_q2)
+                # Anchored at the current iterate: the anchor's job is to put the start at
+                # z = 0, and the free set is not invariant across SAEM iterations.
+                _, _, _q2_from_z, _z_from_q2 = _precondition_maps(
+                    get_model(dm), q2_free_now, θt_q2, axs_q2, _precondition_on(method))
+                function obj_q2(z, p)
+                    any(isnan, z) && return eltype(z)(Inf)
+                    ψt_ca = _q2_from_z(z)
                     T = eltype(ψt_ca)
                     θt_full_q2 = ComponentArray(T.(collect(θt_full_q2_base)), axs_full_q2)
                     for name in q2_free_now
@@ -3222,13 +3228,16 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
                     fe, q2_free_now, collect(θt_q2), method.optimizer, nothing,
                     nothing, NamedTuple(); allow_bbo = false)
                 optf_q2 = OptimizationFunction(obj_q2, method.adtype)
+                z0_q2 = _z_from_q2(θ0_q2)
                 prob_q2 = use_bounds_q2 ?
-                          OptimizationProblem(optf_q2, θ0_q2; lb = lb_q2, ub = ub_q2) :
-                          OptimizationProblem(optf_q2, θ0_q2)
+                          OptimizationProblem(optf_q2, z0_q2;
+                    lb = _z_from_q2(lb_q2), ub = _z_from_q2(ub_q2)) :
+                          OptimizationProblem(optf_q2, z0_q2)
                 sol_q2 = Optimization.solve(
                     prob_q2, method.optimizer; method.optim_kwargs...)
                 if all(isfinite, sol_q2.u)
-                    θt_q2_opt = ComponentArray(sol_q2.u, axs_q2)
+                    # Mapped back before the SA damping below, which must act on θt.
+                    θt_q2_opt = _q2_from_z(sol_q2.u)
                     if method.saem.mstep_sa_on_params
                         θt_q2_before = collect(θt_q2)
                         θt_q2_opt = ComponentArray(
@@ -3297,10 +3306,14 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
             axs_full_obj = axs_full_iter
             free_names_obj = free_names_iter
             axs_free_obj = axs_free
-            function obj_only(θt, p)
-                any(isnan, θt) && return eltype(θt)(Inf)
-                θt_free_loc = θt isa ComponentArray ? θt :
-                              ComponentArray(θt, axs_free_obj)
+            # Anchored at the current iterate, as for Q2. The objective cache below is keyed on
+            # θt and lives inside this loop; with a per-iteration anchor, z = 0 means a different
+            # θt each iteration, so hoisting the cache would make it permanently stale.
+            _, _, _θt_from_z, _z_from_θt = _precondition_maps(
+                get_model(dm), free_names_iter, θt_free, axs_free, _precondition_on(method))
+            function obj_only(z, p)
+                any(isnan, z) && return eltype(z)(Inf)
+                θt_free_loc = _θt_from_z(z)
                 θt_vec = θt_free_loc
                 use_cache = !(eltype(θt_free_loc) <: ForwardDiff.Dual)
                 if use_cache && obj_cache.θ[] !== nothing &&
@@ -3341,8 +3354,12 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
             lb, ub, use_bounds, θ0_init = _resolve_optim_bounds(
                 fe, free_names_iter, collect(θt_free), method.optimizer,
                 method.lb, method.ub, constants; method_label = "SAEM")
-            prob = use_bounds ? OptimizationProblem(optf, θ0_init; lb = lb, ub = ub) :
-                   OptimizationProblem(optf, θ0_init)
+            # z-space problem only; `lb`/`ub` stay on the θt scale below, where the closed-form
+            # M-step clamps with them directly.
+            z0 = _z_from_θt(θ0_init)
+            prob = use_bounds ?
+                   OptimizationProblem(optf, z0; lb = _z_from_θt(lb), ub = _z_from_θt(ub)) :
+                   OptimizationProblem(optf, z0)
             if method.saem.suffstats !== nothing &&
                method.saem.mstep_closed_form !== nothing
                 closed_form_custom_used = true
@@ -3368,9 +3385,8 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
                     @warn "SAEM M-step iter $iter: optimizer returned non-finite parameters; skipping update."
                     mstep_skipped = true
                 else
-                    θ_hat_t_raw = sol.u
-                    θ_hat_t_free = θ_hat_t_raw isa ComponentArray ? θ_hat_t_raw :
-                                   ComponentArray(θ_hat_t_raw, axs_free)
+                    # Mapped back before the SA damping below, which must act on θt.
+                    θ_hat_t_free = _θt_from_z(sol.u)
                     if method.saem.mstep_sa_on_params
                         # SA update: θ_new = θ_old + γ*(θ̂ − θ_old)
                         θt_free = ComponentArray(

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -418,7 +418,7 @@ struct SAEM{O, K, A, SO, L, U} <: FittingMethod
 end
 
 function SAEM(;
-        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking()),
+        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking(maxstep = 1.0)),
         optim_kwargs = (; iterations = 10, g_abstol = 1e-4, f_reltol = 1e-6),
         adtype = Optimization.AutoForwardDiff(),
         sampler = SaemixMH(),
@@ -448,7 +448,7 @@ function SAEM(;
         resid_var_param = :σ,
         re_cov_params = NamedTuple(),
         re_mean_params = NamedTuple(),
-        ebe_optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking()),
+        ebe_optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking(maxstep = 1.0)),
         ebe_optim_kwargs = NamedTuple(),
         ebe_adtype = Optimization.AutoForwardDiff(),
         ebe_grad_tol = :auto,
@@ -2650,7 +2650,7 @@ function _saem_builtin_mean_updates(dm::DataModel,
         sample_store::_SAEMSampleStore,
         transform,
         inv_transform;
-        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking()),
+        optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking(maxstep = 1.0)),
         optim_kwargs::NamedTuple = NamedTuple(),
         serialization::SciMLBase.EnsembleAlgorithm = EnsembleThreads(),
         penalty::NamedTuple = NamedTuple(),

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -314,7 +314,7 @@ end
            ebe_multistart_k, ebe_multistart_max_rounds, ebe_multistart_sampling,
            ebe_rescue_on_high_grad, ebe_rescue_multistart_n, ebe_rescue_multistart_k,
            ebe_rescue_max_rounds, ebe_rescue_grad_tol, ebe_rescue_multistart_sampling,
-           lb, ub) <: FittingMethod
+           lb, ub, precondition) <: FittingMethod
 
 Stochastic Approximation Expectation-Maximization for random-effects models. SAEM
 maintains a stochastic approximation of the sufficient statistics using a decreasing
@@ -393,6 +393,13 @@ or closed-form updates (when `builtin_stats` is enabled).
 - `ebe_rescue_on_high_grad` (default `false`), `ebe_rescue_*`: rescue multistart settings
   when an EBE mode has a high gradient norm. Disabled by default.
 - `lb`, `ub`: bounds on the transformed fixed-effect scale, or `nothing`.
+- `precondition::Bool = true`: optimize the scaled offset `z` with
+  `θ_transformed = θ0 + s .* z`, so every fit starts at `z = 0` and no coordinate can be
+  frozen by an unlucky starting value. `s` is 1 for any coordinate already in log/logit
+  space and `max(abs(θ0), 1)` for a genuinely natural-scale `:identity` coordinate. Set
+  `false` to optimize the transformed vector directly, which reproduces pre-0.2 results
+  bit-for-bit. Note that with preconditioning on, the optimizer object behind
+  [`get_raw`](@ref) works in `z`; [`get_params`](@ref) always returns the usual scales.
 - `mstep_sa_on_params::Bool = true`: if `true`, the numerical M-step uses only the
   current iteration's random-effect samples (not the ring buffer) as the objective,
   and applies a Robbins-Monro parameter update

--- a/test/estimation_laplace_tests.jl
+++ b/test/estimation_laplace_tests.jl
@@ -695,14 +695,30 @@ end
         y = 0.05 .* exp.(0.4 .* randn(rng, 48)))
     dm = DataModel(model, df; primary_id = :ID, time_col = :t)
 
-    on = fit_model(dm, NoLimits.Laplace(); rng = Xoshiro(1))
-    off = fit_model(dm, NoLimits.Laplace(; precondition = false); rng = Xoshiro(1))
+    # BOBYQA is pinned, not defaulted: this test exercises a DERIVATIVE-FREE pathology - such an
+    # optimizer sizes each coordinate's first step by that coordinate's own value, so a
+    # coordinate starting near zero never moves, and preconditioning is what frees it. The
+    # default optimizer is gradient-based and does not size steps that way, so leaving the
+    # optimizer implicit would silently stop testing the thing this testset is named after.
+    bob = NoLimits.NLopt.LN_BOBYQA()
+    on = fit_model(dm, NoLimits.Laplace(; optimizer = bob); rng = Xoshiro(1))
+    off = fit_model(
+        dm, NoLimits.Laplace(; optimizer = bob, precondition = false); rng = Xoshiro(1))
     Ω_on = NoLimits.get_params(on; scale = :untransformed).Ω
     Ω_off = NoLimits.get_params(off; scale = :untransformed).Ω
 
     # Preconditioning must never do worse, and it must move Ω[2,2] off its start.
     @test NoLimits.get_objective(on) <= NoLimits.get_objective(off) + 1e-8
     @test abs(Ω_on[2, 2] - 1.0) > abs(Ω_off[2, 2] - 1.0)
+
+    # The gradient-based default does not size steps by |x0|, so preconditioning neither frees
+    # nor freezes a coordinate there - it must simply not disturb the fit. Asserted two-sided on
+    # purpose: which of two optimizer parameterizations lands infinitesimally lower is arbitrary
+    # (they agree to ~1e-8 relative here), so a one-sided inequality would fail on a coin flip.
+    on_d = fit_model(dm, NoLimits.Laplace(); rng = Xoshiro(1))
+    off_d = fit_model(dm, NoLimits.Laplace(; precondition = false); rng = Xoshiro(1))
+    @test isfinite(NoLimits.get_objective(on_d))
+    @test NoLimits.get_objective(on_d)≈NoLimits.get_objective(off_d) rtol=1e-4
 end
 
 # Preconditioning rescales the outer variable, so the gradient handed to the optimizer

--- a/test/estimation_precondition_tests.jl
+++ b/test/estimation_precondition_tests.jl
@@ -1,0 +1,125 @@
+using Test
+using NoLimits
+using DataFrames
+using Distributions
+using ComponentArrays
+using Random
+using Turing
+using LinearAlgebra
+
+# `precondition` was added to nine methods but only `Laplace` had coverage
+# (estimation_laplace_tests.jl). These tests cover the shared algebra once and then check that
+# every method agrees between the two settings, which is what a broken z <-> theta_t mapping
+# would break.
+#
+# The fixture deliberately uses an :identity coordinate with |theta0| > 1. With
+# `RealNumber(0.2)` the scale is max(0.2, 1) = 1 and every assertion below passes
+# vacuously — a `precondition = false` check against s == 1 tests nothing at all.
+
+const _PC_DF = DataFrame(ID = [:A, :A, :B, :B, :C, :C, :D, :D],
+    t = repeat([0.0, 1.0], 4), y = [3.1, 3.4, 2.7, 2.9, 3.3, 3.0, 2.8, 3.2])
+
+function _pc_model_re()
+    @Model(begin
+        @covariates begin
+            t = Covariate()
+        end
+        # Priors exist only so `PooledMap` -- Pooled plus a log-prior, and it requires random
+        # effects -- can share this fixture. Every ML method below ignores them.
+        @fixedEffects begin
+            a = RealNumber(3.0; prior = Normal(0.0, 10.0))   # identity, |theta0| = 3 -> s = 3
+            b = RealNumber(0.5, scale = :log, prior = LogNormal(0.0, 1.0))   # log -> s = 1
+            σ = RealNumber(0.4, scale = :log, prior = LogNormal(0.0, 1.0))
+        end
+        @randomEffects begin
+            η = RandomEffect(Normal(0.0, 1.0); column = :ID)
+        end
+        @formulas begin
+            y ~ Normal(a + b * t + η, σ)
+        end
+    end)
+end
+
+function _pc_model_nore()
+    @Model(begin
+        @covariates begin
+            t = Covariate()
+        end
+        @fixedEffects begin
+            a = RealNumber(3.0; prior = Normal(0.0, 10.0))
+            σ = RealNumber(0.4, scale = :log, prior = LogNormal(0.0, 1.0))
+        end
+        @formulas begin
+            y ~ Normal(a, σ)
+        end
+    end)
+end
+
+const _PC_DM_RE = DataModel(_pc_model_re(), _PC_DF; primary_id = :ID, time_col = :t)
+const _PC_DM_NORE = DataModel(_pc_model_nore(), _PC_DF; primary_id = :ID, time_col = :t)
+
+@testset "_precondition_maps round-trips and is non-vacuous" begin
+    model = get_model(_PC_DM_RE)
+    fe = NoLimits.get_fixed(model)
+    θ0_t = get_θ0_transformed(fe)
+    free_names = propertynames(θ0_t)
+    axs = ComponentArrays.getaxes(θ0_t)
+
+    θ0_pc, s_pc, θt_from_z, z_from_θt = NoLimits._precondition_maps(
+        model, free_names, θ0_t, axs, true)
+
+    # Non-vacuity guard: at least one coordinate must be scaled, else the round-trip below
+    # would hold for the identity map and prove nothing.
+    @test any(!=(1), s_pc)
+    @test s_pc[findfirst(==(:a), collect(free_names))] ≈ 3.0
+
+    # z = 0 must sit exactly at the start, and the maps must invert each other.
+    @test collect(θt_from_z(zeros(length(s_pc)))) ≈ collect(θ0_t)
+    @test z_from_θt(θ0_t) ≈ zeros(length(s_pc))
+    z = collect(range(-0.7, 1.3; length = length(s_pc)))
+    @test z_from_θt(θt_from_z(z)) ≈ z
+
+    # off: theta0 = 0 and s = 1, so z IS the transformed vector.
+    _, s_off, θt_off, z_off = NoLimits._precondition_maps(
+        model, free_names, θ0_t, axs, false)
+    @test all(==(1), s_off)
+    @test collect(θt_off(collect(θ0_t))) ≈ collect(θ0_t)
+    @test z_off(θ0_t) ≈ collect(θ0_t)
+end
+
+# Both settings parameterize the same problem, so a converged fit must land at the same
+# objective. A mapping bug (wrong anchor, wrong scale, bounds not mapped into z) sends one of
+# them somewhere else entirely, which this catches without pinning any number.
+@testset "precondition on/off agree per method" begin
+    fast_em = (maxiters = 2, t0 = 1, kappa = 0.6, mcmc_steps = 1)
+    cases = [
+        ("MLE", _PC_DM_NORE, pc -> NoLimits.MLE(; precondition = pc), NamedTuple()),
+        ("MAP", _PC_DM_NORE, pc -> NoLimits.MAP(; precondition = pc), NamedTuple()),
+        ("Pooled", _PC_DM_RE, pc -> NoLimits.Pooled(; precondition = pc), NamedTuple()),
+        ("PooledMap", _PC_DM_RE, pc -> NoLimits.PooledMap(; precondition = pc),
+            NamedTuple()),
+        ("FOCEI", _PC_DM_RE, pc -> NoLimits.FOCEI(; precondition = pc), NamedTuple()),
+        ("GHQuadrature", _PC_DM_RE,
+            pc -> NoLimits.GHQuadrature(; level = 3, precondition = pc), NamedTuple()),
+        ("SAEM", _PC_DM_RE,
+            pc -> NoLimits.SAEM(; precondition = pc, q_store_max = 2,
+                turing_kwargs = (; n_samples = 4, n_adapt = 2, progress = false),
+                fast_em...), NamedTuple()),
+        ("MCEM", _PC_DM_RE,
+            pc -> NoLimits.MCEM(; precondition = pc, maxiters = 2,
+                turing_kwargs = (; n_samples = 4, n_adapt = 2, progress = false)),
+            NamedTuple())
+    ]
+    for (name, dm, mk, kw) in cases
+        on = fit_model(dm, mk(true); rng = Xoshiro(11), kw...)
+        off = fit_model(dm, mk(false); rng = Xoshiro(11), kw...)
+        o_on, o_off = get_objective(on), get_objective(off)
+        @test isfinite(o_on)
+        @test isfinite(o_off)
+        # Stochastic-EM methods take a fixed, tiny number of steps from different
+        # parameterizations, so they are compared loosely; the deterministic ones must agree.
+        tol = name in ("SAEM", "MCEM") ? 5.0 : 1e-3
+        @test isapprox(o_on, o_off; atol = tol, rtol = 1e-4) ||
+              error("$name: precondition on/off disagree ($o_on vs $o_off)")
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,6 +93,7 @@ const TEST_GROUPS = [
         "saem_var_lb_tests.jl",
         "estimation_multistart_tests.jl",
         "estimation_ghquadrature_tests.jl",
+        "estimation_precondition_tests.jl",
         "extra_objective_tests.jl",
         "uq_tests.jl",
         "uq_edge_cases_tests.jl"],


### PR DESCRIPTION
Stacked on #92 (retargets to `main` when that merges). Four commits, each with its own verification.

> **Behaviour change, stated up front:** every existing script calling `Laplace()` or `FOCEI()` will produce different estimates after this — better on 11 of 12 benchmark cells, but different. Backward compatibility was explicitly not required.

## 1. `LBFGS(BackTracking(maxstep = 1.0))` replaces `LN_BOBYQA` as the default

With the gradient corrected in #92, the gradient path is better on **both** axes. Six models × both methods, AGHQ marginal `-2LL`, warm timings with the compile fit discarded:

- **likelihood:** better or equal on 11 of 12 cells, **net −573 units**. warfarin Laplace −522, mavoglurant Laplace −24, nimo −9 to −20. One loss: mavoglurant FOCEI, +7.9.
- **speed:** **1.8–5.9× faster on 11 of 12**, median 2.9×, total 939 s → 470 s. The one slower cell is warfarin Laplace, and it is *not* like-for-like — BOBYQA finishes in 24 s because it stops 522 units short and never reaches the better optimum at any runtime.

The `maxstep` cap is load-bearing: the gradient's coordinates span four orders of magnitude at a poorly scaled start (pheno's `add_err` coordinate is ~4e4 against 6–49), so an uncapped unit first step overflows into the infeasible region — `-2LL` 6038 against 973.44 capped. Every *inner* empirical-Bayes optimizer in the package has always carried `maxstep = 1.0`; no *outer* or M-step optimizer did. Now applied uniformly across all nine methods.

Two alternatives were measured across all six models and rejected: `InitialStatic(scaled = true)` terminates after **6 iterations** on warfarin, 378 units short; `InitialPrevious` fails worse than no control at all.

## 2. Preconditioning for every numerical method

`θt = θ0 + s .* z` previously existed only in the Laplace/FOCEI driver. Extended to MLE, MAP, Pooled, PooledMap, GHQuadrature, SAEM and MCEM via a shared `_precondition_maps` helper, so the map, its inverse, the bounds map (the same affine operation) and the arbitrary-method guard have **one** definition rather than one per driver.

- SAEM/MCEM M-steps anchor at the **current iterate**, rebuilt each iteration: the anchor's only job is to put the start at `z = 0`, and the free set is not invariant across EM iterations.
- Pooled's zero-contribution **freezing** machinery stays on raw transformed coordinates — it perturbs by absolute magnitudes, so rescaling it would change *which* parameters get frozen, a change to what the method does rather than a reparameterization.
- **VI and MCMC are excluded deliberately**: neither builds an `OptimizationProblem`, and their sampled parameters live in Bijectors' linked prior space rather than NoLimits' transformed θ, so the declared scales the preconditioner keys off do not apply. Both already have an analogue (a learned variational scale; NUTS' mass-matrix adaptation).

Governing invariant, verified: with the optimizer pinned identically, `precondition = false` is **bit-identical** to the pre-port tree for all nine methods.

## 3. Infeasible points report a finite value, not `Inf`

A line search cannot interpolate through a non-finite function value — `BackTracking(order = 3)` fits a cubic through its trial values — so it abandoned the search instead of shrinking the step. On pheno from a well-scaled start, **five** gradient optimizers (LBFGS × 3 line searches, BFGS, ConjugateGradient) all returned the *starting point* with `retcode = Failure`, while an Armijo-acceptable step giving a 42-unit decrease sat at α = 0.01.

36 cells (6 models × 2 methods × 3 optimizers) against the same tree without it:

- `LN_BOBYQA`: 11 of 12 bit-identical; **warfarin Laplace 2765.77 → 2231.89 (−533.9)**. Not inert for the derivative-free path — on the one model whose BOBYQA result was conspicuously worse than its LBFGS result, BOBYQA was stalling against the infeasible region.
- `maxstep = 1.0` (default): 11 of 12 bit-identical; warfarin Laplace −11.5.
- uncapped: 9 of 12 improve, 2 unchanged, 1 regresses. pheno Laplace 6039 → 2673 (**603 s → 75 s**), wbc FOCEI 911 → 790, wbc Laplace 826 → 791. Single regression: mavoglurant Laplace, **+0.11**.

Worst movement anywhere is +0.11; best is −533.9. It does **not** substitute for the cap (uncapped pheno reaches 2673, not 973.35).

## Verification performed

- Full 92-file suite, docs build, JuliaFormatter v1, Aqua.
- The docs build and `simplechains_nn_tests` caught a real bug in the wall — guarding on the *current* eltype rather than the concrete float type made every LBFGS fit throw `MethodError: Float64(::Dual)`, because Optimization.jl pushes Duals through `obj_only` on the gradient path. No estimator test covers that path.
- The near-zero-coordinate preconditioning test now pins BOBYQA explicitly, since it exercises a derivative-free pathology the new default does not have; a two-sided check on the default path keeps that covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

_Supersedes #93, which GitHub auto-closed when #92 merged and its base branch was deleted. Same commits, rebased onto `main`._
