### PR TITLE
fix: SAEM multi-chain E-step collapsed RE variances by averaging the chains' draws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ### Bug fixes
 
+- SAEM with more than one E-step chain collapsed every random-effect variance
+  geometrically to the `1e-5` floor, independent of the data, the sampler, the
+  starting values, and the M-step mode. The chains' η draws were AVERAGED into a
+  single pseudo-sample (`b_current`) before the sufficient statistics and Q
+  objectives were formed; the second moment of an average of `C` posterior draws is
+  `Ω²·(1 − B(1 − 1/C))` (`B` = shrinkage fraction) instead of `Ω²`, whose only fixed
+  point is `Ω = 0`. Because `auto_small_n_chains = true` silently raises the chain
+  count whenever there are fewer than `small_n_chain_target` (50) batches, every
+  small-dataset SAEM fit was affected. Chains are now consumed as separate draws
+  everywhere: the closed-form sufficient statistics accumulate over all chains, the
+  ring buffer stores one entry per chain with weight `γ/n_chains`,
+  `Q_current`/`Q2_current` average the log-densities over chains, custom `suffstats`
+  are evaluated per chain and averaged, and the E-step retry check flags a batch if
+  any chain is non-finite. Single-chain fits are unchanged.
+- The builtin closed-form M-step silently overwrote user-supplied `constants`
+  (e.g. `constants = (; Omega = 0.6)` still updated `Omega` every iteration).
+  Constants now always win over closed-form updates.
 - The analytic outer gradient of the `Laplace` and `FOCEI` marginal objectives was wrong,
   which made a gradient-based outer optimizer perform far worse than the derivative-free
   default instead of better. Two independent causes, both invisible to `LN_BOBYQA`:

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -96,6 +96,9 @@ end
 # Invariant: active slots in age order are head, head+1, ..., head+len-1 (all mod capacity,
 # 1-based). After each push, entries whose SA weight falls below q_epsilon are pruned from
 # the oldest end (subject to the q_min floor). Retained weights are normalized in _saem_Q.
+# Each E-step chain is stored as its OWN entry with weight γ/n_chains. Never store the
+# average of the chains' η: second moments of an average are deflated by the within-
+# posterior variance, which makes RE variance estimates decay geometrically to zero.
 mutable struct _SAEMSampleStore
     weights::Vector{Float64}                          # [slot] weight, preallocated
     snaps::Vector{Vector{Vector{Float64}}}            # [slot][batch] re-values, preallocated
@@ -114,7 +117,7 @@ function _init_saem_sample_store(capacity::Int, q_epsilon::Float64, q_min::Int,
     return _SAEMSampleStore(weights, snaps, 1, 1, 0, capacity, q_epsilon, q_min)
 end
 
-function _saem_store_push!(store::_SAEMSampleStore, b_current, γ::Float64)
+function _saem_store_push!(store::_SAEMSampleStore, b_chains, γ::Float64, n_chains::Int)
     γ == 0.0 && return store
     one_minus_γ = 1.0 - γ
     # Scale all active weights in-place, iterating from head (wrapping)
@@ -123,21 +126,24 @@ function _saem_store_push!(store::_SAEMSampleStore, b_current, γ::Float64)
         store.weights[h] *= one_minus_γ
         h = h == store.capacity ? 1 : h + 1
     end
-    # If full, evict oldest by advancing head (len stays at capacity)
-    if store.len == store.capacity
-        store.head = store.head == store.capacity ? 1 : store.head + 1
-    else
-        store.len += 1
+    # Write one entry per chain, splitting this iteration's SA weight evenly
+    γ_chain = γ / n_chains
+    for c in 1:n_chains
+        # If full, evict oldest by advancing head (len stays at capacity)
+        if store.len == store.capacity
+            store.head = store.head == store.capacity ? 1 : store.head + 1
+        else
+            store.len += 1
+        end
+        idx = store.next_idx
+        store.weights[idx] = γ_chain
+        snaps_slot = store.snaps[idx]
+        @inbounds for bi in eachindex(b_chains)
+            snap = snaps_slot[bi]
+            isempty(snap) || copyto!(snap, b_chains[bi][c])
+        end
+        store.next_idx = store.next_idx == store.capacity ? 1 : store.next_idx + 1
     end
-    # Write new entry to next_idx
-    idx = store.next_idx
-    store.weights[idx] = γ
-    snaps_slot = store.snaps[idx]
-    @inbounds for bi in eachindex(b_current)
-        snap = snaps_slot[bi]
-        isempty(snap) || copyto!(snap, b_current[bi])
-    end
-    store.next_idx = store.next_idx == store.capacity ? 1 : store.next_idx + 1
     # Prune entries below q_epsilon from the oldest end (subject to q_min floor)
     @inbounds while store.len > store.q_min &&
                     store.weights[store.head] < store.q_epsilon
@@ -631,23 +637,14 @@ function _saem_effective_chains(n_chains::Int, auto::Bool, target::Int, n_batche
     return n_chains
 end
 
+# b_current is a point summary (chain 1's sample) used only for display (_saem_obsLL)
+# and the GLM support check. Sufficient statistics and Q evaluations must consume every
+# chain via b_chains: averaging the chains' η before computing second moments deflates
+# RE variances by the within-posterior variance and collapses them geometrically to zero.
 function _saem_update_b_current!(b_current::Vector, b_chains::Vector,
-        batch_indices::AbstractVector{Int}, n_chains::Int)
-    if n_chains == 1
-        @inbounds for bi in batch_indices
-            b_current[bi] = b_chains[bi][1]
-        end
-    else
-        inv_nc = 1.0 / n_chains
-        @inbounds for bi in batch_indices
-            chains = b_chains[bi]
-            b = b_current[bi]
-            fill!(b, 0.0)
-            for c in 1:n_chains
-                b .+= chains[c]
-            end
-            b .*= inv_nc
-        end
+        batch_indices::AbstractVector{Int})
+    @inbounds for bi in batch_indices
+        b_current[bi] = b_chains[bi][1]
     end
     return b_current
 end
@@ -1820,9 +1817,14 @@ function _saem_collect_outcome_stats_individual(dm::DataModel,
     return (NamedTuple(pairs), true)
 end
 
+# Collect this iteration's sufficient statistics from EVERY chain's sample. Each chain
+# is a separate E-step draw: second moments must include the across-chain dispersion,
+# so the chains' η are never averaged before the moments are formed (doing so deflates
+# RE variance estimates by the within-posterior variance and collapses them to zero).
 function _saem_builtin_collect_current_stats(dm::DataModel,
         batch_infos::Vector{REBatchInfo},
-        b_current::AbstractVector,
+        b_chains::AbstractVector,
+        n_chains::Int,
         θ::ComponentArray,
         const_cache::REConstantsCache,
         resid_var_param,
@@ -1844,8 +1846,8 @@ function _saem_builtin_collect_current_stats(dm::DataModel,
         sum_x = nothing
         sum_xx = nothing
         nvals = 0
-        for (bi, info) in enumerate(batch_infos)
-            b = b_current[bi]
+        for (bi, info) in enumerate(batch_infos), c in 1:n_chains
+            b = b_chains[bi][c]
             rei = get_re_info(info)[ri]
             for lvl_id in get_levels(get_re_map(rei))
                 v = _re_value_from_b(rei, lvl_id, b)
@@ -1888,8 +1890,8 @@ function _saem_builtin_collect_current_stats(dm::DataModel,
     if !isempty(keys(obs_targets))
         obs_acc = Dict{Symbol, Any}()
         all_supported = true
-        for (bi, info) in enumerate(batch_infos)
-            b = b_current[bi]
+        for (bi, info) in enumerate(batch_infos), c in 1:n_chains
+            b = b_chains[bi][c]
             for i in get_inds(info)
                 η_ind = _build_eta_ind(dm, i, info, b, const_cache, θ)
                 stats_i, ok = _saem_collect_outcome_stats_individual(
@@ -1922,8 +1924,8 @@ function _saem_builtin_collect_current_stats(dm::DataModel,
     if !isempty(keys(hmm_emission_params))
         hmm_acc = Dict{Symbol, Any}()
         all_supported = true
-        for (bi, info) in enumerate(batch_infos)
-            b = b_current[bi]
+        for (bi, info) in enumerate(batch_infos), c in 1:n_chains
+            b = b_chains[bi][c]
             for i in get_inds(info)
                 η_ind = _build_eta_ind(dm, i, info, b, const_cache, θ)
                 stats_i, ok = _saem_collect_hmm_stats_individual(
@@ -2476,24 +2478,36 @@ function _saem_obsLL(dm::DataModel,
     return total
 end
 
-# Evaluate Q from only the current iteration's samples (b_current).
-# Used when mstep_sa_on_params=true: O(N) vs O(q_store_max × N) for _saem_Q.
-# Shared core, parameterized like `_saem_Q_core` (Q vs Q2 density).
+# Evaluate Q from only the current iteration's samples (all chains in b_chains).
+# Used when mstep_sa_on_params=true: O(N × n_chains) vs O(q_store_max × N) for _saem_Q.
+# Shared core, parameterized like `_saem_Q_core` (Q vs Q2 density). Each chain is a
+# separate E-step draw, so Q is the chain average of the log-densities.
 function _saem_Q_current_core(logf_fn::F, dm::DataModel,
         batch_infos::Vector{REBatchInfo},
         θ::ComponentArray,
         const_cache::REConstantsCache,
         ll_cache,
-        b_current::AbstractVector;
+        b_chains::AbstractVector,
+        n_chains::Int;
         anneal_sds::NamedTuple = NamedTuple()) where {F}
     total = zero(eltype(θ))
     ll_cache_local = ll_cache isa Vector ? ll_cache[1] : ll_cache
+    inv_nc = one(total) / n_chains
     for (bi, info) in enumerate(batch_infos)
-        snap = get_n_b(info) == 0 ? eltype(θ)[] : b_current[bi]
-        logf = logf_fn(dm, info, θ, snap, const_cache, ll_cache_local;
-            anneal_sds = anneal_sds)
-        !isfinite(logf) && return typeof(total)(Inf)
-        total += logf
+        if get_n_b(info) == 0
+            # Chain-independent contribution — evaluate once at full weight.
+            logf = logf_fn(dm, info, θ, eltype(θ)[], const_cache, ll_cache_local;
+                anneal_sds = anneal_sds)
+            !isfinite(logf) && return typeof(total)(Inf)
+            total += logf
+            continue
+        end
+        for c in 1:n_chains
+            logf = logf_fn(dm, info, θ, b_chains[bi][c], const_cache, ll_cache_local;
+                anneal_sds = anneal_sds)
+            !isfinite(logf) && return typeof(total)(Inf)
+            total += inv_nc * logf
+        end
     end
     return total
 end
@@ -2503,11 +2517,12 @@ function _saem_Q_current(dm::DataModel,
         θ::ComponentArray,
         const_cache::REConstantsCache,
         ll_cache,
-        b_current::AbstractVector;
+        b_chains::AbstractVector,
+        n_chains::Int;
         serialization::SciMLBase.EnsembleAlgorithm = EnsembleThreads(),
         anneal_sds::NamedTuple = NamedTuple())
     return _saem_Q_current_core(_laplace_logf_batch, dm, batch_infos, θ,
-        const_cache, ll_cache, b_current; anneal_sds = anneal_sds)
+        const_cache, ll_cache, b_chains, n_chains; anneal_sds = anneal_sds)
 end
 
 # Q2 counterpart to _saem_Q: evaluates only log p(η|θ_re), averaged over the ring buffer.
@@ -2531,32 +2546,40 @@ function _saem_Q2_current(dm::DataModel,
         θ::ComponentArray,
         const_cache::REConstantsCache,
         ll_cache,
-        b_current::AbstractVector;
+        b_chains::AbstractVector,
+        n_chains::Int;
         serialization::SciMLBase.EnsembleAlgorithm = EnsembleThreads(),
         anneal_sds::NamedTuple = NamedTuple())
     return _saem_Q_current_core(_re_logpdf_batch, dm, batch_infos, θ,
-        const_cache, ll_cache, b_current; anneal_sds = anneal_sds)
+        const_cache, ll_cache, b_chains, n_chains; anneal_sds = anneal_sds)
 end
 
-# Return indices (into batch_infos) from `updated` whose current RE sample gives a
-# non-finite log-likelihood at θ. Used by the E-step retry mechanism.
+# Return indices (into batch_infos) from `updated` whose current RE samples give a
+# non-finite log-likelihood at θ. A batch is bad if ANY chain's sample is non-finite,
+# since Q_current averages over all chains. Used by the E-step retry mechanism.
 function _saem_bad_batches(dm::DataModel,
         batch_infos::Vector{REBatchInfo},
         updated::AbstractVector{Int},
         θ::ComponentArray,
-        b_current::AbstractVector,
+        b_chains::AbstractVector,
+        n_chains::Int,
         const_cache::REConstantsCache,
         ll_cache;
         anneal_sds::NamedTuple = NamedTuple())
     bad = Int[]
     ll_cache_local = ll_cache isa Vector ? ll_cache[1] : ll_cache
     @inbounds for bi in updated
-        snap = b_current[bi]
-        isempty(snap) && continue
-        logf = _laplace_logf_batch(
-            dm, batch_infos[bi], θ, snap, const_cache, ll_cache_local;
-            anneal_sds = anneal_sds)
-        isfinite(logf) || push!(bad, bi)
+        chains = b_chains[bi]
+        (isempty(chains) || isempty(chains[1])) && continue
+        for c in 1:n_chains
+            logf = _laplace_logf_batch(
+                dm, batch_infos[bi], θ, chains[c], const_cache, ll_cache_local;
+                anneal_sds = anneal_sds)
+            if !isfinite(logf)
+                push!(bad, bi)
+                break
+            end
+        end
     end
     return bad
 end
@@ -2962,11 +2985,14 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
     var_lb_eff = min(method.saem.anneal_min_sd, method.saem.var_lb_value)
 
     # O2+O4+O5: preallocated ring buffer for SA sample history
-    # When mstep_sa_on_params=true the M-step reads only b_current, so the ring buffer is
-    # never used for optimization — capacity=1 minimizes memory while keeping Q_new valid.
-    _store_capacity = method.saem.mstep_sa_on_params ? 1 : method.saem.q_store_max
+    # When mstep_sa_on_params=true the M-step reads only the current iteration's chains,
+    # so the ring buffer is never used for optimization — one slot per chain minimizes
+    # memory while keeping Q_new valid. Capacity scales with the chain count so the SA
+    # memory horizon (in iterations) is independent of effective_n_chains.
+    _store_capacity = (method.saem.mstep_sa_on_params ? 1 : method.saem.q_store_max) *
+                      effective_n_chains
     sample_store = _init_saem_sample_store(_store_capacity, method.saem.q_store_epsilon,
-        min(method.saem.q_store_min, _store_capacity), batch_infos)
+        min(method.saem.q_store_min * effective_n_chains, _store_capacity), batch_infos)
     s = nothing
     builtin_stats_state = nothing
     closed_form_builtin_used = false
@@ -3055,14 +3081,23 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
             re_names, method.saem.warm_start, last_chain_params, b_chains,
             effective_n_chains, serialization;
             anneal_sds = anneal_sds, outer_iter = iter)
-        _saem_update_b_current!(b_current, b_chains, updated, effective_n_chains)
+        _saem_update_b_current!(b_current, b_chains, updated)
 
         if method.saem.suffstats !== nothing
-            s_new = method.saem.suffstats(dm, batch_infos, b_current, θu_curr, fixed_maps)
+            # Average the sufficient STATISTICS over chains (running mean via
+            # _saem_stats_update with weight 1/c) — never average the η draws
+            # themselves, which deflates second moments.
+            s_new = nothing
+            for c in 1:effective_n_chains
+                b_chain_c = [b_chains[bi][c] for bi in eachindex(batch_infos)]
+                s_c = method.saem.suffstats(dm, batch_infos, b_chain_c, θu_curr,
+                    fixed_maps)
+                s_new = _saem_stats_update(s_new, s_c, 1.0 / c)
+            end
             s = _saem_stats_update(s, s_new, γ)
         else
             # O2+O4+O5: push into ring buffer in-place (no allocation, no Array shifts)
-            _saem_store_push!(sample_store, b_current, γ)
+            _saem_store_push!(sample_store, b_chains, γ, effective_n_chains)
         end
 
         # E-step retry: when mstep_sa_on_params=true the M-step objective is Q_current,
@@ -3072,8 +3107,8 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
         if method.saem.mstep_sa_on_params && method.saem.max_estep_retries > 0 &&
            method.saem.suffstats === nothing
             for _retry in 1:(method.saem.max_estep_retries)
-                bad = _saem_bad_batches(dm, batch_infos, updated, θu_curr, b_current,
-                    const_cache, ll_cache; anneal_sds = anneal_sds)
+                bad = _saem_bad_batches(dm, batch_infos, updated, θu_curr, b_chains,
+                    effective_n_chains, const_cache, ll_cache; anneal_sds = anneal_sds)
                 isempty(bad) && break
                 if method.saem.verbose
                     @info "SAEM retrying bad batches" iter=iter retry=_retry bad_batches=bad
@@ -3083,8 +3118,8 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
                     re_names, method.saem.warm_start, last_chain_params, b_chains,
                     effective_n_chains, serialization;
                     anneal_sds = anneal_sds, outer_iter = iter)
-                _saem_update_b_current!(b_current, b_chains, bad, effective_n_chains)
-                _saem_store_push!(sample_store, b_current, γ)
+                _saem_update_b_current!(b_current, b_chains, bad)
+                _saem_store_push!(sample_store, b_chains, γ, effective_n_chains)
             end
         end
 
@@ -3092,7 +3127,8 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
         iter_constants = constants
         if builtin_stats_mode == :closed_form
             cache = ll_cache isa Vector ? ll_cache[1] : ll_cache
-            curr_stats = _saem_builtin_collect_current_stats(dm, batch_infos, b_current,
+            curr_stats = _saem_builtin_collect_current_stats(dm, batch_infos, b_chains,
+                effective_n_chains,
                 ComponentArray(θu_curr, getaxes(θu_curr)), const_cache,
                 resid_var_param, hmm_emission_params,
                 re_cov_params, re_mean_params,
@@ -3103,6 +3139,11 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
                 dm, ComponentArray(θu_curr, getaxes(θu_curr)),
                 builtin_stats_state, resid_var_param, hmm_emission_params,
                 re_cov_params, re_mean_params)
+            # User-supplied constants always win over builtin closed-form updates.
+            for k in keys(constants)
+                haskey(updates, k) &&
+                    (updates = Base.structdiff(updates, NamedTuple{(k,)}((nothing,))))
+            end
             if !isempty(updates)
                 closed_form_builtin_used = true
                 # annealing always wins: strip cov targets for annealed REs
@@ -3221,7 +3262,7 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
                     θu_q2 = inv_transform(θt_full_q2)
                     Q2val = if method.saem.mstep_sa_on_params
                         _saem_Q2_current(dm, batch_infos, θu_q2, const_cache, ll_cache,
-                            b_current; serialization = serialization,
+                            b_chains, effective_n_chains; serialization = serialization,
                             anneal_sds = anneal_sds)
                     else
                         _saem_Q2(dm, batch_infos, θu_q2, const_cache, ll_cache,
@@ -3340,7 +3381,8 @@ function _fit_model(dm::DataModel, method::SAEM, args...;
                        method.saem.q_from_stats !== nothing
                     method.saem.q_from_stats(s, θu, dm)
                 elseif method.saem.mstep_sa_on_params
-                    _saem_Q_current(dm, batch_infos, θu, const_cache, ll_cache, b_current;
+                    _saem_Q_current(dm, batch_infos, θu, const_cache, ll_cache,
+                        b_chains, effective_n_chains;
                         serialization = serialization, anneal_sds = anneal_sds)
                 else
                     _saem_Q(dm, batch_infos, θu, const_cache, ll_cache, sample_store;

--- a/test/saem_multichain_tests.jl
+++ b/test/saem_multichain_tests.jl
@@ -27,27 +27,30 @@ using Turing
     @test NoLimits._saem_effective_chains(1, true, 50, 0) == 50   # ceil(50/1)
 end
 
-@testset "Multi-chain: _saem_update_b_current! n_chains=1 passthrough" begin
+@testset "Multi-chain: _saem_update_b_current! aliases chain 1" begin
     b_chains = [[Float64[1.0, 2.0]], [Float64[3.0, 4.0]]]
     b_current = [zeros(2), zeros(2)]
 
-    NoLimits._saem_update_b_current!(b_current, b_chains, [1, 2], 1)
+    NoLimits._saem_update_b_current!(b_current, b_chains, [1, 2])
 
     @test b_current[1] === b_chains[1][1]
     @test b_current[2] === b_chains[2][1]
 end
 
-@testset "Multi-chain: _saem_update_b_current! n_chains=3 average" begin
+@testset "Multi-chain: _saem_update_b_current! never averages chains" begin
+    # Averaging the chains' η deflates second moments and collapses RE variances
+    # geometrically to zero; b_current must be an actual draw (chain 1), regardless
+    # of the chain count.
     b_chains = [
         [Float64[1.0], Float64[3.0], Float64[5.0]],   # batch 1: chains 1,2,3
         [Float64[2.0], Float64[4.0], Float64[6.0]]   # batch 2: chains 1,2,3
     ]
     b_current = [zeros(1), zeros(1)]
 
-    NoLimits._saem_update_b_current!(b_current, b_chains, [1, 2], 3)
+    NoLimits._saem_update_b_current!(b_current, b_chains, [1, 2])
 
-    @test b_current[1] ≈ [3.0]   # (1+3+5)/3
-    @test b_current[2] ≈ [4.0]   # (2+4+6)/3
+    @test b_current[1] === b_chains[1][1]
+    @test b_current[2] === b_chains[2][1]
 end
 
 @testset "Multi-chain: _saem_update_b_current! only updates listed batches" begin
@@ -55,10 +58,38 @@ end
     b_current = [Float64[99.0], Float64[99.0]]
 
     # Only update batch 1
-    NoLimits._saem_update_b_current!(b_current, b_chains, [1], 1)
+    NoLimits._saem_update_b_current!(b_current, b_chains, [1])
 
     @test b_current[1] === b_chains[1][1]
     @test b_current[2][1] == 99.0   # unchanged
+end
+
+@testset "Multi-chain: _saem_store_push! stores each chain as its own entry" begin
+    capacity = 4
+    n_batches = 1
+    store = NoLimits._SAEMSampleStore(
+        zeros(Float64, capacity),
+        [[zeros(Float64, 1) for _ in 1:n_batches] for _ in 1:capacity],
+        1, 1, 0, capacity, 1e-10, 0
+    )
+    b_chains = [[Float64[1.0], Float64[5.0]]]   # batch 1: chains 1,2
+
+    NoLimits._saem_store_push!(store, b_chains, 0.5, 2)
+
+    @test store.len == 2
+    @test store.weights[1] ≈ 0.25   # γ / n_chains
+    @test store.weights[2] ≈ 0.25
+    @test store.snaps[1][1] == [1.0]
+    @test store.snaps[2][1] == [5.0]
+
+    # Second push: old entries scale by (1 - γ), new pair gets γ/2 each
+    b_chains2 = [[Float64[2.0], Float64[6.0]]]
+    NoLimits._saem_store_push!(store, b_chains2, 0.5, 2)
+    @test store.len == 4
+    @test store.weights[1] ≈ 0.125
+    @test store.weights[2] ≈ 0.125
+    @test store.weights[3] ≈ 0.25
+    @test store.weights[4] ≈ 0.25
 end
 
 @testset "Multi-chain: SAEMOptions n_chains defaults" begin
@@ -176,4 +207,63 @@ end
         ))
     conv = NoLimits.get_diagnostics(res).convergence
     @test all(n == 1 for n in conv.n_chains_used)
+end
+
+# Deterministic random-intercept dataset with real between-subject spread.
+# 12 subjects → 12 batches < target=50 → auto chains = ceil(50/12) = 5.
+function _mc_variance_dm()
+    model = @Model begin
+        @covariates begin
+            t = Covariate()
+        end
+        @fixedEffects begin
+            a = RealNumber(0.0)
+            ω = RealNumber(1.0, scale = :log)
+            σ = RealNumber(0.5, scale = :log)
+        end
+        @randomEffects begin
+            η = RandomEffect(Normal(0.0, ω); column = :ID)
+        end
+        @formulas begin
+            y ~ Normal(a + η, σ)
+        end
+    end
+    n_id = 12
+    etas = [(-1.1, 1.1)[mod1(i, 2)] * (0.4 + 0.6 * i / n_id) for i in 1:n_id]
+    eps = (-0.3, 0.0, 0.3)
+    df = DataFrame(
+        ID = repeat(1:n_id, inner = 3),
+        t = repeat([0.0, 1.0, 2.0], n_id),
+        y = [etas[i] + eps[j] for i in 1:n_id for j in 1:3]
+    )
+    return DataModel(model, df; primary_id = :ID, time_col = :t)
+end
+
+@testset "Multi-chain: RE variance does not collapse with auto-inflated chains" begin
+    # Regression: the chains' η used to be AVERAGED into b_current before the
+    # variance sufficient statistics were formed. That deflates the second moment
+    # by the within-posterior variance each iteration, so ω decayed geometrically
+    # to the 1e-5 floor whenever effective_n_chains > 1 — independent of the data.
+    dm = _mc_variance_dm()
+    res = fit_model(dm,
+        NoLimits.SAEM(;
+            maxiters = 40, t0 = 20, progress = false,
+            auto_small_n_chains = true, small_n_chain_target = 50
+        ))
+    conv = NoLimits.get_diagnostics(res).convergence
+    @test all(n == 5 for n in conv.n_chains_used)   # ceil(50/12)
+
+    ω̂ = get_params(res; scale = :untransformed).ω
+    # Between-subject sd of the data is ≈ 0.85; a collapse would give ω̂ ≈ 1e-5.
+    @test ω̂ > 0.3
+end
+
+@testset "Multi-chain: closed-form M-step respects user constants" begin
+    # Regression: builtin closed-form updates were merged over the user-supplied
+    # `constants`, silently overwriting them.
+    dm = _mc_variance_dm()
+    res = fit_model(dm,
+        NoLimits.SAEM(; maxiters = 10, t0 = 5, progress = false);
+        constants = (; ω = 0.55))
+    @test get_params(res; scale = :untransformed).ω ≈ 0.55
 end

--- a/test/saem_schedule_tests.jl
+++ b/test/saem_schedule_tests.jl
@@ -150,15 +150,15 @@ end
         [[zeros(Float64, 1) for _ in 1:n_batches] for _ in 1:capacity],
         1, 1, 0, capacity, 1e-10, 0
     )
-    b = [zeros(Float64, 1), zeros(Float64, 1)]
+    b_chains = [[zeros(Float64, 1)], [zeros(Float64, 1)]]   # [batch][chain]
 
     # γ = 0: store stays empty
-    NoLimits._saem_store_push!(store, b, 0.0)
+    NoLimits._saem_store_push!(store, b_chains, 0.0, 1)
     @test store.len == 0
     @test store.next_idx == 1
 
     # γ = 1: store gains one entry
-    NoLimits._saem_store_push!(store, b, 1.0)
+    NoLimits._saem_store_push!(store, b_chains, 1.0, 1)
     @test store.len == 1
     @test store.weights[1] == 1.0
 end


### PR DESCRIPTION
## Bug

With more than one E-step chain, SAEM collapsed every random-effect variance geometrically to the `1e-5` floor — independent of the data, the sampler, the starting values, and the M-step mode. Since `auto_small_n_chains = true` silently raises the chain count whenever there are fewer than `small_n_chain_target` (50) batches, **every small-dataset SAEM fit was affected**.

### Mechanism

`_saem_update_b_current!` averaged the chains' η into a single pseudo-sample (`b_current`), and all statistics consumers (closed-form suffstats, ring buffer, `Q_current`/`Q2_current`, custom `suffstats`) read only that average. The second moment of an average of `C` posterior draws is

```
Ω² · (1 − B(1 − 1/C))      (B = shrinkage fraction)
```

instead of `Ω²`, whose only fixed point is `Ω = 0`. As `Ω → 0`, `B → 1` and the log-SD decay rate approaches `½·ln(1/C)` per iteration (−0.347 for C=2), matching observed trajectories exactly. A single draw satisfies `Var(draw) = (1−B)Ω² + BΩ² = Ω²` — which is why single-chain fits were always unbiased and unaffected.

Empirical isolation (33-subject joint ODE model): default/forced C=2 collapsed bit-for-bit identically to the floor; forced C=1 was stable at Ω ≈ 0.41 ≈ the Laplace estimate (0.45) on the same `DataModel`.

## Fix

Chains are now consumed as **separate draws** everywhere; the η-average no longer exists:

- closed-form sufficient statistics accumulate over all chains (`_saem_builtin_collect_current_stats`)
- the ring buffer stores one entry per chain with weight `γ/n_chains`; capacity scales with the chain count so the SA memory horizon (in iterations) is unchanged (`_saem_store_push!`)
- `Q_current`/`Q2_current` average the log-densities over chains
- custom `suffstats` are evaluated per chain and their statistics averaged (running mean via `_saem_stats_update`)
- the E-step retry check flags a batch if **any** chain's draw is non-finite
- `b_current` is reduced to a display/GLM-support point summary (chain 1's draw)

Also fixed in passing: the builtin closed-form M-step silently overwrote user-supplied `constants` (e.g. `constants = (; Omega = 0.6)` kept updating `Omega` every iteration). Constants now always win over closed-form updates.

## Tests

- New regression: RE variance must not collapse under auto-inflated chains (12 subjects → C=5; asserts `ω̂ > 0.3` where collapse gave `1e-5`)
- New unit test: ring buffer stores one entry per chain with weight `γ/n_chains`, old entries scale by `(1−γ)`
- New regression: closed-form M-step respects user `constants`
- Updated two tests that codified the averaging behavior; `saem_schedule_tests.jl` store calls migrated to the new signature
- `NL_TEST_FILES` runs: `saem_multichain_tests.jl`, `saem_schedule_tests.jl` (105 pass) and `estimation_saem_tests.jl`, `estimation_saem_autodetect_tests.jl`, `saem_mh_kernel_tests.jl`, `saem_sa_anneal_tests.jl`, `saem_var_lb_tests.jl` (398 pass)

Verified on the originally-failing real-data joint model: default settings now keep Ω healthy, and the fit reaches a mode with marginal log-likelihood −382 vs −840 for the mode Laplace and pre-fix SAEM found (checked with `laplace_marginal` and `ghq_marginal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
