### PR TITLE
fix: get_loglikelihood errored on SAEM/MCEM fits (#105)

### DIFF
--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -1877,8 +1877,9 @@ end
 
 Compute the marginal log-likelihood at the estimated parameter values.
 
-For MLE/MAP results, evaluates the population log-likelihood. For Laplace-style
-results, evaluates using the EB modes stored in the result.
+For MLE/MAP results, evaluates the population log-likelihood. For random-effect
+results (Laplace/FOCEI/SAEM/MCEM), evaluates using the EB modes stored in the
+result, recomputing them when the fit was run with `store_eb_modes = false`.
 
 # Keyword Arguments
 - `constants_re::NamedTuple = NamedTuple()`: random effects fixed at given values.
@@ -1897,11 +1898,12 @@ function get_loglikelihood(dm::DataModel,
     if get_result(res) isa FrequentistResult || get_result(res) isa MAPResult
         return loglikelihood(dm, θu, ComponentArray(); ode_args = ode_args,
             ode_kwargs = ode_kwargs, serialization = serialization)
-    elseif get_result(res) isa FrequentistREResult
-        pairing, batch_infos, const_cache = _build_re_batch_infos(dm, constants_re)
-        bstars = get_eb_modes(get_result(res))
-        length(bstars) == length(batch_infos) ||
-            error("Laplace-style EB modes do not match number of batches.")
+    elseif get_result(res) isa FrequentistREResult || get_result(res) isa SAEMResult ||
+           get_result(res) isa MCEMResult
+        # SAEM/MCEM store the same EB modes as Laplace/FOCEI; the shared resolver also
+        # covers unstored modes and SAEM's annealed RE constants.
+        bstars, batch_infos, θu, const_cache, _, _ = _resolve_bstars_for_re(
+            dm, res, constants_re)
         η_vec = _eta_from_eb(dm, batch_infos, bstars, const_cache, θu)
         return loglikelihood(dm, θu, η_vec; ode_args = ode_args,
             ode_kwargs = ode_kwargs, serialization = serialization)

--- a/test/estimation_saem_tests.jl
+++ b/test/estimation_saem_tests.jl
@@ -1593,3 +1593,26 @@ end
         end
     end
 end
+
+# Issue #105: get_loglikelihood errored on SAEM/MCEM results although documented
+# as supported.
+@testset "SAEM/MCEM get_loglikelihood" begin
+    tk = (n_samples = 2, n_adapt = 2, progress = false)
+    for (label, method) in (
+        ("SAEM", NoLimits.SAEM(; sampler = MH(), turing_kwargs = tk, SAEM_FAST...)),
+        ("MCEM", NoLimits.MCEM(; sampler = MH(), turing_kwargs = tk, maxiters = 2)))
+        @testset "$label" begin
+            res = fit_model(_SAEM_DM_S, method)
+            θ = NoLimits.get_params(res; scale = :untransformed)
+            re = NoLimits.get_random_effects(_SAEM_DM_S, res).η
+            ηs = Dict(re.ID .=> re.η_1)
+            manual = sum(logpdf(Normal(θ.a + ηs[id], θ.σ), y)
+            for (id, y) in zip(_SAEM_DF_S.ID, _SAEM_DF_S.y))
+            @test NoLimits.get_loglikelihood(res)≈manual rtol=1e-8
+
+            # EB modes not stored: must recompute rather than throw
+            res2 = fit_model(_SAEM_DM_S, method; store_eb_modes = false)
+            @test isfinite(NoLimits.get_loglikelihood(res2))
+        end
+    end
+end


### PR DESCRIPTION
Closes #105.

## Problem
`get_loglikelihood(res)` on a SAEM or MCEM fit threw
`loglikelihood accessor not supported for this method.`, although the docstring
and CLAUDE.md list SAEM/MCEM among the supported methods.

## Cause
`get_loglikelihood` hand-rolled its own EB-mode lookup and matched only
`FrequentistREResult` (Laplace/FOCEI); the SAEM/MCEM result kinds fell through
to the error, even though they store the same `eb_modes`.

## Fix
Route the random-effect branch through `_resolve_bstars_for_re` - the shared
resolver that `cv.jl`, `plotting.jl` and `plotting_residuals.jl` already use for
exactly this bstars-to-eta step. It covers Laplace/FOCEI/SAEM/MCEM, recomputes
the modes when the fit ran with `store_eb_modes = false`, and applies SAEM's
annealed RE constants.

Side effect: the old branch called `length(bstars)` unconditionally, so a
Laplace fit made with `store_eb_modes = false` crashed with a `MethodError`.
That path now works too.

GHQuadrature keeps its own branch - it re-evaluates the sparse-grid marginal
likelihood, which is a different quantity from the plug-in likelihood.

## Test
`test/estimation_saem_tests.jl`: for SAEM and MCEM, `get_loglikelihood(res)` is
checked against the hand-computed `sum(logpdf(Normal(a + eta_id, sigma), y))`
built from the returned RE table, plus a `store_eb_modes = false` case that must
recompute rather than throw.

Green locally: `estimation_saem_tests.jl`, `estimation_mcem_tests.jl`,
`estimation_laplace_tests.jl`, `estimation_pooled_tests.jl`,
`serialization_tests.jl`. JuliaFormatter v1 no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)