### PR TITLE
fix: Vector{Distribution} priors crashed MCMC/VI instead of sampling (#111)

### DIFF
--- a/src/estimation/mcmc_turing.jl
+++ b/src/estimation/mcmc_turing.jl
@@ -143,6 +143,12 @@ end
     end
 end
 
+# Turing's `~` takes a single distribution, so a per-element prior vector (accepted on
+# NN/SoftTree/NPF blocks) has to become one product distribution -- the same conversion
+# `_logprior_eval` already does on the MAP path.
+_turing_prior(prior) = prior
+_turing_prior(prior::AbstractVector{<:Distribution}) = product_distribution(prior)
+
 # Shared θ-reconstruction metaprogramming for both MCMC model builders: sample the
 # free fixed effects from their priors, merge with the constants, and rebuild the
 # full fixed-effect ComponentArray in declaration order.
@@ -439,7 +445,8 @@ function _fit_model(dm::DataModel, method::MCMC, args...;
 
     free_names_t = Tuple(free_names)
     θ_template = get_θ0_untransformed(fe)
-    priors_nt = NamedTuple{free_names_t}(Tuple(getfield(priors, n) for n in free_names))
+    priors_nt = NamedTuple{free_names_t}(Tuple(_turing_prior(getfield(priors, n))
+    for n in free_names))
     model = nothing
     if isempty(re_names)
         fname = _build_turing_model(fixed_names, free_names)

--- a/src/estimation/vi_turing.jl
+++ b/src/estimation/vi_turing.jl
@@ -237,7 +237,8 @@ function _fit_model(dm::DataModel, method::VI, args...;
         serialization = serialization, force_saveat = true)
 
     free_names_t = Tuple(free_names)
-    priors_nt = NamedTuple{free_names_t}(Tuple(getfield(priors, n) for n in free_names))
+    priors_nt = NamedTuple{free_names_t}(Tuple(_turing_prior(getfield(priors, n))
+    for n in free_names))
     fname = _build_turing_model(fixed_names, free_names)
     model_fn = Base.invokelatest(getfield, @__MODULE__, fname)
     model = Base.invokelatest(

--- a/test/estimation_mcmc_tests.jl
+++ b/test/estimation_mcmc_tests.jl
@@ -199,6 +199,40 @@ end
     @test res_map isa FitResult
 end
 
+@testset "MCMC/VI accept Vector{Distribution} priors on flat blocks" begin
+    # A per-element prior vector is valid on NN/SoftTree/NPF blocks but is not a
+    # distribution Turing's `~` accepts; it must be turned into a product distribution.
+    st = SoftTreeParameters(1, 2; function_name = :ST1)
+    st_prior = fill(Normal(0.0, 1.0), length(st.value))
+
+    model = @Model begin
+        @fixedEffects begin
+            Γ = SoftTreeParameters(
+                1, 2; function_name = :ST1, calculate_se = false, prior = st_prior)
+            σ = RealNumber(0.5, scale = :log, prior = LogNormal(0.0, 0.5))
+        end
+
+        @covariates begin
+            t = Covariate()
+        end
+
+        @formulas begin
+            y ~ Normal(ST1([t], Γ)[1], σ)
+        end
+    end
+
+    df = DataFrame(ID = [1, 1, 2, 2], t = [0.0, 1.0, 0.0, 1.0],
+        y = [0.1, 0.3, 0.05, 0.35])
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+
+    res = fit_model(dm,
+        NoLimits.MCMC(; turing_kwargs = (n_samples = 2, n_adapt = 2, progress = false)))
+    @test NoLimits.get_chain(res) isa MCMCChains.Chains
+
+    res_vi = fit_model(dm, NoLimits.VI(; turing_kwargs = (max_iter = 2,)))
+    @test NoLimits.get_variational_posterior(res_vi) !== nothing
+end
+
 @testset "MCMC ODE with NN/SoftTree/Spline (fixed blocks)" begin
     chain = Chain(Dense(1, 3, tanh), Dense(3, 1))
     knots = collect(range(0.0, 1.0; length = 4))


### PR DESCRIPTION
Closes #111.

## Problem

A per-element prior vector such as `fill(Normal(0, 1), n)` passes model-build validation on the flat blocks (`NNParameters`, `SoftTreeParameters`, `NPFParameter`) and works for MLE/MAP, where `_logprior_eval` wraps it in a `product_distribution`. The Turing entry points passed the raw `Vector{<:Distribution}` straight to `~`, so MCMC and VI crashed:

```
MethodError: no method matching tilde_assume!!(..., ::Vector{Normal{Float64}}, ...)
```

## Fix

`_turing_prior` applies the same `product_distribution` conversion where `priors_nt` is built, in both `mcmc_turing.jl` and `vi_turing.jl`. Non-vector priors pass through unchanged, so existing models (including `filldist`/`MvNormal` priors) are untouched.

## Test

`test/estimation_mcmc_tests.jl`: a soft-tree model with a `Vector{Normal}` prior now fits under both MCMC and VI. Verified the failure first on `main` with the same model.

`NL_TEST_FILES="estimation_mcmc_tests.jl,estimation_vi_tests.jl"` → 51/51 pass; JuliaFormatter v1 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)