### PR TITLE
fix: Multistart default start sampling respected declared bounds (#110)

### DIFF
--- a/docs/src/estimation/multistart.md
+++ b/docs/src/estimation/multistart.md
@@ -101,7 +101,7 @@ Starting points are constructed as follows:
   - the fixed-effect prior, if one is defined;
   - otherwise, the parameter retains its default value across all starts.
 
-All sampled values are validated against the natural-scale bounds of each parameter. If any sampled value violates its bounds, an error is raised before fitting begins.
+Sampling distributions are bounded to the natural-scale bounds of each parameter before drawing, whether they come from `dists` or from a prior: a univariate distribution that puts mass outside the bounds is truncated to them, and a multivariate one is replaced by its per-coordinate truncated marginals (dropping the joint correlation). Both cases emit a warning naming the parameter and its bounds. If a distribution has no mass at all inside the bounds, an error is raised before fitting begins, as is any sampled value that still violates its bounds.
 
 ## Distribution Inputs
 

--- a/src/estimation/Multistart.jl
+++ b/src/estimation/Multistart.jl
@@ -28,7 +28,9 @@ fully optimized.
 
 # Keyword Arguments
 - `dists::NamedTuple = NamedTuple()`: per-parameter sampling distributions, keyed by
-  fixed-effect name. Parameters without an entry use their prior, if available.
+  fixed-effect name. Parameters without an entry use their prior, if available. Both are
+  bounded to the parameter's declared natural-scale bounds before sampling (truncation,
+  or per-coordinate truncated marginals for a multivariate distribution), with a warning.
 - `n_draws_requested::Int = 100`: number of candidate starting points to sample.
 - `n_draws_used::Int = 50`: number of candidates to fully optimize after screening.
 - `sampling::Symbol = :random`: sampling strategy for starting points: `:random` or `:lhs`
@@ -232,27 +234,60 @@ end
 
 _bound_at(b, idx) = b isa Number ? b : b[idx]
 
-function _truncate_to_bounds(d, lo, hi)
+function _mass_outside(d, lo, hi)
+    below = isfinite(lo) ? cdf(d, lo) : 0.0
+    above = isfinite(hi) ? ccdf(d, hi) : 0.0
+    return below + above
+end
+
+function _truncate_to_bounds(name::Symbol, d, lo, hi)
     (d isa UnivariateDistribution && (isfinite(lo) || isfinite(hi))) || return d
+    outside = _mass_outside(d, lo, hi)
+    outside <= 1e-10 && return d
+    outside >= 1.0 &&
+        error("Multistart sampling for $(name): the sampling distribution $(d) has no " *
+              "probability mass inside the declared bounds [$(lo), $(hi)]. Pass a `dists` " *
+              "entry that overlaps the bounds.")
     return truncated(d; lower = isfinite(lo) ? lo : nothing,
         upper = isfinite(hi) ? hi : nothing)
 end
 
-# Keep prior-derived draws inside the parameter's declared range (a :log coordinate
-# must stay positive). A multivariate prior degrades to per-coordinate truncated
-# marginals; correlation in the start points is not worth preserving here.
-function _bound_default_dist(p, value, lo, hi)
-    p isa AbstractArray && return [_truncate_to_bounds(p[j], _bound_at(lo, j),
-                _bound_at(hi, j)) for j in eachindex(p)]
-    value isa Number && return _truncate_to_bounds(p, lo, hi)
+function _warn_bounded(warn::Bool, name::Symbol, source::AbstractString, lo, hi,
+        marginalised::Bool)
+    warn || return nothing
+    extra = marginalised ?
+            " Draws are taken from per-coordinate truncated marginals, so the joint correlation is dropped." :
+            ""
+    @warn "Multistart: the $(source) sampling distribution for $(name) puts mass outside the declared bounds; draws are truncated to the bounds.$(extra)" parameter=name lower=lo upper=hi
+end
+
+# Keep draws inside the parameter's declared range (a :log coordinate must stay
+# positive). A multivariate distribution degrades to per-coordinate truncated marginals
+# only when its bounds actually bind; otherwise the joint distribution is kept.
+function _bound_dist(name::Symbol, p, value, lo, hi, source::AbstractString, warn::Bool)
+    if p isa AbstractArray
+        out = [_truncate_to_bounds(name, p[j], _bound_at(lo, j), _bound_at(hi, j))
+               for j in eachindex(p)]
+        any(j -> out[j] !== p[j], eachindex(p)) &&
+            _warn_bounded(warn, name, source, lo, hi, false)
+        return out
+    end
+    if value isa Number
+        out = _truncate_to_bounds(name, p, lo, hi)
+        out === p || _warn_bounded(warn, name, source, lo, hi, false)
+        return out
+    end
     (value isa AbstractVector && (any(isfinite, lo) || any(isfinite, hi))) || return p
     marg = [_laplace_marginal_mvnormal(p, j) for j in eachindex(value)]
     any(isnothing, marg) && return p
-    return [_truncate_to_bounds(marg[j], _bound_at(lo, j), _bound_at(hi, j))
-            for j in eachindex(value)]
+    out = [_truncate_to_bounds(name, marg[j], _bound_at(lo, j), _bound_at(hi, j))
+           for j in eachindex(value)]
+    any(j -> out[j] !== marg[j], eachindex(out)) || return p
+    _warn_bounded(warn, name, source, lo, hi, true)
+    return out
 end
 
-function _collect_param_dists(dm::DataModel, ms::Multistart)
+function _collect_param_dists(dm::DataModel, ms::Multistart; warn::Bool = true)
     fe = get_fixed(get_model(dm))
     priors = get_priors(fe)
     names = get_names(fe)
@@ -260,17 +295,14 @@ function _collect_param_dists(dm::DataModel, ms::Multistart)
     lower, upper = get_bounds_untransformed(fe)
     pairs = Pair{Symbol, Any}[]
     for name in names
-        if haskey(ms.dists, name)
-            # User-supplied dists are used verbatim; an out-of-bounds draw stays an error.
-            push!(pairs, name => getfield(ms.dists, name))
-        else
-            p = hasproperty(priors, name) ? getfield(priors, name) : Priorless()
-            if !(p isa Priorless)
-                push!(pairs,
-                    name => _bound_default_dist(p, getproperty(θ0_u, name),
-                        getproperty(lower, name), getproperty(upper, name)))
-            end
-        end
+        user = haskey(ms.dists, name)
+        p = user ? getfield(ms.dists, name) :
+            (hasproperty(priors, name) ? getfield(priors, name) : Priorless())
+        p isa Priorless && continue
+        source = user ? "supplied" : "prior-derived"
+        push!(pairs,
+            name => _bound_dist(name, p, getproperty(θ0_u, name), getproperty(lower, name),
+                getproperty(upper, name), source, warn))
     end
     return NamedTuple(pairs)
 end
@@ -549,7 +581,7 @@ function fit_model(ms::Multistart, dm::DataModel, method::FittingMethod, args...
     all_starts = _multistart_initials(dm, ms)
     n_req = length(all_starts)
     n_used = min(ms.n_draws_used, n_req)
-    varied = collect(keys(_collect_param_dists(dm, ms)))
+    varied = collect(keys(_collect_param_dists(dm, ms; warn = false)))
     varied_str = isempty(varied) ? "none" : join(string.(varied), ", ")
 
     if n_req > n_used

--- a/src/estimation/Multistart.jl
+++ b/src/estimation/Multistart.jl
@@ -230,18 +230,45 @@ function _sample_param(
     return [_fix_matrix(rand(rng, dist)) for _ in 1:n]
 end
 
+_bound_at(b, idx) = b isa Number ? b : b[idx]
+
+function _truncate_to_bounds(d, lo, hi)
+    (d isa UnivariateDistribution && (isfinite(lo) || isfinite(hi))) || return d
+    return truncated(d; lower = isfinite(lo) ? lo : nothing,
+        upper = isfinite(hi) ? hi : nothing)
+end
+
+# Keep prior-derived draws inside the parameter's declared range (a :log coordinate
+# must stay positive). A multivariate prior degrades to per-coordinate truncated
+# marginals; correlation in the start points is not worth preserving here.
+function _bound_default_dist(p, value, lo, hi)
+    p isa AbstractArray && return [_truncate_to_bounds(p[j], _bound_at(lo, j),
+                _bound_at(hi, j)) for j in eachindex(p)]
+    value isa Number && return _truncate_to_bounds(p, lo, hi)
+    (value isa AbstractVector && (any(isfinite, lo) || any(isfinite, hi))) || return p
+    marg = [_laplace_marginal_mvnormal(p, j) for j in eachindex(value)]
+    any(isnothing, marg) && return p
+    return [_truncate_to_bounds(marg[j], _bound_at(lo, j), _bound_at(hi, j))
+            for j in eachindex(value)]
+end
+
 function _collect_param_dists(dm::DataModel, ms::Multistart)
     fe = get_fixed(get_model(dm))
     priors = get_priors(fe)
     names = get_names(fe)
+    θ0_u = get_θ0_untransformed(fe)
+    lower, upper = get_bounds_untransformed(fe)
     pairs = Pair{Symbol, Any}[]
     for name in names
         if haskey(ms.dists, name)
+            # User-supplied dists are used verbatim; an out-of-bounds draw stays an error.
             push!(pairs, name => getfield(ms.dists, name))
         else
             p = hasproperty(priors, name) ? getfield(priors, name) : Priorless()
             if !(p isa Priorless)
-                push!(pairs, name => p)
+                push!(pairs,
+                    name => _bound_default_dist(p, getproperty(θ0_u, name),
+                        getproperty(lower, name), getproperty(upper, name)))
             end
         end
     end

--- a/test/estimation_multistart_tests.jl
+++ b/test/estimation_multistart_tests.jl
@@ -55,6 +55,37 @@ end
         ms, dm, NoLimits.MLE(; optim_kwargs = (maxiters = 2,)))
 end
 
+@testset "Multistart default sampling respects bounds" begin
+    model = @Model begin
+        @covariates begin
+            t = Covariate()
+        end
+
+        @fixedEffects begin
+            β = RealVector([0.5, 0.5]; scale = [:identity, :log],
+                lower = [-Inf, 1e-12], prior = MvNormal(zeros(2), I))
+            σ = RealNumber(0.5; scale = :log, prior = Normal(0.0, 1.0))
+        end
+
+        @formulas begin
+            y ~ Normal(β[1] + β[2] * t, σ)
+        end
+    end
+    df = DataFrame(
+        ID = [:A, :A, :B, :B],
+        t = [0.0, 1.0, 0.0, 1.0],
+        y = [0.1, 0.2, 0.0, -0.1]
+    )
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+    ms = NoLimits.Multistart(n_draws_requested = 8, n_draws_used = 8, progress = false)
+    starts = NoLimits._multistart_initials(dm, ms)
+    @test length(starts) == 8
+    @test all(s -> s.β[2] > 0 && s.σ > 0, starts)
+    res = fit_model(ms, dm, NoLimits.MLE(; optim_kwargs = (maxiters = 2,)))
+    @test length(NoLimits.get_multistart_results(res)) +
+          length(NoLimits.get_multistart_failed_results(res)) == 8
+end
+
 @testset "Multistart MAP" begin
     ms = NoLimits.Multistart(n_draws_requested = 4, n_draws_used = 3)
     res = fit_model(ms, fx_nore_prior_dm(), NoLimits.MAP(; optim_kwargs = (maxiters = 2,)))

--- a/test/estimation_multistart_tests.jl
+++ b/test/estimation_multistart_tests.jl
@@ -29,6 +29,29 @@ end
     @test all(s -> s.σ == starts[1].σ, starts) # σ not sampled, stays fixed
 end
 
+@testset "Multistart supplied dists are truncated to bounds" begin
+    model = @Model begin
+        @covariates begin
+            t = Covariate()
+        end
+
+        @fixedEffects begin
+            a = RealNumber(0.2; lower = -1.0, upper = 1.0, scale = :identity)
+        end
+
+        @formulas begin
+            y ~ Normal(a, 1.0)
+        end
+    end
+    df = DataFrame(ID = [:A, :A], t = [0.0, 1.0], y = [0.1, 0.2])
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+    ms = NoLimits.Multistart(
+        dists = (; a = Normal(0.8, 1.0)), n_draws_requested = 6, n_draws_used = 6)
+    starts = @test_logs (:warn, r"supplied sampling distribution for a") match_mode=:any NoLimits._multistart_initials(
+        dm, ms)
+    @test all(s -> -1.0 <= s.a <= 1.0, starts)
+end
+
 @testset "Multistart bounds violation" begin
     model = @Model begin
         @covariates begin
@@ -78,7 +101,8 @@ end
     )
     dm = DataModel(model, df; primary_id = :ID, time_col = :t)
     ms = NoLimits.Multistart(n_draws_requested = 8, n_draws_used = 8, progress = false)
-    starts = NoLimits._multistart_initials(dm, ms)
+    starts = @test_logs (:warn, r"prior-derived sampling distribution for β") match_mode=:any NoLimits._multistart_initials(
+        dm, ms)
     @test length(starts) == 8
     @test all(s -> s.β[2] > 0 && s.σ > 0, starts)
     res = fit_model(ms, dm, NoLimits.MLE(; optim_kwargs = (maxiters = 2,)))


### PR DESCRIPTION
Closes #110.

`Multistart` builds its sampling distributions from the fixed-effect priors (or from user-supplied `dists`) and then hard-errors when a draw lands outside the parameter's declared bounds - so a `:log` coordinate with an `MvNormal` prior (`β = RealVector(...; scale = [:identity, :log], lower = [-Inf, 1e-12], prior = MvNormal(...))`) makes the default sampler fail on its own draws with "Use a truncated distribution for sampling".

Fix, in `_collect_param_dists` and applied identically to prior-derived and user-supplied distributions:

- a univariate distribution with mass outside the declared bounds is `truncated` to them;
- a multivariate one is replaced by its per-coordinate truncated marginals (reusing `_laplace_marginal_mvnormal`, already the LHS path), and only when the bounds actually bind - otherwise the joint distribution is kept, so correlated starts are unchanged;
- a distribution whose mass lies entirely outside the bounds now errors informatively (name, distribution, bounds) instead of reporting a bounds violation after the draw;
- every truncation warns once per parameter, naming the source (prior-derived / supplied), the parameter, and its bounds. The `varied` bookkeeping call re-collects with `warn = false` so the warning appears once per fit.

The post-draw `_check_bounds` guard stays as the backstop.

Tests: mixed-scale `RealVector` + log-scale scalar with priors under a default `Multistart` (fails on `main` with the exact error from the issue) and a supplied out-of-bounds `dists` entry; both assert the warning and that all starts are in-bounds. The existing wildly-out-of-bounds `dists` test still errors, now via the informative message. Docs and the `dists` docstring updated.

`NL_TEST_FILES="estimation_multistart_tests.jl" Pkg.test()` passes (40/40); formatted with JuliaFormatter v1/sciml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)