### PR TITLE
fix: Turing/MCMC lacked the throwing-RE-prior guard (#108)

### DIFF
--- a/src/estimation/mcmc_turing.jl
+++ b/src/estimation/mcmc_turing.jl
@@ -196,6 +196,22 @@ function _build_turing_model(fixed_names::Vector{Symbol}, free_names::Vector{Sym
     return fname
 end
 
+# Turing's counterpart of the frequentist RE-prior guard (`_re_logpdf_batch`): a proposal for
+# which the RE distribution constructor throws — `sqrt` of a negative variance, a non-PD Ω —
+# must be rejected, not kill the sampler. Returns `nothing` so the caller scores the draw -Inf.
+function _mcmc_re_dist(dists_builder, θ_re, const_cov, model_funs, helpers, re::Symbol)
+    try
+        return getproperty(dists_builder(θ_re, const_cov, model_funs, helpers), re)
+    catch err
+        _is_numeric_error(err) || rethrow(err)
+        if !Threads.atomic_cas!(_WARNED_NUMERIC_ERROR, false, true)
+            @warn "A numeric error ($(nameof(typeof(err)))) was raised while building the " *
+                  "random-effect distribution; rejecting this proposal. Warned once per fit."
+        end
+        return nothing
+    end
+end
+
 # Evaluates log p(η_const | θ) for all constant RE levels passed via const_re_info.
 # const_re_info: NamedTuple mapping RE name → (vals::Vector, reps::Vector{Int})
 function _mcmc_const_re_prior(dm::DataModel, θ_re::ComponentArray, const_re_info,
@@ -206,9 +222,9 @@ function _mcmc_const_re_prior(dm::DataModel, θ_re::ComponentArray, const_re_inf
     for (re, info) in Base.pairs(const_re_info)
         isempty(info.vals) && continue
         for (val, rep) in zip(info.vals, info.reps)
-            dists = dists_builder(
-                θ_re, get_const_cov(get_individuals(dm)[rep]), model_funs, helpers)
-            dist = getfield(dists, re)
+            dist = _mcmc_re_dist(dists_builder,
+                θ_re, get_const_cov(get_individuals(dm)[rep]), model_funs, helpers, re)
+            dist === nothing && return convert(T, -Inf)
             v = val isa AbstractVector ? T.(val) : T(val)
             lp = logpdf(dist, v)
             isfinite(lp) || return T(-Inf)
@@ -241,22 +257,34 @@ function _build_turing_model_re(
         reps_get = :(getproperty($meta_sym, :reps))
         is_scalar = :(getproperty($meta_sym, :is_scalar))
         dim = :(getproperty($meta_sym, :dim))
+        # On a rejected proposal the variable still has to be sampled (a skipped `~` leaves it
+        # out of the VarInfo), so it draws from a placeholder and `re_reject` scores -Inf.
         scalar_block = quote
             local $vals_sym = Vector{T}(undef, length($levels_sym))
             for j in eachindex($levels_sym)
                 const_cov = const_covs[$reps_sym[j]]
-                dists = dists_builder(θ_re, const_cov, model_funs, helpers)
-                dist = getproperty(dists, $re_q)
-                $vals_sym[j] ~ dist
+                dist = _mcmc_re_dist(
+                    dists_builder, θ_re, const_cov, model_funs, helpers, $re_q)
+                if dist === nothing
+                    re_reject = true
+                    $vals_sym[j] ~ Normal(zero(T), one(T))
+                else
+                    $vals_sym[j] ~ dist
+                end
             end
         end
         vector_block = quote
             local $vals_sym = Vector{Vector{T}}(undef, length($levels_sym))
             for j in eachindex($levels_sym)
                 const_cov = const_covs[$reps_sym[j]]
-                dists = dists_builder(θ_re, const_cov, model_funs, helpers)
-                dist = getproperty(dists, $re_q)
-                $vals_sym[j] ~ dist
+                dist = _mcmc_re_dist(
+                    dists_builder, θ_re, const_cov, model_funs, helpers, $re_q)
+                if dist === nothing
+                    re_reject = true
+                    $vals_sym[j] ~ MvNormal(zeros(T, $dim), Diagonal(ones(T, $dim)))
+                else
+                    $vals_sym[j] ~ dist
+                end
             end
         end
         push!(sample_blocks.args, :(local $meta_sym = $meta_get))
@@ -283,8 +311,13 @@ function _build_turing_model_re(
             dists_builder = create_random_effect_distribution(get_random(get_model(dm)))
             model_funs = get_model_funs(get_model(dm))
             helpers = get_helper_funs(get_model(dm))
+            re_reject = false
 
             $sample_blocks
+            if re_reject
+                Turing.@addlogprob! -Inf
+                return nothing
+            end
             Turing.@addlogprob! _mcmc_const_re_prior(
                 dm, θ_re, const_re_info, model_funs, helpers)
             re_samples = $re_samples_expr

--- a/test/estimation_mcmc_re_tests.jl
+++ b/test/estimation_mcmc_re_tests.jl
@@ -435,3 +435,51 @@ end
     @test res isa FitResult
     @test NoLimits.get_chain(res) isa MCMCChains.Chains
 end
+
+# Turing sibling of the frequentist RE-prior guard (#96): a proposal whose RE distribution
+# constructor throws must be rejected, not kill the sampler (#108).
+@testset "MCMC RE prior that throws is rejected" begin
+    model = @Model begin
+        @covariates begin
+            t = Covariate()
+        end
+
+        @fixedEffects begin
+            a = RealNumber(1.0, prior = Normal(0.0, 1.0))
+            σ = RealNumber(0.5, scale = :log, prior = LogNormal(0.0, 0.5))
+        end
+
+        @randomEffects begin
+            # sqrt(a) throws as soon as the sampler proposes a negative `a`
+            η = RandomEffect(Normal(0.0, sqrt(a)); column = :ID)
+        end
+
+        @formulas begin
+            y ~ Normal(a + η, σ)
+        end
+    end
+
+    dm = DataModel(model,
+        DataFrame(ID = [:A, :A, :B, :B], t = [0.0, 1.0, 0.0, 1.0],
+            y = [0.1, 0.2, 0.0, -0.1]);
+        primary_id = :ID, time_col = :t)
+
+    m = NoLimits.get_model(dm)
+    builder = NoLimits.create_random_effect_distribution(NoLimits.get_random(m))
+    θ = get_θ0_untransformed(NoLimits.get_fixed(m))
+    cc = NoLimits.get_const_cov(NoLimits.get_individuals(dm)[1])
+    mf = NoLimits.get_model_funs(m)
+    hp = NoLimits.get_helper_funs(m)
+    @test builder !== nothing
+    @test NoLimits._mcmc_re_dist(builder, θ, cc, mf, hp, :η) isa Normal
+    θ_bad = deepcopy(θ)
+    θ_bad.a = -1.0
+    @test NoLimits._mcmc_re_dist(builder, θ_bad, cc, mf, hp, :η) === nothing
+
+    res = fit_model(dm,
+        NoLimits.MCMC(; sampler = MH(),
+            turing_kwargs = (n_samples = 20, n_adapt = 5, progress = false));
+        rng = MersenneTwister(1), theta_0_untransformed = θ)
+    @test res isa FitResult
+    @test NoLimits.get_chain(res) isa MCMCChains.Chains
+end


### PR DESCRIPTION
## Root cause

PR #96 taught the frequentist paths to score a proposal `-Inf` when the random-effect
distribution constructor throws (`_re_logpdf_batch` wraps the build in
`_is_numeric_error`). The Turing path builds the very same distributions itself - once per
free RE level inside the generated `@model` body, and once more in `_mcmc_const_re_prior`
for constant levels - with no such wrapper. So `Normal(m, sqrt(v0 - v1))` with `v0 < v1`
raised an uncaught `DomainError` and an `MvNormal` RE with a non-PD `RealPSDMatrix` Omega
raised an uncaught `PosDefException`, both killing the sampler instead of rejecting the
proposal.

## Fix

`_mcmc_re_dist(dists_builder, theta_re, const_cov, model_funs, helpers, re)` is the Turing
sibling of the #96 guard: same `_is_numeric_error` whitelist, same warn-once
(`_WARNED_NUMERIC_ERROR`), returning `nothing` instead of throwing. Both build sites route
through it:

- generated RE model: on `nothing` the level is still sampled - from a placeholder
  `Normal(0, 1)` / `MvNormal(0, I)` of the right shape, because a skipped `~` would leave
  the variable out of the VarInfo and break the next evaluation - and `re_reject` makes the
  model `@addlogprob! -Inf` and return early, so the draw is rejected and sampling
  continues.
- `_mcmc_const_re_prior`: returns `-Inf` for that proposal.

No VI change: `VI` errors out for models with random effects (`_fit_model(::VI)` checks
`get_re_names`), so it never builds an RE distribution; its only other exposure, the
observation likelihood, is already guarded by `_loglikelihood_individual`. Non-RE MCMC is
covered by that same existing guard.

## Verification

- New testset `MCMC RE prior that throws is rejected` in `test/estimation_mcmc_re_tests.jl`
  (mirror of #96's frequentist test): an RE prior `Normal(0, sqrt(a))` under `MH()` with a
  `Normal(0, 1)` prior on `a`, so negative `a` is proposed within the run. Asserts
  `_mcmc_re_dist` returns the distribution at a good theta and `nothing` at a bad one, and
  that `fit_model` completes and returns a chain.
- On this branch: `NL_TEST_FILES="estimation_mcmc_re_tests.jl" julia --project -e 'using
  Pkg; Pkg.test()'` -> 39/39 pass, with the warn-once guard firing as designed.
- With `src/estimation/mcmc_turing.jl` reverted, the same test file dies with exactly the
  issue's error: `DomainError with -0.759...: sqrt was called with a negative real
  argument`.
- Formatted with JuliaFormatter v1 (sciml) in a pinned scratch env; no unrelated files
  touched.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
