### PR TITLE
fix: informative DataModel error for time offsets below the dynamic covariate window (#117)

### DIFF
--- a/src/data_model/DataModel.jl
+++ b/src/data_model/DataModel.jl
@@ -1395,6 +1395,11 @@ function DataModel(model,
     if saveat_mode != :dense && requires_dense
         error("Formulas include non-constant time offsets for DE states/signals. Use saveat_mode=:dense or rewrite formulas to use constant offsets.")
     end
+    # Dynamic covariates used inside the DE are interpolated over an individual's row
+    # times only, so the integration span must not start below that support.
+    de_fun_syms = model.de.de === nothing ? Symbol[] : get_de_meta(model.de.de).fun_syms
+    de_dyn = sort!(collect(intersect(Set(cov.dynamic), Set(de_fun_syms))))
+    off_min = isempty(time_offsets) ? 0.0 : minimum(time_offsets)
     keys_sorted, groups = _group_indices(df, primary_id)
     individuals = Vector{Individual}(undef, length(groups))
     obs_groups = Vector{Vector{Int}}(undef, length(groups))
@@ -1435,6 +1440,9 @@ function DataModel(model,
                 bad_tmin[id_val] = tmin
             end
             tspan = (t0 === nothing ? tmin : min(oftype(tmin, t0), tmin), tmax)
+        end
+        if !isempty(de_dyn) && tspan[1] < minimum(tvals)
+            error("Formulas request times earlier than the dynamic covariate support for individual $(keys_sorted[i]): the integration span starts at t=$(tspan[1]) (smallest formula time offset $(off_min)), but the dynamic covariate(s) $(join(de_dyn, ", ")) used in @DifferentialEquation are only supported on [$(minimum(tvals)), $(maximum(tvals))] and cannot be extrapolated. Add covariate rows covering t=$(tspan[1]), or change the formula offset (or t0) so that the integration starts at or after $(minimum(tvals)).")
         end
         re_groups = _build_re_groups(model, df, rows)
         cb_times = callbacks !== nothing ? callbacks.all_times : Float64[]

--- a/test/data_model_tests.jl
+++ b/test/data_model_tests.jl
@@ -1307,6 +1307,57 @@ end
     @test_throws ErrorException DataModel(model_saveat, df; primary_id = :ID, time_col = :t)
 end
 
+@testset "DataModel errors on offsets below dynamic covariate support" begin
+    model = @Model begin
+        @fixedEffects begin
+            a = RealNumber(0.1)
+            σ = RealNumber(0.5)
+        end
+
+        @covariates begin
+            t = Covariate()
+            w1 = DynamicCovariate(; interpolation = LinearInterpolation)
+        end
+
+        @randomEffects begin
+            η = RandomEffect(Normal(0.0, 1.0); column = :ID)
+        end
+
+        @DifferentialEquation begin
+            D(x1) ~ -a * x1 + w1(t)
+        end
+
+        @initialDE begin
+            x1 = 1.0
+        end
+
+        @formulas begin
+            y ~ Normal(x1(t - 0.5), σ)
+        end
+    end
+
+    # rows start at t = 0.5, so t_first + offset = 0.0 clears the negative-time check,
+    # but the interpolants have no support below 0.5.
+    df = DataFrame(
+        ID = [1, 1, 1],
+        t = [0.5, 1.0, 2.0],
+        w1 = [1.0, 1.2, 1.4],
+        y = [1.0, 1.1, 1.2]
+    )
+
+    model_saveat = set_solver_config(model; saveat_mode = :saveat)
+    err = try
+        DataModel(model_saveat, df; primary_id = :ID, time_col = :t)
+        nothing
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("dynamic covariate support", err.msg)
+    @test occursin("-0.5", err.msg)
+    @test occursin("[0.5, 2.0]", err.msg)
+end
+
 @testset "DataModel pairing creates multiple batches" begin
     model = @Model begin
         @fixedEffects begin


### PR DESCRIPTION
Closes #117

## Root cause

A constant negative formula time offset (`x1(t - 0.5)`) extends every individual's integration span 0.5 below its first row. Dynamic covariates are interpolated over that individual's row times only (`_build_dyn_cov` builds the interpolants from `df[rows, time_col]`), so a dynamic covariate used inside `@DifferentialEquation` gets evaluated below `first(A.t)` on the very first solver step and DataInterpolations throws `ExtrapolationError` (`ExtrapolationType.None`) deep inside the likelihood, with no mention of the offset or the covariate window.

The existing construction-time check only catches `t_first + offset < 0` (integration before the initial conditions at t=0). The reported case slips through it: rows start at t = 0.5, so `0.5 - 0.5 = 0.0` is non-negative, yet the interpolants have no support below 0.5.

## Fix

`src/data_model/DataModel.jl`, in the same per-individual loop that builds the tspan: once `tspan` is known, refuse construction when it starts below the individual's first row time and the DE actually uses dynamic covariates. The message names the offending individual, the integration start, the smallest formula offset, the dynamic covariates involved, and their support window - matching the style of the existing "Formulas request times earlier than the first observation" refusal.

The condition is on `tspan[1]`, not on the offset alone, so it also covers the identical failure produced by `t0` alone (default `t0 = 0.0` with data starting later), which fails at fit time today in exactly the same way. It is gated on dynamic covariates that appear in `@DifferentialEquation` (`intersect(cov.dynamic, get_de_meta(de).fun_syms)`), so models where the interpolants are only touched at observation times are unaffected.

```
Formulas request times earlier than the dynamic covariate support for individual 1:
the integration span starts at t=0.0 (smallest formula time offset -0.5), but the
dynamic covariate(s) temp used in @DifferentialEquation are only supported on
[0.5, 4.0] and cannot be extrapolated. Add covariate rows covering t=0.0, or change
the formula offset (or t0) so that the integration starts at or after 0.5.
```

## Verification

- Reproduced the issue on `main` with a minimal M12-shaped model (dynamic covariate in the DE, rows from t = 0.5, `y ~ Normal(x1(t - 0.5), sigma)`): `DataModel` constructed fine with `tspan[1] = 0.0`, then `fit_model(dm, Laplace())` died with the DataInterpolations `ExtrapolationError`. With the fix, construction refuses with the message above.
- New regression test `DataModel errors on offsets below dynamic covariate support` in `test/data_model_tests.jl` asserts the error type and that the message carries the offset and the window.
- `NL_TEST_FILES="data_model_tests.jl" julia --project -e 'using Pkg; Pkg.test()'` - 97/97 pass.
- No false positives in the other dynamic-covariate suites: `data_model_ode_tests.jl`, `covariates_tests.jl`, `model_tests.jl`, `data_simulation_tests.jl`, `splines_tests.jl`, `summaries_data_model_tests.jl`, `estimation_common_tests.jl`, `ad_model_full.jl` all pass.
- Formatted with JuliaFormatter v1 (pinned scratch env); `git diff --stat` touches only the two files.

## Triage of the related `predict` item

Suite bug, not a package bug - left out of this PR deliberately.

`predict(res, newdata)` rebuilds a `DataModel` from the new data (`src/plotting/plotting_residuals.jl`), so it re-runs the same validation. In the stress suite, the offset model's training data starts at t = 1.0 (`OBS_TIMES`), so `1.0 - 0.5 >= 0` passes; but `generate_holdout` calls `_simulate_dyncov_rows` with the default `support_start = 0.0`, producing rows at t = 0.0 where `0.0 - 0.5 = -0.5 < 0`. That is the pre-existing, correct "Formulas request times earlier than the first observation" refusal firing on holdout data the offset model can never accept. Fix belongs in the suite's holdout generator (generate holdout rows on the same time grid as training).

One genuine, unrelated observation noted while triaging and not acted on: `predict(res, newdata)` does not carry `t0` over from the fitted `DataModel` (it is not stored in `DataModelConfig`), so a fit built with `t0 = nothing` silently gets `t0 = 0.0` on new data. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)