### PR TITLE
fix: closed-form Bateman path ignored infusion forcing on the upstream compartment (#112)

### DIFF
--- a/src/model/closed_form_ode.jl
+++ b/src/model/closed_form_ode.jl
@@ -324,12 +324,22 @@ end
     return u == 1 ? [xu, xd] : [xd, xu]
 end
 
+# The `:bateman` kernel only propagates the upstream state's *initial value* into the
+# downstream state, so it is exact only while the upstream state is unforced. Detection
+# proves that for the model RHS, but an infusion event adds forcing at run time, so those
+# segments fall back to the exact matrix-exponential form.
+@inline function _cf_segment_mode(mode::Symbol, A, b)
+    mode === :bateman || return mode
+    return iszero(b[iszero(A[1, 2]) ? 1 : 2]) ? :bateman : :linear
+end
+
 # Advance `x' = A x + b` over `Δ` from `x0`: per-state scalar (:diagonal), the
 # two-state sequential scalar form (:bateman), or the matrix-exp action (:linear).
 function _cf_propagate(mode::Symbol, A, b, x0, Δ)
-    mode === :diagonal &&
+    m = _cf_segment_mode(mode, A, b)
+    m === :diagonal &&
         return [_cf_state_value(A[i, i], b[i], x0[i], Δ) for i in eachindex(x0)]
-    mode === :bateman && return _cf_bateman(A, b, x0, Δ)
+    m === :bateman && return _cf_bateman(A, b, x0, Δ)
     return _cf_expv(A, b, x0, Δ)
 end
 
@@ -339,16 +349,17 @@ end
 # scalar formulas are identical to `_cf_propagate`/`_cf_bateman`, so results are
 # bit-identical; only the storage differs.
 function _cf_propagate!(out, mode::Symbol, A, b, x0, Δ)
-    if mode === :diagonal
+    m = _cf_segment_mode(mode, A, b)
+    if m === :diagonal
         @inbounds for i in eachindex(x0)
             out[i] = _cf_state_value(A[i, i], b[i], x0[i], Δ)
         end
-    elseif mode === :bateman
+    elseif m === :bateman
         u, d, xu, xd = _cf_bateman_ud(A, b, x0, Δ)
         @inbounds out[u] = xu
         @inbounds out[d] = xd
     else
-        out .= _cf_expv(A, b, x0, Δ)  # :linear (opt-in): matrix-exp action, rare
+        out .= _cf_expv(A, b, x0, Δ)  # :linear (opt-in / forced upstream): matrix-exp
     end
     return out
 end

--- a/test/closed_form_ode_tests.jl
+++ b/test/closed_form_ode_tests.jl
@@ -340,6 +340,53 @@ end
     @test a≈b rtol=1e-4
 end
 
+@testset "closed-form Bateman with a forced upstream compartment (#112)" begin
+    # An infusion event dosing the DEPOT adds constant forcing to the upstream state,
+    # which the Bateman kernel (initial-value propagation only) cannot represent — it
+    # must fall back to the matrix-exp form. Tight solver tolerances so the comparison
+    # measures the closed form, not solver error.
+    function oral(cf)
+        m = @Model begin
+            @fixedEffects begin
+                ka = RealNumber(0.7, scale = :log)
+                ke = RealNumber(0.2, scale = :log)
+                σ = RealNumber(5.0, scale = :log)
+            end
+            @covariates begin
+                t = Covariate()
+            end
+            @DifferentialEquation begin
+                D(depot) ~ -ka * depot
+                D(central) ~ ka * depot - ke * central
+            end
+            @initialDE begin
+                depot = 0.0
+                central = 0.0
+            end
+            @formulas begin
+                y ~ Normal(central(t), σ)
+            end
+        end
+        set_solver_config(m; alg = Vern9(), saveat_mode = :saveat, closed_form = cf,
+            kwargs = (; reltol = 1e-12, abstol = 1e-12))
+    end
+    # bolus at t0 (depot), infusion into the depot at t=6, reset of central at t=12
+    df = DataFrame(ID = fill(1, 7), t = [0.0, 2.0, 4.0, 6.0, 8.0, 12.0, 16.0],
+        EVID = [1, 0, 0, 1, 0, 2, 0], AMT = [100.0, 0, 0, 30.0, 0, 5.0, 0],
+        RATE = [0.0, 0, 0, 10.0, 0, 0, 0], CMT = [1, 1, 1, 1, 1, 2, 1],
+        y = [missing, 60.0, 40.0, missing, 25.0, missing, 20.0])
+    kw = (; primary_id = :ID, time_col = :t, evid_col = :EVID, amt_col = :AMT,
+        rate_col = :RATE, cmt_col = :CMT)
+    dm_cf = DataModel(oral(:auto), df; kw...)
+    dm_off = DataModel(oral(:off), df; kw...)
+    @test get_closed_form_plan(dm_cf).mode === :bateman
+    θ = get_θ0_untransformed(get_fixed(get_model(dm_cf)))
+    η = ComponentArray(NamedTuple())
+    ll_cf = NoLimits.conditional_loglikelihood(dm_cf, 1, θ, η)
+    ll_off = NoLimits.conditional_loglikelihood(dm_off, 1, θ, η)
+    @test ll_cf≈ll_off atol=1e-8
+end
+
 @testset "closed-form/numerical split (partial)" begin
     # Linear PK compartment x1 (closed-form) driving a nonlinear PD state x2
     # (numerical, reads x1(t) from the closed form). Compare marginal loglik at


### PR DESCRIPTION
## Root cause

The bug is not "events are unsupported by the closed form" - bolus (EVID=1, RATE=0),
reset (EVID=2), and segment splitting are all handled correctly. It is narrower and
was invisible to the existing event test because that test uses a single-compartment
(`:diagonal`) model.

`_cf_bateman_ud` implements the two-state sequential form as

```
xu = _cf_state_value(au, b[u], x0[u], Δ)
xd = _cf_state_value(ad, b[d], x0[d], Δ) + A[d,u] * x0[u] * _cf_expdd(au, ad, Δ)
```

The cross term propagates only the upstream compartment's **initial value** `x0[u]`
into the downstream state. The particular solution driven by a constant forcing
`b[u]` on the upstream state never reaches `xd`. That is fine as long as `b[u] == 0`,
which `_detect_closed_form` proves symbolically before choosing `:bateman`
(`_cf_is_zero(substitute(syms[up], subs))`).

But infusion is added **outside** the model RHS: `_cf_build_segments` folds an active
infusion rate into the segment forcing as `b_base .+ infusion`. So an `EVID=1` record
with `RATE > 0` dosing the *upstream* compartment (the depot of the ubiquitous 1-cmt
oral model) makes `b[u] != 0` at run time, and the whole `b[u] -> xd` contribution is
silently dropped. Hence the ~68-nat gap under the default `closed_form = :auto`.

Measured on a depot/central model at fixed theta (`conditional_loglikelihood`,
closed form vs numeric), before the fix:

| event pattern | delta (cf - numeric) |
|---|---|
| bolus t0 + mid | -9.4e-5 (solver tol, ok) |
| EVID=2 reset | -5.4e-5 (solver tol, ok) |
| infusion into **central** (downstream) | -2.4e-5 (solver tol, ok) |
| infusion into **depot** (upstream) at t=6 | **+3.40** |
| t0 infusion into **depot** | **-24.52** |
| bolus t0 + depot infusion t6 + reset t12 (M10-like) | **+2.16** |

## Fix

Route segments whose upstream forcing is nonzero to the exact augmented
matrix-exponential form, which already handles arbitrary constant forcing, repeated
eigenvalues, and singular `A`:

```julia
@inline function _cf_segment_mode(mode::Symbol, A, b)
    mode === :bateman || return mode
    return iszero(b[iszero(A[1, 2]) ? 1 : 2]) ? :bateman : :linear
end
```

`_cf_propagate` and `_cf_propagate!` both go through it. Those two functions are the
only propagation entry points (`_cf_state_vector`, `_cf_materialize`,
`_cf_build_segments` all call them), so every consumer - estimation
(`_ll_solve_de`/`_cf_dispatch_solve`), plotting (`plotting.jl:335`), and simulation
(`data_simulation.jl:101`) - is fixed by the one guard. Unforced Bateman segments keep
the fast scalar path; only the forced ones pay for a 3x3 `expm`.

Alternative considered and rejected: adding the missing `b[u]`-driven analytic term
`c*(b[u]/au)*(E - Δ*φ(ad*Δ))`. It is removable-singular at both `au = 0` and
`au = ad`, so it needs a new two-parameter confluent kernel - more code for the same
answer the existing matrix-exp path already gives exactly.

## Verification

- Same repro after the fix: every pattern above agrees to solver tolerance
  (max |delta| = 1.4e-4 at default tolerances).
- With `Vern9()` and `reltol = abstol = 1e-12`, the M10-like case agrees to
  **9.2e-13**, i.e. the closed form is exact and the residual was solver error - this
  clears the 1e-8 bar in the issue.
- Regression test added to `test/closed_form_ode_tests.jl`: a depot/central model with
  bolus at t0, an infusion into the depot at t=6, and an EVID=2 reset at t=12,
  asserting `mode === :bateman` still engages under `:auto` and that the closed-form
  and numeric log-likelihoods match to `atol = 1e-8` at fixed theta. It fails by ~2.2
  nats without the fix.
- `NL_TEST_FILES="closed_form_ode_tests.jl"` -> 44/44 pass.
- `NL_TEST_FILES="ode_callbacks_tests.jl"` -> 24/24 pass.
- JuliaFormatter v1 (sciml) clean: `git diff --stat` touches only the two changed files.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
