### PR TITLE
fix: predict(re_mode=:marginal) sampled the RE posterior instead of the prior

### DIFF
--- a/src/plotting/plotting_residuals.jl
+++ b/src/plotting/plotting_residuals.jl
@@ -635,11 +635,13 @@ from `res`; how the random effects are chosen is controlled by `re_mode`:
 - `:reestimate`: compute a fresh empirical-Bayes estimate on `newdata` while holding
   the fitted fixed effects, so new subjects that carry their own observations get an
   individual prediction.
-- `:marginal`: integrate the random effects out by Monte Carlo. For seen subjects the
-  conditional posterior is sampled, for unseen subjects the prior is sampled, and the
-  prediction is the average conditional mean over `marginal_draws` draws.
+- `:marginal`: integrate the random effects out over their prior by Monte Carlo — the
+  prediction is the average conditional mean over `marginal_draws` prior draws. This
+  is subject-agnostic like `:population` and differs from it only through the
+  nonlinearity of the model (`E[f(η)]` vs `f(E[η])`); use `:ebe`/`:reestimate` for
+  subject-specific predictions.
 
-Matching in `:ebe`/`:marginal` is on the whole random-effect grouping signature, so in
+Matching in `:ebe` is on the whole random-effect grouping signature, so in
 a hierarchical model a subject with a new primary id counts as unseen even if it shares
 a known upper level. `:ebe`/`:reestimate`/`:marginal` need a random-effects method
 (Laplace, FOCEI, GHQuadrature, MCEM, or SAEM; `:reestimate` excludes GHQuadrature) and
@@ -680,7 +682,7 @@ function predict(res::FitResult, dm_new::DataModel;
     end
     _validate_predict_re_mode(res, dm_new, re_mode)
     if re_mode == :marginal
-        return _predict_marginal(res, dm_new, θ; fitted_stat = fitted_stat,
+        return _predict_marginal(dm_new, θ; fitted_stat = fitted_stat,
             constants_re = constants_re, marginal_draws = marginal_draws, rng = rng,
             ode_args = ode_args, ode_kwargs = ode_kwargs, kwargs...)
     end
@@ -768,32 +770,21 @@ function _predict_eta_ebe(res::FitResult, dm_new::DataModel, θ::ComponentArray,
     return η_vec
 end
 
-# Monte-Carlo marginal prediction: integrate the conditional posterior for seen
-# subjects and the prior for unseen subjects, averaging the per-draw predicted means.
-function _predict_marginal(res::FitResult, dm_new::DataModel, θ::ComponentArray;
+# Monte-Carlo marginal prediction: integrate the random effects over their prior,
+# averaging the per-draw predicted means.
+function _predict_marginal(dm_new::DataModel, θ::ComponentArray;
         fitted_stat, constants_re::NamedTuple, marginal_draws::Int,
         rng::AbstractRNG, ode_args::Tuple, ode_kwargs::NamedTuple, kwargs...)
     marginal_draws >= 1 || error("predict: marginal_draws must be >= 1.")
-    dm_old = get_data_model(res)
-    dm_old === nothing &&
-        error("predict: re_mode=:marginal requires the fit to store its DataModel; " *
-              "refit with store_data_model = true.")
-    bstars, batch_infos, θu, const_cache, ll_cache_train, _ = _resolve_bstars_for_re(
-        dm_old, res, constants_re)
-    re_to_train = Dict{Any, Tuple{Int, Int}}()
-    for (bi, info) in enumerate(batch_infos)
-        for i in get_inds(info)
-            re_to_train[get_re_groups(get_individuals(dm_old)[i])] = (bi, i)
-        end
-    end
-    bstars_per_sample = _sample_conditional_bstars(dm_old, batch_infos, bstars, θu,
-        const_cache, ll_cache_train, res, marginal_draws, rng)
     dists_builder = create_random_effect_distribution(get_random(get_model(dm_new)))
     model_funs = get_model_funs(get_model(dm_new))
     helpers = get_helper_funs(get_model(dm_new))
     re_names = get_re_names(get_random(get_model(dm_new)))
     sample_rngs = _spawn_child_rngs(rng, marginal_draws)
     n_new = length(get_individuals(dm_new))
+    # θ is fixed, so each individual's RE priors are the same for every draw.
+    dists_vec = [dists_builder(θ, get_const_cov(get_individuals(dm_new)[j]),
+                     model_funs, helpers) for j in 1:n_new]
 
     sum_acc = Float64[]
     cnt_acc = Int[]
@@ -804,17 +795,9 @@ function _predict_marginal(res::FitResult, dm_new::DataModel, θ::ComponentArray
         srng = sample_rngs[s]
         η_vec = Vector{ComponentArray}(undef, n_new)
         for j in 1:n_new
-            tinfo = get(re_to_train, get_re_groups(get_individuals(dm_new)[j]), nothing)
-            η_vec[j] = if tinfo !== nothing
-                bi, ti = tinfo
-                ComponentArray(_build_eta_ind(dm_old, ti, batch_infos[bi],
-                    bstars_per_sample[s][bi], const_cache, θu))
-            else
-                dists = dists_builder(
-                    θu, get_const_cov(get_individuals(dm_new)[j]), model_funs, helpers)
-                ComponentArray(NamedTuple((re => rand(srng, getproperty(dists, re))
-                for re in re_names)))
-            end
+            η_vec[j] = ComponentArray(NamedTuple((re => rand(srng,
+                                                      getproperty(dists_vec[j], re))
+            for re in re_names)))
         end
         cache = _fill_plot_cache(dm_new, θ, η_vec, constants_re, true,
             ode_args, ode_kwargs)

--- a/test/residual_plots_tests.jl
+++ b/test/residual_plots_tests.jl
@@ -256,11 +256,18 @@ end
     reest = NoLimits.predict(res, df; re_mode = :reestimate)
     @test isapprox(collect(reest.prediction), collect(ebe.prediction); atol = 5e-2)
 
-    # :marginal integrates the conditional posterior for seen subjects → tracks :ebe.
-    marg = NoLimits.predict(res, df; re_mode = :marginal, marginal_draws = 100,
+    # :marginal integrates the RE prior, so on a linear mean-zero-RE model it matches
+    # :population up to Monte-Carlo error that shrinks with marginal_draws (issue #103).
+    marg = NoLimits.predict(res, df; re_mode = :marginal, marginal_draws = 800,
         rng = MersenneTwister(1))
+    marg_few = NoLimits.predict(res, df; re_mode = :marginal, marginal_draws = 25,
+        rng = MersenneTwister(1))
+    dev = maximum(abs.(collect(marg.prediction) .- collect(pop.prediction)))
+    dev_few = maximum(abs.(collect(marg_few.prediction) .- collect(pop.prediction)))
     @test nrow(marg) == nrow(df)
-    @test isapprox(collect(marg.prediction), collect(ebe.prediction); atol = 0.1)
+    @test dev < 0.3
+    @test dev < dev_few
+    @test !isapprox(collect(marg.prediction), collect(ebe.prediction); atol = 0.5)
 
     # Unseen subject with only missing outcomes: rows are kept, and :ebe/:marginal
     # fall back to the population value (prior mean / prior draws).


### PR DESCRIPTION
## Root cause

Not a per-draw plumbing bug - the draws come from the wrong distribution. `_predict_marginal` (added in #73) looked every individual up in the training `DataModel` and, for anyone whose random-effect grouping signature was seen during the fit, drew from the **conditional posterior** `p(b | y, θ̂)` via `_sample_conditional_bstars`; only genuinely unseen individuals were drawn from the prior. On the training rows every subject is "seen", so `:marginal` collapsed onto the EBE/IPRED prediction rather than the population-marginal one. That also explains the reported independence from the held-out `y`: the conditional draws condition on the *training* outcomes stored in the fit, not on the new data.

Reproduced locally on a linear random intercept + slope model (`y ~ (a + η1) + (b + η2) t`, 20 subjects, Laplace):

```
max |marginal - population| = 10.2555
max |marginal - ebe|        =  0.0727   <-- marginal was tracking IPRED
max |ebe - population|      = 10.2565
```

## Fix

`:marginal` now draws every individual's random effects from their prior `p(η | θ̂)`, seen or not, so it is the Monte-Carlo integral of the conditional mean over the RE distribution and differs from `:population` only through the model nonlinearity (`E[f(η)]` vs `f(E[η])`). The per-individual RE distributions are built once instead of once per draw (θ is fixed). Subject-specific prediction stays available through `:ebe` and `:reestimate`.

Net effect is a deletion: the training-lookup, conditional-sampling and batch bookkeeping are gone from the marginal path (`-36/+26` lines over two files). `_sample_conditional_bstars` is untouched and still serves `fit_cv`'s `seen_re_mode = :conditional`.

## Verification

Same model/fit as above, after the fix:

```
draws  max |marginal - population|
  100  0.721
  400  0.722
 1600  0.258
```

versus a constant 10.25 before, i.e. the gap is now Monte-Carlo noise that shrinks with `marginal_draws`, and `max |marginal - ebe|` is back up at 10.75.

Regression test in the existing `predict re_mode` testset (`test/residual_plots_tests.jl`): on a fitted mean-zero-RE linear model, max |marginal - population| over the training rows is < 0.3 at 800 draws, is smaller than at 25 draws, and no longer matches `:ebe`. The old assertion that encoded the posterior semantics (`marginal ≈ ebe`) was replaced.

`NL_TEST_FILES="residual_plots_tests.jl" julia --project -e 'using Pkg; Pkg.test()'` - 64/64 pass. JuliaFormatter v1 (sciml) is a no-op on the result.

The docstring for `predict` was updated to state the new semantics.

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)
