### PR TITLE
fix: DataModel rebuilds dropped t0, silently changing predictions on new data

### DIFF
--- a/src/data_model/DataModel.jl
+++ b/src/data_model/DataModel.jl
@@ -14,6 +14,7 @@ export get_closed_form_plan
 export get_time_col
 export get_obs_cols
 export get_evid_col
+export get_t0
 export get_series
 export get_const_cov
 export get_callbacks
@@ -30,10 +31,10 @@ using Distributions
 using Random
 
 """
-    DataModelConfig{S}
+    DataModelConfig{S, T}
 
 Configuration struct for a [`DataModel`](@ref), storing column names, serialization
-algorithm, and save-time mode.
+algorithm, save-time mode, and the integration start time.
 
 # Fields
 - `primary_id::Symbol`: primary individual-grouping column.
@@ -45,8 +46,9 @@ algorithm, and save-time mode.
 - `obs_cols::Vector{Symbol}`: observation outcome column names.
 - `serialization::S`: SciML ensemble algorithm (e.g. `EnsembleSerial()`, `EnsembleThreads()`).
 - `saveat_mode::Symbol`: `:dense` or `:saveat` (resolved from `:auto` at construction time).
+- `t0::T`: integration start time, or `nothing` to start at each individual's first data time.
 """
-struct DataModelConfig{S}
+struct DataModelConfig{S, T}
     primary_id::Symbol
     time_col::Symbol
     evid_col::Union{Nothing, Symbol}
@@ -56,6 +58,7 @@ struct DataModelConfig{S}
     obs_cols::Vector{Symbol}
     serialization::S
     saveat_mode::Symbol
+    t0::T
 end
 
 struct RowGroups{R, O}
@@ -1343,6 +1346,8 @@ observation counts, and saveat-mode resolution.
 - `amt_col::Symbol = :AMT`: AMT column (dose amounts, used when `evid_col` is set).
 - `rate_col::Symbol = :RATE`: RATE column (infusion rates, used when `evid_col` is set).
 - `cmt_col::Symbol = :CMT`: CMT column (compartment index or name, used when `evid_col` is set).
+- `t0::Union{Nothing, Real} = 0.0`: integration start time. `nothing` starts each
+  individual's integration at its first data time.
 - `serialization::SciMLBase.EnsembleAlgorithm = EnsembleSerial()`: parallelisation
   strategy for ODE solving. Use `EnsembleThreads()` for multi-threaded evaluation.
 """
@@ -1373,7 +1378,7 @@ function DataModel(model,
         error("Unknown saveat_mode $(saveat_mode). Use :dense, :saveat, or :auto.")
     saveat_mode = saveat_mode == :auto ? :saveat : saveat_mode
     config = DataModelConfig(primary_id, time_col, evid_col, amt_col, rate_col,
-        cmt_col, obs_cols, serialization, saveat_mode)
+        cmt_col, obs_cols, serialization, saveat_mode, t0)
     _validate_schema(model, df, config)
     _validate_observed_markov_coarsed_usage(model, df, config)
 
@@ -1585,6 +1590,14 @@ Return the observation (outcome) column names.
 Return the EVID column name (event handling), or `nothing` when events are disabled.
 """
 @inline get_evid_col(dm::DataModel) = dm.config.evid_col
+
+"""
+    get_t0(dm::DataModel) -> Union{Nothing, Real}
+
+Return the integration start time, or `nothing` when integration starts at each
+individual's first data time.
+"""
+@inline get_t0(dm::DataModel) = dm.config.t0
 
 # ── Individual accessors ─────────────────────────────────────────────────────
 

--- a/src/data_simulation/data_simulation.jl
+++ b/src/data_simulation/data_simulation.jl
@@ -393,5 +393,6 @@ function simulate_data_model(dm::DataModel; rng = Random.default_rng(),
         amt_col = cfg.amt_col,
         rate_col = cfg.rate_col,
         cmt_col = cfg.cmt_col,
+        t0 = cfg.t0,
         serialization = serialization)
 end

--- a/src/estimation/cv.jl
+++ b/src/estimation/cv.jl
@@ -82,7 +82,7 @@ function _rebuild_dm(dm_ref::DataModel, rows::Vector{Int})
     return DataModel(get_model(dm_ref), df_sub;
         primary_id = cfg.primary_id, time_col = cfg.time_col,
         evid_col = cfg.evid_col, amt_col = cfg.amt_col,
-        rate_col = cfg.rate_col, cmt_col = cfg.cmt_col,
+        rate_col = cfg.rate_col, cmt_col = cfg.cmt_col, t0 = cfg.t0,
         serialization = cfg.serialization)
 end
 

--- a/src/estimation/serialization.jl
+++ b/src/estimation/serialization.jl
@@ -32,6 +32,7 @@ struct _SavedDataModelConfig
     rate_col::Symbol
     cmt_col::Symbol
     serialization_kind::Symbol   # :serial / :threads / :distributed
+    t0::Union{Nothing, Float64}
 end
 
 # ─── Per-method saved result structs ─────────────────────────────────────────
@@ -169,7 +170,8 @@ function _build_saved_config(dm::DataModel)
         cfg.amt_col,
         cfg.rate_col,
         cfg.cmt_col,
-        _ensemble_to_symbol(cfg.serialization)
+        _ensemble_to_symbol(cfg.serialization),
+        cfg.t0 === nothing ? nothing : float(cfg.t0)
     )
 end
 
@@ -326,6 +328,7 @@ function _reconstruct_data_model(df, config::_SavedDataModelConfig, model)
         amt_col = config.amt_col,
         rate_col = config.rate_col,
         cmt_col = config.cmt_col,
+        t0 = config.t0,
         serialization = _symbol_to_serialization(config.serialization_kind))
 end
 

--- a/src/plotting/plots.jl
+++ b/src/plotting/plots.jl
@@ -286,6 +286,7 @@ function _same_data_model_for_fits(dm1::DataModel, dm2::DataModel)
     cfg1.obs_cols == cfg2.obs_cols || return false
     cfg1.serialization == cfg2.serialization || return false
     cfg1.saveat_mode == cfg2.saveat_mode || return false
+    cfg1.t0 == cfg2.t0 || return false
 
     length(get_individuals(dm1)) == length(get_individuals(dm2)) || return false
     get_obs_rows(get_row_groups(dm1)) == get_obs_rows(get_row_groups(dm2)) || return false

--- a/src/plotting/plotting_residuals.jl
+++ b/src/plotting/plotting_residuals.jl
@@ -714,7 +714,7 @@ function predict(res::FitResult, newdata; kwargs...)
     dm_new = DataModel(get_model(dm_old), newdata;
         primary_id = cfg.primary_id, time_col = cfg.time_col,
         evid_col = cfg.evid_col, amt_col = cfg.amt_col,
-        rate_col = cfg.rate_col, cmt_col = cfg.cmt_col,
+        rate_col = cfg.rate_col, cmt_col = cfg.cmt_col, t0 = cfg.t0,
         serialization = cfg.serialization)
     return predict(res, dm_new; kwargs...)
 end

--- a/test/residual_plots_tests.jl
+++ b/test/residual_plots_tests.jl
@@ -292,3 +292,38 @@ end
     @test_throws ErrorException NoLimits.predict(res_fo, get_df(dm_fo); re_mode = :ebe)
     @test_throws ErrorException NoLimits.predict(res, df; re_mode = :nonsense)
 end
+
+@testset "predict on new data inherits the DataModel t0" begin
+    model = @Model begin
+        @fixedEffects begin
+            A = RealNumber(2.0)
+            k = RealNumber(0.2, scale = :log)
+            σ = RealNumber(0.1, scale = :log)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @DifferentialEquation begin
+            D(x1) ~ -k * x1
+        end
+        @initialDE begin
+            x1 = A
+        end
+        @formulas begin
+            y ~ Normal(x1(t), σ)
+        end
+    end
+
+    # First observation well after 0 so t0 shifts the integration start.
+    df = DataFrame(ID = repeat([1, 2]; inner = 3),
+        t = repeat([5.0, 6.0, 7.0]; outer = 2),
+        y = [0.75, 0.62, 0.50, 0.70, 0.58, 0.47])
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t, t0 = nothing)
+    @test get_t0(dm) === nothing
+    res = fit_model(dm, NoLimits.MLE(; optim_kwargs = (maxiters = 5,)))
+
+    in_sample = NoLimits.predict(res, dm)
+    on_newdata = NoLimits.predict(res, df)
+    @test isapprox(collect(on_newdata.prediction), collect(in_sample.prediction);
+        atol = 1e-8)
+end


### PR DESCRIPTION
## Root cause

`DataModel(model, df; t0 = ...)` (added in #53) uses `t0` to set each individual's integration start, but `t0` was never stored on `DataModelConfig`. Every site that rebuilds a `DataModel` from a fit copies the config field by field, so all of them silently fell back to the constructor default `t0 = 0.0`.

For a fit built with `t0 = nothing` (integration starts at each individual's first data time), the rebuilt `DataModel` starts at `t = 0` instead. The initial conditions are applied at a different time, the ODE evolves for extra time before the first observation, and the predictions change - with no warning.

Verified on `bd7564c9` with a one-compartment decay model observed at `t = 5, 6, 7`:

```
tspan t0=nothing: (5.0, 7.0)
tspan t0=0.0    : (0.0, 7.0)
in-sample (t0=nothing fit, dm):  [0.8897, 0.3710, 0.1547, ...]
predict on newdata (same df):    [0.0112, 0.0047, 0.0020, ...]
max |in-sample - newdata| = 0.878
```

## Fix

Store `t0` on `DataModelConfig` (now `DataModelConfig{S, T}`), add the `get_t0(dm)` accessor, and pass `t0 = cfg.t0` at every rebuild site:

- `predict(res, newdata)` - `src/plotting/plotting_residuals.jl`
- `_rebuild_dm` (cross-validation folds) - `src/estimation/cv.jl`
- `simulate_data_model` - `src/data_simulation/data_simulation.jl`
- `_reconstruct_data_model` / `_SavedDataModelConfig` (`load_fit`) - `src/estimation/serialization.jl`

`_same_data_model_for_fits` in `src/plotting/plots.jl` compares `t0` as well, so two fits that differ only in integration start are no longer treated as sharing a data model.

VPC and the plot caches do not rebuild a `DataModel`, so they need no change.

## Verification

- The repro above now gives `max |in-sample - newdata| = 0.0`.
- New regression test in `test/residual_plots_tests.jl`: a fit built with `t0 = nothing` on data starting at `t = 5` reproduces its in-sample predictions when `predict` is called on its own training data.
- `NL_TEST_FILES="residual_plots_tests.jl,data_model_tests.jl,estimation_cv_tests.jl,serialization_tests.jl,data_simulation_tests.jl,crossing_tests.jl,accessors_tests.jl" julia --project -e 'using Pkg; Pkg.test()'` - 378 passes, 0 failures.
- Formatted with JuliaFormatter v1 (sciml); no unrelated files touched.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)
