### PR TITLE
docs+test: pin the HMM logscore / loglikelihood relationship (#114)

### DIFF
--- a/src/plotting/plotting_residuals.jl
+++ b/src/plotting/plotting_residuals.jl
@@ -284,6 +284,17 @@ Compute residuals for each observation and return a `DataFrame`.
 - `mcmc_quantiles::Vector = [5, 95]`: percentiles for MCMC residual uncertainty bands.
 - `rng::AbstractRNG = Random.default_rng()`: random-number generator.
 - `return_draw_level::Bool = false`: if `true`, return draw-level residuals for MCMC.
+
+# `:logscore` sign and relation to `get_loglikelihood`
+
+`logscore` is the **negative** log predictive density of the observation,
+`-logpdf(dist, y)` (smaller is better), so `-sum(skipmissing(rdf.logscore))` is the
+conditional log-likelihood at the random effects the residuals were evaluated at. For
+HMM-family outcomes `dist` is the forward-filtered distribution, so this identity holds
+through `missing` rows as well. On Laplace/FOCEI/SAEM/MCEM/Pooled fits it therefore
+matches `get_loglikelihood(res)` (which also conditions on the EB modes) to round-off;
+on `GHQuadrature` fits `get_loglikelihood` returns the *marginal* likelihood, which
+integrates over the random effects and is a different quantity.
 """
 function get_residuals(res::FitResult;
         dm::Union{Nothing, DataModel} = nothing,

--- a/test/residual_plots_tests.jl
+++ b/test/residual_plots_tests.jl
@@ -197,6 +197,67 @@ end
     @test !(ls[2] ≈ -logpdf(dists[2], y[2]))
 end
 
+@testset "HMM logscore sum matches the conditional loglik (missing rows)" begin
+    model = @Model begin
+        @fixedEffects begin
+            P = DiscreteTransitionMatrix([0.8 0.2; 0.3 0.7])
+            π0 = ProbabilityVector([0.5, 0.5])
+            μ = RealVector([-0.5, 1.5])
+            σk = RealVector([0.7, 0.7]; scale = [:log, :log])
+            ω = RealNumber(0.5; scale = :log)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η = RandomEffect(Normal(0.0, ω); column = :ID)
+        end
+        @formulas begin
+            y ~ DiscreteTimeDiscreteStatesHMM(P,
+                (Normal(μ[1] + η, σk[1]), Normal(μ[2] + η, σk[2])),
+                Categorical(π0))
+        end
+    end
+
+    rng = Xoshiro(20260812)
+    P_true = [0.9 0.1; 0.2 0.8]
+    rows = NamedTuple[]
+    for id in 1:4
+        η = 0.3 * randn(rng)
+        miss = shuffle(rng, collect(2:8))[1:2]     # missing mid-sequence, never first
+        s = rand(rng, Distributions.Categorical([0.7, 0.3]))
+        for k in 1:8
+            s = rand(rng, Distributions.Categorical(P_true[s, :]))
+            y = k in miss ? missing : [-1.0, 2.0][s] + η + [0.5, 0.6][s] * randn(rng)
+            push!(rows, (; ID = "id_$id", t = Float64(k), y = y))
+        end
+    end
+    df = DataFrame(rows)
+    @test count(ismissing, df.y) == 8
+
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+    res = fit_model(dm, NoLimits.Laplace(; optim_kwargs = (maxiters = 3,)))
+
+    rdf = get_residuals(res; residuals = [:logscore])
+    ls = sum(skipmissing(rdf.logscore))
+    # logscore is the NEGATIVE filtered log predictive density, so its sum is the
+    # conditional loglik at the EB modes with the sign flipped.
+    @test isapprox(-ls, get_loglikelihood(res); atol = 1.0e-6)
+    # Sharpness: unfiltered scoring would be a different number entirely.
+    cache = build_plot_cache(res)
+    θ = cache.params
+    η_ind = cache.random_effects[1]
+    ind = get_individuals(dm)[1]
+    obs_rows = NoLimits.get_row_groups(dm).obs_rows[1]
+    y1 = get_obs(get_series(ind)).y
+    unfiltered = sum(logpdf(
+                         calculate_formulas_obs(model, θ, η_ind, ind.const_cov,
+                             NoLimits._varying_at(dm, ind, j, obs_rows[j])).y, y1[j])
+    for j in eachindex(obs_rows) if y1[j] !== missing)
+    ls1 = sum(skipmissing(rdf[rdf.individual_idx .== 1, :logscore]))
+    @test !isapprox(-ls1, unfiltered; atol = 1.0e-3)
+end
+
 @testset "GOF and diagnostic plots (Laplace RE fit)" begin
     # Moved from coverage_gap_tests.jl (path coverage for GOF/diagnostic plots).
     dm = fx_fixre_dm()


### PR DESCRIPTION
Closes #114

## Root cause

There is no filtering divergence. `get_residuals`' `:logscore` column is the **negative** log predictive density, `-logpdf(dist, y)` (it is plotted as "Negative Log-Likelihood"), while `get_loglikelihood` returns the log-likelihood itself. Comparing `sum(logscore)` against `+loglik` therefore reports `2 * |loglik|` as a "discrepancy" — the 5136 nats on the M13 Laplace cell is exactly `2 x 2568.2279415490557`.

The two forward filters are in fact identical, through the mid-sequence `missing` rows included:

| M13 cell (stress-test JSON, `results_full`) | `logscore_sum` | `get_loglikelihood` | sum + loglik |
|---|---|---|---|
| Laplace | 2568.2279415490557 | -2568.2279415490557 | 0.0 |
| Pooled | 2872.2814704276925 | -2872.2814704276907 | 1.8e-12 |

Reproduced locally on a small DT-HMM (4-6 sequences, 10% missing mid-sequence, shared RE, Laplace): `sum(logscore) + get_loglikelihood(res) = -7.1e-15`.

Gap accounting:
- (a) genuine filtering divergence (missing-row propagation, `_hmm_with_prior` placement): **0 nats**. `_apply_hmm_filter!` and `_loglikelihood_rows_hmm` agree to round-off.
- (b) definitional: **the whole gap**. Sign convention accounts for all of it on the conditional-likelihood methods. On the GHQ cell a further 122.2 nats remain after the sign flip (2693.52 vs 2571.31) because `get_loglikelihood` on a `GHQuadrature` fit returns the *marginal* likelihood (integrated over the random effects), not the conditional one at the EB modes — a genuinely different quantity.

Since the quantities are defensibly different but reconcile exactly under a like-for-like comparison, this takes the second acceptance branch of the issue: document precisely, and pin with a test.

## Fix

- `src/plotting/plotting_residuals.jl`: `get_residuals` docstring now states the `:logscore` sign, that `-sum(skipmissing(logscore))` is the conditional loglik at the random effects the residuals were evaluated at (holding through `missing` rows for HMM outcomes), that this matches `get_loglikelihood` on Laplace/FOCEI/SAEM/MCEM/Pooled fits, and the GHQuadrature marginal-likelihood caveat.
- No runtime behaviour change, so the filtering contract shared by `plot_fits`, `plot_fits_comparison`, `plot_hidden_states`, `get_residuals` and `build_plot_cache` is untouched.

## Verification

- New regression test `HMM logscore sum matches the conditional loglik (missing rows)` in `test/residual_plots_tests.jl`: 2-state DT-HMM with a shared RE, 8 of 32 observations `missing` mid-sequence (never the first row), Laplace fit; asserts `-sum(logscore) ≈ get_loglikelihood(res)` at `atol = 1e-6`, plus a sharpness guard that unfiltered scoring gives a different number.
- `NL_TEST_FILES="residual_plots_tests.jl"`: 65 pass, 0 fail.
- `NL_TEST_FILES="hmm_discrete_time_tests.jl,markov_observed_states_tests.jl,hmm_estimation_method_matrix_tests.jl"`: 123 pass, 0 fail.
- Formatted with JuliaFormatter v1.0.62 (sciml); only the two touched files appear in `git diff --stat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
