### PR TITLE
fix: crossed RE groups broke every plug-in η construction (#101)

### DIFF
--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -2277,9 +2277,11 @@ function _cdll_terms(dm::DataModel, θ::ComponentArray;
             _re_dataframes_from_bstars(dm, batch_infos, bstars;
                 constants_re = constants_re, flatten = false, include_constants = true)
         end
+        # Each RE frame is keyed by ITS OWN grouping column, not by `primary_id`.
+        re_groups = get_re_groups(re)
         map(re_names) do rn
             df = getfield(nt, rn)
-            idc = get_primary_id(dm)
+            idc = getfield(re_groups, rn)
             valc = first(c for c in propertynames(df) if c != idc)
             Dict(Symbol(string(row[idc])) => row[valc] for row in eachrow(df))
         end
@@ -2304,11 +2306,14 @@ function _cdll_terms(dm::DataModel, θ::ComponentArray;
         end
     end
 
-    # Per-individual η ComponentArray (one grouping level per individual per RE).
+    # Per-individual η ComponentArray: one entry per grouping level the individual
+    # belongs to (a crossed design gives several), in the per-individual level order
+    # the row-wise η lookup indexes.
     function build_eta_i(i)
         pairs = Pair{Symbol, Any}[]
         for (ri, rn) in enumerate(re_names)
-            push!(pairs, rn => getval(ri, get_ind_level_ids(re_cache)[i][ri][1]))
+            lvl_vals = [getval(ri, li) for li in get_ind_level_ids(re_cache)[i][ri]]
+            push!(pairs, rn => length(lvl_vals) == 1 ? lvl_vals[1] : lvl_vals)
         end
         return ComponentArray(NamedTuple(pairs))
     end

--- a/src/estimation/pooled.jl
+++ b/src/estimation/pooled.jl
@@ -244,6 +244,19 @@ end
     return ComponentArray(vals, axs)
 end
 
+# η for one individual in a crossed design: the plug-in value repeated once per
+# grouping level the individual belongs to (row lookups index per level).
+function _pooled_crossed_ind_eta(dists_builder, θs, const_cov, model_funs, helpers,
+        re_names, dims, strategies, ::Type{T}, nlev) where {T}
+    dists = dists_builder(θs, const_cov, model_funs, helpers)
+    nt_pairs = Pair{Symbol, Any}[]
+    for (ri, re) in enumerate(re_names)
+        v = _pooled_eta_value(getproperty(dists, re), dims[ri], strategies[ri], T)
+        push!(nt_pairs, re => nlev[ri] == 1 ? v : fill(v, nlev[ri]))
+    end
+    return ComponentArray(NamedTuple(nt_pairs))
+end
+
 function _compute_pooled_etas(dm::DataModel, θ::ComponentArray, strategies)
     model = get_model(dm)
     lp_cache = get_laplace_cache(get_re_group_info(dm))
@@ -278,6 +291,15 @@ function _compute_pooled_etas(dm::DataModel, θ::ComponentArray, strategies)
         return [_pooled_fill_ind_eta(dists_builder, θs, get_const_cov(individuals[i]),
                     model_funs, helpers, re_names, dims, strategies, T, axs, ηlen)
                 for i in 1:n]
+    end
+    # Crossed designs: an individual can span several levels of a grouping column, so
+    # the η shape differs per individual and no shared axes exist.
+    level_ids = get_ind_level_ids(lp_cache)
+    if any(i -> any(ids -> length(ids) > 1, level_ids[i]), 1:n)
+        dims = get_dims(lp_cache)
+        return [_pooled_crossed_ind_eta(dists_builder, θs, get_const_cov(individuals[i]),
+                    model_funs, helpers, re_names, dims, strategies, T,
+                    map(length, level_ids[i])) for i in 1:n]
     end
     # Heterogeneous-shape path (e.g. a dim-1 NPF RE kept as a 1-vector): probe the
     # plug-in SHAPES once with the first individual to build the output axes (the
@@ -862,14 +884,15 @@ function _pooled_re_dataframes(dm::DataModel, η_vec::Vector{<:ComponentArray};
     isempty(re_names) && return NamedTuple()
     re_groups = get_re_groups(get_random(get_model(dm)))
 
-    # (ri, lvl_id) → first individual index with that level
-    level_to_ind = Dict{Tuple{Int, Int}, Int}()
+    # (ri, lvl_id) → (first individual with that level, its position within that
+    # individual's levels — crossed designs put several levels on one individual)
+    level_to_ind = Dict{Tuple{Int, Int}, Tuple{Int, Int}}()
     for i in 1:length(η_vec)
         for ri in 1:length(re_names)
-            ids = get_ind_level_ids(lp_cache)[i][ri]
-            isempty(ids) && continue
-            key = (ri, ids[1])
-            haskey(level_to_ind, key) || (level_to_ind[key] = i)
+            for (pos, lvl) in enumerate(get_ind_level_ids(lp_cache)[i][ri])
+                key = (ri, lvl)
+                haskey(level_to_ind, key) || (level_to_ind[key] = (i, pos))
+            end
         end
     end
 
@@ -882,9 +905,11 @@ function _pooled_re_dataframes(dm::DataModel, η_vec::Vector{<:ComponentArray};
         rows = Any[]
         vals_flat = Vector{Vector{Any}}()
         for (lvl_id, lvl_val) in enumerate(levels_all)
-            i = get(level_to_ind, (ri, lvl_id), 0)
+            i, pos = get(level_to_ind, (ri, lvl_id), (0, 0))
             i == 0 && continue
-            val = getproperty(η_vec[i], re)
+            comp = getproperty(η_vec[i], re)
+            nlev = length(get_ind_level_ids(lp_cache)[i][ri])
+            val = nlev == 1 ? comp : comp[pos]
             push!(rows, lvl_val)
             if flatten
                 push!(vals_flat, val isa Number ? [val] : collect(vec(val)))

--- a/test/complete_data_loglikelihood_tests.jl
+++ b/test/complete_data_loglikelihood_tests.jl
@@ -197,3 +197,71 @@ end
     per = complete_data_loglikelihood_per_individual(npf_dm, θ0; eta = :ebe)
     @test isapprox(sum(per.complete_data_loglikelihood), ebe; rtol = 1e-8)
 end
+
+# Crossed grouping columns (:ID and :RATER, rotating assignment): an individual spans
+# several levels of the second grouping column, so its η carries one entry per level.
+@testset "crossed random-effect groups" begin
+    model = @Model begin
+        @fixedEffects begin
+            a = RealNumber(1.0)
+            b = RealNumber(0.5)
+            σ = RealNumber(0.3, scale = :log)
+            ω_id = RealNumber(0.4, scale = :log)
+            ω_r = RealNumber(0.2, scale = :log)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η_id = RandomEffect(Normal(0.0, ω_id); column = :ID)
+            η_rater = RandomEffect(Normal(0.0, ω_r); column = :RATER)
+        end
+        @formulas begin
+            y ~ Normal(a + b * t + η_id + η_rater, σ)
+        end
+    end
+    nid, nr = 12, 3
+    rows = NamedTuple[]
+    for i in 1:nid, k in 1:4
+        push!(rows,
+            (ID = Symbol("s", i), RATER = Symbol("r", mod1(i + k, nr)),
+                t = Float64(k), y = 1.0 + 0.4k + 0.1 * (i - 6) + 0.05 * k * i))
+    end
+    df = DataFrame(rows)
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+    θ = get_θ0_untransformed(dm)
+
+    # ln p(y, η | θ) with η supplied per level.
+    function manual(ηid, ηr)
+        ll = sum(logpdf(Normal(θ.a + θ.b * r.t + ηid[r.ID] + ηr[r.RATER], θ.σ), r.y)
+        for r in eachrow(df))
+        ll += sum(logpdf(Normal(0.0, θ.ω_id), v) for v in values(ηid))
+        return ll + sum(logpdf(Normal(0.0, θ.ω_r), v) for v in values(ηr))
+    end
+
+    ηid = Dict(Symbol("s", i) => 0.05 * (i - 6) for i in 1:nid)
+    ηr = Dict(Symbol("r", j) => 0.1 * j for j in 1:nr)
+    eta = (; η_id = NamedTuple(k => v for (k, v) in ηid),
+        η_rater = NamedTuple(k => v for (k, v) in ηr))
+    @test isapprox(complete_data_loglikelihood(dm, θ; eta = eta), manual(ηid, ηr);
+        rtol = 1e-10)
+
+    zeros_id = Dict(k => 0.0 for k in keys(ηid))
+    zeros_r = Dict(k => 0.0 for k in keys(ηr))
+    mean_ll = complete_data_loglikelihood(dm, θ; eta = :mean)
+    @test isapprox(mean_ll, manual(zeros_id, zeros_r); rtol = 1e-10)
+
+    ebe_ll = complete_data_loglikelihood(dm, θ; eta = :ebe)
+    @test isfinite(ebe_ll)
+    @test ebe_ll >= mean_ll
+    per = complete_data_loglikelihood_per_individual(dm, θ; eta = :ebe)
+    @test nrow(per) == nid
+    @test isapprox(sum(per.complete_data_loglikelihood), ebe_ll; rtol = 1e-8)
+
+    # The naive-pooled plug-in path shares the η construction.
+    res = fit_model(dm, NoLimits.Pooled())
+    @test isfinite(NoLimits.get_objective(res))
+    re_df = get_random_effects(res)
+    @test nrow(re_df.η_id) == nid
+    @test nrow(re_df.η_rater) == nr
+end


### PR DESCRIPTION
## Root cause

Everything outside the estimator core that builds a per-individual `η` assumed
**one grouping level per individual per random effect**, and the EBE lookup assumed
every RE frame is keyed by `primary_id`. Both are false on a crossed design
(`η_id` by `:ID`, `η_rater` by `:RATER`, rotating assignment): an individual spans
several levels of the second grouping column, so the row-wise η lookup
(`_row_random_effects_fill`) indexes one entry per level. A scalar there raised
`BoundsError: attempt to access Float64 at index [2]`, and the EBE map raised
`ArgumentError: column name :ID not found`.

## Fix

- `_cdll_terms` (`src/estimation/common.jl`)
  - `build_eta_i` now emits one entry per grouping level the individual belongs to,
    in the per-individual level order the row lookup indexes.
  - the `:ebe` map is keyed by each RE's **own** grouping column
    (`get_re_groups(re)`), not `primary_id`.
- `_compute_pooled_etas` (`src/estimation/pooled.jl`): a crossed path replicates the
  plug-in value across the individual's levels (η shape differs per individual, so no
  shared axes exist). The two single-level fast paths are untouched.
- `_pooled_re_dataframes`: maps each level to `(individual, position)` so every level
  gets a row and reads the right entry.

## Verification

Crossed fixture, 12 ids x 3 raters, rotating assignment:

| | before | after |
|---|---|---|
| `complete_data_loglikelihood(dm, θ; eta = :mean)` | `BoundsError` | `-122.42343402048304` |
| `complete_data_loglikelihood(dm, θ; eta = :ebe)` | `ArgumentError: column name :ID not found` | `-3.964805171951562` |
| `fit_model(dm, Pooled())` | `TaskFailedException` (same `BoundsError`) | completes, objective `51.0996372061113`, RE frames 12 / 3 rows |
| `predict` (`:population`, `:ebe`, `:reestimate`, `:marginal`) | all four already ran on this fixture | all four run |

**Regression guard — estimates unchanged.** The same fixture fitted on a pristine
worktree at `b79e3fd5` and on this branch, bit-identical in every digit:

```
Laplace obj = 0.3040347293270429
Laplace θ   = [1.1077324151869155, 0.5204658375342576, 0.12962290418722125, 0.4645666319862942, 0.5450691577714818]
FOCEI   obj = 0.30403472932700737
FOCEI   θ   = [1.107732410668414, 0.5204658377691257, 0.12962290401546814, 0.4645666309087162, 0.5450691590380553]
SAEM    obj = 19.67243381758413
SAEM    θ   = [0.9768142239702863, 0.5204644378581474, 0.1300733745600293, 0.45417901578061887, 0.5391222839078464]
```

**Tests.** New `@testset "crossed random-effect groups"` in
`test/complete_data_loglikelihood_tests.jl`: closed-form check of the joint density
with per-level η supplied explicitly (this is what pins the per-level *ordering*),
`:mean` against the same closed form, `:ebe` finite and `>= :mean`, the
per-individual breakdown summing to the scalar, and a `Pooled()` fit completing with
one RE row per level. `NL_TEST_FILES="complete_data_loglikelihood_tests.jl,estimation_pooled_tests.jl"`
→ 142/142 pass. Formatted with JuliaFormatter v1 (sciml).

Note on symptom 3 of the issue: all four `predict` re_modes already ran on this
fixture before the change (the predict path builds η through `build_eta_individual`,
which handles multiple levels). If `:marginal` still fails on the stress-test model,
that is the separate `:marginal`-draw bug tracked in #103, not this one.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
