### PR TITLE
fix: closed_form=:all crashed under nested Duals (_cf_matexp)

### DIFF
--- a/src/model/closed_form_ode.jl
+++ b/src/model/closed_form_ode.jl
@@ -272,11 +272,14 @@ end
 # stable at confluent/repeated eigenvalues (e.g. ka ≈ ke) — unlike `A⁻¹`/divided-
 # difference forms. ForwardDiff-safe: value via the Float64 `exp`, each partial via
 # the block-2×2 Padé Fréchet derivative (`_expm_frechet`); a `Dual` specialization
-# is needed because `exp(::Matrix{Dual})` has no method. Nested Duals fall back to
-# the generic path. (Used only on the opt-in `:linear`/hybrid path — for a small
-# dense system the numerical solver is hard to beat on the gradient, so `:auto`
-# does not route general-linear systems here; see `get_closed_form_plan`.)
+# is needed because `exp(::Matrix{Dual})` has no method. Nested Duals (Laplace/FOCEI
+# inner Hessians, Wald UQ) route through the Dual-generic Padé `_matexp`, which
+# propagates derivatives at any nesting depth. (Used only on the opt-in `:linear`/
+# hybrid path — for a small dense system the numerical solver is hard to beat on the
+# gradient, so `:auto` does not route general-linear systems here; see
+# `get_closed_form_plan`.)
 _cf_matexp(M::AbstractMatrix{<:AbstractFloat}) = exp(M)
+_cf_matexp(M::AbstractMatrix{<:Real}) = _matexp(M)
 function _cf_matexp(M::AbstractMatrix{ForwardDiff.Dual{
         Tg, V, N}}) where {
         Tg, V <: AbstractFloat, N}

--- a/test/closed_form_ode_tests.jl
+++ b/test/closed_form_ode_tests.jl
@@ -5,6 +5,9 @@ using Distributions
 using ComponentArrays
 using OrdinaryDiffEq
 using Random
+using ForwardDiff
+using FiniteDifferences
+using LinearAlgebra
 
 # Two-state decoupled diagonal-linear PK-flavored model (constant forcing on x2),
 # no random effects → fit with MLE. Built once, reused across the oracle tests.
@@ -392,6 +395,91 @@ end
     r_s = fit_model(dm_off_s, NoLimits.MLE())
     @test isfinite(NoLimits.get_objective(fit_model(dm_cf_s, NoLimits.MLE())))
     @test NoLimits.get_loglikelihood(dm_cf_s, r_s)≈NoLimits.get_loglikelihood(dm_off_s, r_s) rtol=1e-4
+end
+
+# Bidirectional two-compartment (genuinely `:linear`, so opt-in via `closed_form = :all`)
+# with a random effect on clearance. The Laplace inner Hessian drives nested Duals
+# through `_cf_matexp`.
+function _cf_twocmt_re_model(cf::Symbol)
+    m = @Model begin
+        @fixedEffects begin
+            k10 = RealNumber(0.5, scale = :log)
+            k12 = RealNumber(0.3, scale = :log)
+            k21 = RealNumber(0.2, scale = :log)
+            ω = RealNumber(0.3, scale = :log)
+            σ = RealNumber(0.05, scale = :log)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η = RandomEffect(Normal(0.0, ω); column = :ID)
+        end
+        @DifferentialEquation begin
+            D(x1) ~ -(k10 * exp(η) + k12) * x1 + k21 * x2
+            D(x2) ~ k12 * x1 - k21 * x2
+        end
+        @initialDE begin
+            x1 = 1.0
+            x2 = 0.0
+        end
+        @formulas begin
+            y ~ Normal(x1(t), σ)
+        end
+    end
+    return set_solver_config(m; saveat_mode = :saveat, closed_form = cf)
+end
+
+function _cf_twocmt_re_df()
+    ts = [0.5, 1.0, 2.0]
+    rates = [0.45, 0.75, 0.6, 0.95, 0.55]   # between-ID spread keeps ω identified
+    noise = [0.01, -0.02, 0.015, -0.01, 0.02, -0.015, 0.005, 0.01, -0.02, 0.012,
+        -0.008, 0.018, -0.011, 0.007, -0.016]
+    return DataFrame(ID = repeat(1:length(rates), inner = length(ts)),
+        t = repeat(ts, length(rates)),
+        y = vec([0.9 * exp(-r * t) for t in ts, r in rates]) .+ noise)
+end
+
+@testset "closed-form :linear under nested Duals" begin
+    # Derivative correctness of `_cf_matexp` at 1st and 2nd ForwardDiff order.
+    A(p) = [-(p[1] + p[2]) p[3] p[4]; p[2] -p[3] 0.0; 0.0 0.0 0.0]
+    w = [0.3, -0.7, 1.1, 0.2, 0.9, -0.4, 0.5, 0.15, -0.25]
+    f(p) = sum(vec(NoLimits._cf_matexp(A(p) .* 1.7)) .* w)
+    p0 = [0.5, 0.3, 0.2, 0.4]
+    fd = central_fdm(5, 1)
+    @test ForwardDiff.gradient(f, p0)≈FiniteDifferences.grad(fd, f, p0)[1] rtol=1e-6 atol=1e-9
+    H = ForwardDiff.hessian(f, p0)
+    H_fd = FiniteDifferences.jacobian(fd, x -> ForwardDiff.gradient(f, x), p0)[1]
+    @test H≈H_fd rtol=1e-6 atol=1e-9
+    @test H ≈ H'
+
+    # Nested-Dual value and first partials match the Float64 and single-Dual paths.
+    Mv = A(p0) .* 1.7
+    d1 = ForwardDiff.Dual{:t1}.(Mv, 1.0)
+    E2 = NoLimits._cf_matexp(ForwardDiff.Dual{:t2}.(d1, 1.0))
+    @test ForwardDiff.value.(ForwardDiff.value.(E2)) ≈ exp(Mv)
+    @test ForwardDiff.partials.(ForwardDiff.value.(E2), 1) ≈
+          ForwardDiff.partials.(NoLimits._cf_matexp(d1), 1)
+
+    # Laplace fit (nested Duals in the inner Hessian) and Wald UQ on that fit.
+    df = _cf_twocmt_re_df()
+    dm_all = DataModel(_cf_twocmt_re_model(:all), df; primary_id = :ID, time_col = :t)
+    dm_off = DataModel(_cf_twocmt_re_model(:off), df; primary_id = :ID, time_col = :t)
+    @test get_closed_form_plan(dm_all).mode === :linear
+    # k12/k21 held fixed: with only x1 observed they sit on a flat ridge, which would
+    # make the two optimizer paths land far apart for no path-related reason.
+    cst = (k12 = 0.3, k21 = 0.2)
+    res_all = fit_model(dm_all, NoLimits.Laplace(); constants = cst)
+    res_off = fit_model(dm_off, NoLimits.Laplace(); constants = cst)
+    @test NoLimits.get_objective(res_all)≈NoLimits.get_objective(res_off) rtol=1e-4
+    @test collect(NoLimits.get_params(res_all;
+        scale = :untransformed))≈
+    collect(NoLimits.get_params(res_off; scale = :untransformed)) rtol=1e-2
+    # Same params, both paths: isolates the closed-form solve from optimizer noise.
+    @test NoLimits.get_loglikelihood(dm_all,
+        res_off)≈NoLimits.get_loglikelihood(dm_off, res_off) rtol=1e-5
+    @test compute_uq(res_all; method = :wald, n_draws = 20,
+        rng = Random.Xoshiro(11)) !== nothing
 end
 
 @testset "closed-form and numerical simulate agree" begin


### PR DESCRIPTION
## Root cause

`_cf_matexp` (`src/model/closed_form_ode.jl`) — the matrix exponential behind the
`:linear` closed-form ODE path — had exactly two methods: `Matrix{<:AbstractFloat}`
(BLAS `exp`) and a first-order `ForwardDiff.Dual{Tg, V<:AbstractFloat, N}`
specialization built from the Padé Fréchet derivative. Anything that pushes
second-order AD through the path produces `Dual{..., Dual{...}}` matrices, which
match neither method:

- `Laplace`/`FOCEI` with `closed_form = :all` on a genuinely `:linear` system (e.g. a
  bidirectional 2-compartment model) — the inner Hessian dies with a `MethodError` at
  fit time.
- `compute_uq(res; method = :wald)` on a fit that ran through that path (SAEM fits
  fine at first order, then its Wald UQ crashes with the same `MethodError`).

## Fix

One method, reusing the machinery the `:expm` covariance transform already ships
(PR #78):

```julia
_cf_matexp(M::AbstractMatrix{<:Real}) = _matexp(M)
```

`_matexp` (`src/utils/ParameterTranformations.jl`) is a scaling-and-squaring Padé
(Higham degree 13) written with only `+`, `*`, `\`, `I`, so it propagates
derivatives at arbitrary `Dual` nesting depth. The existing `Matrix{<:AbstractFloat}`
and single-level-`Dual` methods are strictly more specific and remain untouched, so
neither the Float64 hot path nor first-order AD changes at all.

## Verification

Derivative correctness (not just absence of a `MethodError`), `f(p) = ⟨w, vec(_cf_matexp(A(p)·Δ))⟩`
on a 3×3 augmented 2-compartment matrix, cross-checked against `FiniteDifferences.central_fdm(5, 1)`:

| check | max abs error |
|---|---|
| `ForwardDiff.gradient` vs FD gradient | 3.0e-13 |
| `ForwardDiff.hessian` vs FD Jacobian of the AD gradient | 4.5e-13 |
| Hessian symmetry | 1.1e-16 |
| nested-Dual value vs Float64 `exp` | 2.2e-16 |
| nested-Dual 1st partial vs the single-Dual Fréchet method | 2.2e-16 |

Issue acceptance criteria, 2-compartment linear model (`D(x1) ~ -(k10·exp(η) + k12)·x1 + k21·x2`,
`D(x2) ~ k12·x1 - k21·x2`, RE on clearance), Laplace:

- before: `MethodError: no method matching _cf_matexp(::Matrix{ForwardDiff.Dual{...Dual...}})`
- after: fit completes; objective `-26.601093` (`:all`) vs `-26.601171` (`:off`), rel. diff 3e-6;
  free params agree to 3.5e-4 relative; log-likelihood at identical parameters agrees to
  9e-7 relative (isolates the solve from optimizer noise).
- `compute_uq(res_all; method = :wald)` succeeds.

Regression tests added to `test/closed_form_ode_tests.jl` (nested-Dual `_cf_matexp`
correctness + the `closed_form = :all` Laplace fit and its Wald UQ):

```
NL_TEST_FILES="closed_form_ode_tests.jl" julia --project -e 'using Pkg; Pkg.test()'
→ 52 passed, 0 failed (3m09s)
```

Formatted with JuliaFormatter v1 (`format(["src", "test"]) == true`, no other files touched).

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
