### PR TITLE
fix: GHQuadrature integrated against the prior, not the posterior

### DIFF
--- a/src/estimation/ghquadrature.jl
+++ b/src/estimation/ghquadrature.jl
@@ -30,8 +30,12 @@ Approximates the batch marginal likelihood via
     log L_batch ≈ signed_logsumexp_r [ log|W_r| + Σᵢ ℓᵢ(μ + Lzᵣ, θ) ]
 
 where `{(zᵣ, Wᵣ)}` are Smolyak–Gauss-Hermite quadrature nodes/weights at the
-requested `level`.  Unlike `Laplace`, there is no inner optimization during the
-forward pass: the objective is fully differentiable by `AutoForwardDiff`.
+requested `level`.  The rule is *adaptive* for Gaussian random effects: like
+`Laplace` it solves for the empirical-Bayes mode of each batch, then centers and
+whitens the nodes there.  Non-Gaussian random effects keep the prior-centered
+transport-map rule, which needs a higher `level` for the same accuracy.
+`level = 1` is a single-node rule whose value is the Laplace approximation but
+whose gradient is not; use `Laplace()` for that, and `level ≥ 3` here.
 
 # Keyword Arguments
 - `level = 3`: Smolyak accuracy level.  May be:
@@ -122,7 +126,7 @@ end
 # ---------------------------------------------------------------------------
 
 """
-    _ghq_batch_ll(dm, info, θu_re, const_cache, ll_cache, level) -> T
+    _ghq_batch_ll(dm, info, θu_re, const_cache, ll_cache, level, b_star = nothing) -> T
 
 Evaluate the batch marginal log-likelihood using the sparse grid at `level`.
 
@@ -130,6 +134,9 @@ Evaluate the batch marginal log-likelihood using the sparse grid at `level`.
 - `level::NamedTuple`: anisotropic — maps RE name to level; RE groups not
   mentioned default to level 1.  The batch grid is the tensor product of
   per-RE-group Smolyak grids.
+- `b_star`: precomputed empirical-Bayes mode for this batch (adaptive
+  quadrature).  `nothing` solves for it here; pass a warm-started mode when the
+  caller already runs an EBE pass over all batches.
 
 For batches with `n_b == 0` (all RE are constant), returns the sum of
 individual conditional log-likelihoods directly.
@@ -139,7 +146,8 @@ function _ghq_batch_ll(dm::DataModel,
         θu_re::ComponentArray,
         const_cache::REConstantsCache,
         ll_cache::_LLCache,
-        level)   # Int or NamedTuple
+        level,   # Int or NamedTuple
+        b_star = nothing)
     T = eltype(θu_re)
     if get_n_b(info) == 0
         # All RE are constant — no integration needed.
@@ -167,7 +175,9 @@ function _ghq_batch_ll(dm::DataModel,
     # parameters hit numerical limits (e.g. Beta with α→0 due to underflow).
     # Treat these as invalid parameter regions and return -Inf.
     re_measure = try
-        build_re_measure_from_batch(info, θu_re, const_cache, dm, ll_cache)
+        m = build_re_measure_from_batch(info, θu_re, const_cache, dm, ll_cache)
+        mc = _ghq_adaptive_measure(dm, info, θu_re, const_cache, ll_cache, m, b_star)
+        mc === nothing ? m : mc
     catch e
         e isa DomainError && return T(-Inf)
         rethrow(e)
@@ -176,6 +186,48 @@ function _ghq_batch_ll(dm::DataModel,
     const_ll = _const_re_prior_logf(dm, info, θu_re, const_cache, ll_cache)
     (!isfinite(ghq_ll) || !isfinite(const_ll)) && return T(-Inf)
     return ghq_ll + T(const_ll)
+end
+
+# Empirical-Bayes mode of one batch, standalone (own single-slot EBE cache, cold start).
+function _ghq_bstar_batch(dm::DataModel, info::REBatchInfo, θ_val::ComponentArray,
+        const_cache::REConstantsCache, ll_cache::_LLCache)
+    cache = _init_laplace_eval_cache(1, Float64)
+    _laplace_compute_bstar_batch!(cache, 1, dm, info, θ_val, const_cache, ll_cache)
+    b = cache.bstar_cache.b_star[1]
+    return isempty(b) ? nothing : b
+end
+
+"""
+    _ghq_adaptive_measure(dm, info, θu_re, const_cache, ll_cache, prior_measure, b_star)
+
+Upgrade a prior-centered batch measure to the adaptive (AGHQ) one: nodes centered
+at the empirical-Bayes mode and whitened by the posterior curvature there.
+
+This is what makes the rule usable. Centered on the prior, the integrand is a
+likelihood bump far narrower than the prior, and the signed Smolyak weights make
+the estimate oscillate and drift *away* from the true integral as the level rises,
+regularly turning the batch marginal negative (issue #98). Centered on the mode it
+converges at level 1-3.
+
+Returns `nothing` (keep the prior-centered measure) when the batch is not purely
+Gaussian — `CenteredREMeasure` places nodes anywhere in ℝ^n_b, which only stays
+inside the random-effect support when every RE in the batch is `Normal`/`MvNormal`
+— or when the mode/curvature is unavailable.
+"""
+function _ghq_adaptive_measure(dm::DataModel, info::REBatchInfo,
+        θu_re::ComponentArray, const_cache::REConstantsCache, ll_cache::_LLCache,
+        prior_measure::AbstractREMeasure, b_star)
+    prior_measure isa GaussianRE || return nothing
+    # b*, H and S are frozen w.r.t. the outer AD: at a converged rule the value no
+    # longer depends on where the nodes sit, so the dropped ∂/∂b*, ∂/∂S terms are of
+    # the order of the quadrature error. `θ_prior` keeps the RE-prior term of the
+    # correction differentiable in θ.
+    θ_val = _laplace_floatize(θu_re)
+    b = b_star === nothing ?
+        _ghq_bstar_batch(dm, info, θ_val, const_cache, ll_cache) : b_star
+    (b === nothing || length(b) != get_n_b(info)) && return nothing
+    return build_centered_re_measure(b, info, 1, θ_val, const_cache, dm, ll_cache;
+        θ_prior = θu_re)
 end
 
 """
@@ -325,6 +377,18 @@ function _fit_model_scalar(dm::DataModel, method::GHQuadrature, args...;
         θu = inv_transform(θt_full)
         θu_re = _symmetrize_psd_params(θu, get_fixed(get_model(dm)))
 
+        # One warm-started EBE pass per θ feeds the adaptive quadrature centers; the
+        # per-batch fallback inside `_ghq_batch_ll` would cold-start every solve.
+        bstars = _laplace_get_bstar!(ebe_cache, dm, batch_infos,
+            _laplace_floatize(θu_re), const_cache, ll_cache;
+            optimizer = inner_opts.optimizer,
+            optim_kwargs = inner_opts.kwargs,
+            adtype = inner_opts.adtype,
+            grad_tol = inner_opts.grad_tol,
+            multistart = multistart_opts,
+            rng = rng,
+            serialization = serialization)
+
         total = if ll_cache isa AbstractVector
             results = Vector{T}(undef, length(batch_infos))
             bad = Threads.Atomic{Bool}(false)
@@ -339,7 +403,7 @@ function _fit_model_scalar(dm::DataModel, method::GHQuadrature, args...;
                         continue
                     end
                     bll = _ghq_batch_ll(dm, batch_infos[bi], θu_re, const_cache,
-                        cache_c, method.level)
+                        cache_c, method.level, bstars[bi])
                     if bll == -Inf
                         Threads.atomic_or!(bad, true)
                         results[bi] = zero(T)
@@ -354,8 +418,9 @@ function _fit_model_scalar(dm::DataModel, method::GHQuadrature, args...;
             sum(results)
         else
             s = zero(T)
-            for info in batch_infos
-                bll = _ghq_batch_ll(dm, info, θu_re, const_cache, ll_cache, method.level)
+            for (bi, info) in enumerate(batch_infos)
+                bll = _ghq_batch_ll(dm, info, θu_re, const_cache, ll_cache,
+                    method.level, bstars[bi])
                 bll == -Inf && return infT
                 s += bll
             end

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -2641,7 +2641,9 @@ function _fit_laplace_family(dm::DataModel, method, hmode::_HessMode, args, fit_
 end
 
 @inline _laplace_value(x) = x
-@inline _laplace_value(x::ForwardDiff.Dual) = ForwardDiff.value(x)
+# Recursive: a Hessian pass hands down Dual-over-Dual, and peeling one level only
+# still leaves a `Float64(::Dual)` for the caller.
+@inline _laplace_value(x::ForwardDiff.Dual) = _laplace_value(ForwardDiff.value(x))
 
 function _laplace_floatize(θ::ComponentArray)
     eltype(θ) === Float64 && return θ

--- a/src/estimation/remeasure.jl
+++ b/src/estimation/remeasure.jl
@@ -578,6 +578,11 @@ and scaling by the inverse Cholesky of the negative log-posterior Hessian at b*.
 Returns `nothing` if the Cholesky factorization of `-H` fails (e.g. due to a
 near-flat or indefinite Hessian). The caller is responsible for handling this case,
 for example by falling back to a sampling-based marginal likelihood estimator.
+
+`θ_prior` supplies the parameters used inside the prior term of the correction. It
+defaults to `θu` and only differs on the AD path, where `θu` is the Float64 value
+(b*, H and S are frozen w.r.t. the outer derivative) while `θ_prior` still carries
+the `Dual` tags the gradient has to flow through.
 """
 function build_centered_re_measure(
         b_star::AbstractVector,
@@ -588,7 +593,8 @@ function build_centered_re_measure(
         dm::DataModel,
         ll_cache::_LLCache;
         jitter::Float64 = 1e-6,
-        max_tries::Int = 6
+        max_tries::Int = 6,
+        θ_prior::ComponentArray = θu
 )
     # Always work in Float64: SAEM stores eb_modes as Float32, and the Hessian
     # computation promotes to Float64 regardless, so T must be Float64.
@@ -613,7 +619,8 @@ function build_centered_re_measure(
     issuccess(cS) || return nothing
     S = LowerTriangular(Matrix(cS.L))
     log_det_S = -sum(log, diag(L))  # |det S| = 1/sqrt(det(-H)) either way
-    re_prior_logf = b -> _re_prior_logf_batch(dm, batch_info, θu, b, const_cache, ll_cache)
+    re_prior_logf = b -> _re_prior_logf_batch(
+        dm, batch_info, θ_prior, b, const_cache, ll_cache)
     return CenteredREMeasure(b_star, S, T(log_det_S), re_prior_logf, get_n_b(batch_info))
 end
 

--- a/test/estimation_ghquadrature_tests.jl
+++ b/test/estimation_ghquadrature_tests.jl
@@ -1631,8 +1631,9 @@ end
         res_g = fit_model(dm, NoLimits.GHQuadrature(level = 5); kw...)
 
         @test isfinite(get_objective(res_g))
-        p_l = get_params(res_l; scale = :untransformed)
-        p_g = get_params(res_g; scale = :untransformed)
+        # qualified: MCMCChains also exports get_params, ambiguous when batched
+        p_l = NoLimits.get_params(res_l; scale = :untransformed)
+        p_g = NoLimits.get_params(res_g; scale = :untransformed)
         # This model is linear-Gaussian, so Laplace is exact and adaptive
         # quadrature must reproduce it at any level.
         @test isapprox(p_g.σ, p_l.σ; rtol = 0.02)

--- a/test/estimation_ghquadrature_tests.jl
+++ b/test/estimation_ghquadrature_tests.jl
@@ -987,10 +987,10 @@ end  # @testset "GHQuadrature mcmc_refit UQ"
     @testset "EnsembleThreads matches EnsembleSerial objective" begin
         res_serial = fit_model(
             dm_par, GHQuadrature(level = 2; optim_kwargs = (maxiters = 2,));
-            serialization = EnsembleSerial())
+            serialization = NoLimits.EnsembleSerial())
         res_threaded = fit_model(
             dm_par, GHQuadrature(level = 2; optim_kwargs = (maxiters = 2,));
-            serialization = EnsembleThreads())
+            serialization = NoLimits.EnsembleThreads())
 
         # Objectives should agree within numerical tolerance (same deterministic quadrature)
         @test abs(get_objective(res_serial) - get_objective(res_threaded)) < 1.0
@@ -1545,5 +1545,98 @@ end  # @testset "get_loglikelihood_quadrature MC sampling"
         @test isapprox(A, I(size(A, 1)); rtol = 1e-6, atol = 1e-6)
         # the determinant was already right with the wrong factor, so assert the shape
         @test isapprox(rm.S * rm.S', inv(-H); rtol = 1e-6, atol = 1e-8)
+    end
+end
+
+# Issue #98: the quadrature was centered on the RE prior, whose scale is far wider
+# than the batch posterior. The signed Smolyak weights then drift away from the
+# integral as the level rises and regularly flip the batch marginal negative,
+# which the caller turns into -Inf (objective Inf, singular Wald Hessian, no
+# recovery). The rule is now centered on the EB mode.
+@testset "GHQuadrature is adaptive (issue #98)" begin
+    ri_model = @Model begin
+        @fixedEffects begin
+            a = RealNumber(2.0)
+            b = RealNumber(-0.5)
+            σ = RealNumber(0.3, scale = :log)
+            Ω = RealPSDMatrix([0.4 0.15; 0.15 0.25], scale = :cholesky)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η = RandomEffect(MvNormal(zeros(2), Ω); column = :ID)
+        end
+        @formulas begin
+            mu = (a + η[1]) + (b + η[2]) * t
+            y ~ Normal(mu, σ)
+        end
+    end
+
+    ts = collect(range(0.0, 2.0; length = 8))
+    function _ri_df(nid)
+        rng = Xoshiro(1)
+        Ω = [0.4 0.15; 0.15 0.25]
+        ID = String[]
+        T = Float64[]
+        Y = Float64[]
+        for i in 1:nid
+            e = rand(rng, MvNormal(zeros(2), Ω))
+            for tt in ts
+                push!(ID, "s$i")
+                push!(T, tt)
+                push!(Y, (2.0 + e[1]) + (-0.5 + e[2]) * tt + 0.3 * randn(rng))
+            end
+        end
+        return DataFrame(ID = ID, t = T, y = Y)
+    end
+
+    @testset "batch marginal matches the exact linear-Gaussian value" begin
+        dm = DataModel(ri_model, _ri_df(6); primary_id = :ID, time_col = :t)
+        fe = NoLimits.get_fixed(NoLimits.get_model(dm))
+        θ = NoLimits.get_θ0_untransformed(fe)
+        θ_re = NoLimits._symmetrize_psd_params(θ, fe)
+        _, infos, cc = NoLimits._build_re_batch_infos(dm, NamedTuple())
+        cache = NoLimits.build_ll_cache(dm; force_saveat = true)
+        cache = cache isa AbstractVector ? cache[1] : cache
+
+        # y_i ~ N(a .+ b .* t, σ²I + Z Ω Z') for this model, so the marginal is exact.
+        Z = hcat(ones(length(ts)), ts)
+        V = Symmetric(0.3^2 * Matrix(I, length(ts), length(ts)) +
+                      Z * [0.4 0.15; 0.15 0.25] * Z')
+        rows = NoLimits.get_row_groups(dm).obs_rows
+        for bi in 1:3
+            inds = NoLimits.get_inds(infos[bi])
+            @test length(inds) == 1
+            y = NoLimits.get_df(dm).y[rows[only(inds)]]
+            exact = logpdf(MvNormal(2.0 .- 0.5 .* ts, V), Vector{Float64}(y))
+            for level in (3, 5)
+                bll = NoLimits._ghq_batch_ll(dm, infos[bi], θ_re, cc, cache, level)
+                @test isfinite(bll)
+                @test isapprox(bll, exact; rtol = 1e-5)
+            end
+        end
+    end
+
+    @testset "fit recovers what Laplace recovers, with a finite objective" begin
+        dm = DataModel(ri_model, _ri_df(30); primary_id = :ID, time_col = :t)
+        θ0 = NoLimits.get_θ0_untransformed(NoLimits.get_fixed(ri_model))
+        θ0 = ComponentArray(copy(θ0), getaxes(θ0))
+        θ0.a = 1.0
+        θ0.b = 0.0
+        θ0.σ = 1.0
+        θ0.Ω = [1.0 0.0; 0.0 1.0]
+        kw = (; theta_0_untransformed = θ0, serialization = NoLimits.EnsembleSerial())
+        res_l = fit_model(dm, NoLimits.Laplace(); kw...)
+        res_g = fit_model(dm, NoLimits.GHQuadrature(level = 5); kw...)
+
+        @test isfinite(get_objective(res_g))
+        p_l = get_params(res_l; scale = :untransformed)
+        p_g = get_params(res_g; scale = :untransformed)
+        # This model is linear-Gaussian, so Laplace is exact and adaptive
+        # quadrature must reproduce it at any level.
+        @test isapprox(p_g.σ, p_l.σ; rtol = 0.02)
+        @test isapprox(p_g.Ω, p_l.Ω; rtol = 0.15)
+        @test isapprox(get_objective(res_g), get_objective(res_l); rtol = 1e-4)
     end
 end


### PR DESCRIPTION
Closes #98

## Root cause

`GHQuadrature` built its batch quadrature measure with `build_re_measure_from_batch`,
which centers and scales the Smolyak grid by the **random-effects prior**. For any
batch carrying real information the posterior is far narrower than the prior, and a
signed sparse-grid rule on that integrand does not converge - it oscillates and drifts
*away* from the integral as the level rises, and the signed sum regularly comes out
negative. `batch_loglik_ghq` maps a negative sum to `-Inf`, so the fit objective becomes
`Inf`.

Meanwhile `get_marginal_likelihood` / `get_loglikelihood_quadrature` already used the
adaptive measure (`build_centered_re_measure`, mode-centered and curvature-whitened).
That mismatch is exactly the reported "objective is `Inf` while `get_marginal_likelihood`
at the same estimate is finite".

## Numerical isolation

2-dim random-intercept+slope model, 8 obs/subject, truth `a=2, b=-0.5, sigma=0.3,
Omega=[0.4 0.15; 0.15 0.25]`. One batch at the true theta. The model is linear-Gaussian,
so the marginal is available in closed form: **-4.2159**.

| integrator | value |
|---|---|
| prior-centered Smolyak, level 1 | -3.6053 |
| prior-centered Smolyak, level 3 | -3.4011 |
| prior-centered Smolyak, level 5 | **negative sum** |
| prior-centered Smolyak, level 9 | **negative sum** |
| prior-centered Smolyak, level 13 | **negative sum** |
| full tensor GH, 41 nodes/dim (1681 nodes) | -4.1944 |
| adaptive (mode-centered), level 1 / 3 / 5 | -4.2385 (identical to 15 digits) |
| Monte Carlo, 1e6 prior draws | -4.2439 |

The Smolyak rule itself is **not** the defect: it reproduces the Gaussian moments
exactly at the expected levels (`∫1=1`, `∫z²=1`, `∫z⁴=3`, `∫z₁⁴z₂⁴=9` from level 5).
Non-adaptive Gauss-Hermite simply needs ~40 nodes per dimension here, which a sparse
grid never delivers.

## Fix

- `_ghq_batch_ll` now upgrades a purely-Gaussian batch measure to the adaptive
  (AGHQ) one: nodes centered at the batch empirical-Bayes mode, whitened by the
  posterior curvature. The pieces already existed - this reuses
  `_laplace_compute_bstar_batch!` and `build_centered_re_measure`.
- `b*`, `H` and `S` are frozen with respect to the outer derivative. At a converged
  rule the value no longer depends on where the nodes sit, so the dropped
  `∂/∂b*` and `∂/∂S` terms are of the order of the quadrature error. The RE-prior
  term of the correction keeps the `Dual` tags, via a new `θ_prior` keyword on
  `build_centered_re_measure`.
- The fit objective runs one warm-started EBE pass per theta and hands the modes down;
  every other caller falls back to a per-batch cold solve, so the fix reaches
  **Wald UQ, profile UQ, `ghq_marginal` and the dev-API primitives** without touching
  those call sites.
- `src/estimation/laplace.jl` (one line, kept deliberately minimal - #115 is being
  worked on separately in that file): `_laplace_value` is recursive. A Hessian pass
  hands down `Dual`-over-`Dual`, and peeling a single level still left a
  `Float64(::Dual)` for `_laplace_floatize`. That is what made the ForwardDiff Hessian
  in `compute_uq` fall back to finite differences.

## Verification

120 subjects x 8 obs, identical data and identical start (`a=1, b=0, sigma=1, Omega=I`):

| | objective | a | b | sigma | Omega |
|---|---|---|---|---|---|
| Laplace | 573.2683 | 1.9889 | -0.5523 | 0.3120 | [0.392 0.1774; 0.1774 0.2161] |
| GHQ level 5 **before** | `Inf` | 1.0 | 0.0 | 1.0 | I (never left the start) |
| GHQ level 5 **after** | 573.2683 | 1.9889 | -0.5523 | 0.3120 | [0.392 0.1774; 0.1774 0.2161] |

Against the acceptance list in the issue:

- [x] recovery matches Laplace - to machine precision (relative difference 0.0 on
  every parameter; the model is linear-Gaussian, so Laplace is exact and adaptive
  quadrature must reproduce it). `sigma` sits 4% from the simulation truth on this
  draw and **Laplace is off by the same 4%**, i.e. that residual is the finite-sample
  error of the dataset, not method bias.
- [x] `get_objective` of a converged fit is finite (was `Inf`).
- [x] `compute_uq(res; method = :wald)` succeeds (was `SingularException(1)`).
- [x] permuted / relabelled run: `dObj = 0.0` exactly (was `NaN`).
- [x] no more "batch marginal likelihood estimate is negative" warnings on this model.

Tests: `NL_TEST_FILES="estimation_ghquadrature_tests.jl"` green (new testset 19/19),
`api_primitives_tests.jl,uq_tests.jl` green.

## Not fixed by this PR

- **Non-Gaussian random effects** keep the prior-centered transport-map rule, so
  the same divergence remains there. `CenteredREMeasure` places nodes anywhere in
  R^n_b, which only stays inside the RE support when every RE in the batch is
  `Normal`/`MvNormal`; the guard is explicit. If the stress-suite models that still
  warn have `LogNormal`/`Beta`/flow REs, they will need a z-space adaptive rule.
- **`level = 1`** is a single-node rule whose *value* is the Laplace approximation
  but whose *gradient* is not (the frozen `log|det S|` contributes nothing), so it
  converges elsewhere than `Laplace()`. Documented in the docstring; use `Laplace()`
  or `level >= 3`.
- Verified against a self-built replica of the M03 anchor model, not the stress
  suite's own data - re-running `NoLimitsStressTests` is worthwhile before closing.

Kept disjoint from #123 (grid-size guard); the two touch different regions of
`ghquadrature.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
