### PR TITLE
fix: MCMC/VI get_params dropped vector/matrix fixed-effect blocks (#99)

### DIFF
--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -516,10 +516,26 @@ function _res_constants_re(res::FitResult, constants_re::NamedTuple)
     return constants_re
 end
 
+# Chain-based fits (MCMC/VI) run no optimizer, so their point-estimate slot starts empty.
+# Fill it with the posterior mean of the fixed effects — the point estimate every
+# downstream consumer of `get_params` needs. Constants come from the fit's own kwargs;
+# they are pinned, not sampled, so they are never looked up in the chain.
+function _with_posterior_params(res::FitResult, dm::DataModel; rng::AbstractRNG)
+    θ_u, _ = _posterior_fixed_means(
+        res, dm; rng = rng, overrides = _fit_kw(res, :constants, NamedTuple()))
+    fe = get_fixed(get_model(dm))
+    params = FitParameters(get_transform(fe)(θ_u), θ_u)
+    s = get_summary(res)
+    summary = FitSummary(s.objective, s.converged, params, s.notes)
+    return FitResult(get_method(res), get_result(res), summary, get_diagnostics(res),
+        get_data_model(res), get_fit_args(res), get_fit_kwargs(res))
+end
+
 """
     get_params(res::FitResult; scale=:both) -> FitParameters or ComponentArray
 
-Return the estimated parameter vector.
+Return the estimated parameter vector. For chain-based fits (`MCMC`/`VI`) this is the
+posterior mean of the fixed effects.
 
 # Keyword Arguments
 - `scale::Symbol = :both`: which scale to return.

--- a/src/estimation/mcmc_turing.jl
+++ b/src/estimation/mcmc_turing.jl
@@ -102,11 +102,11 @@ Bayesian estimator into the same first-class `FitResult` a built-in `MCMC` fit r
 posterior-predictive plotting, and `summarize` (which reports `inference: bayesian`) all work.
 The estimator brings its own `chain`; this only packages it - it does not run a sampler.
 
-Mirrors the built-in MCMC path exactly: the point-estimate slot is empty (so `get_params`
-returns empty - posterior summaries come from the chain via `summarize`/`compute_uq`), and
-`observed` defaults to the model's observed-outcome columns. Pass `n_adapt` when the chain
-still contains adaptation draws - summaries and chain UQ drop that many warm-up rows by
-default. `fit_kwargs` (e.g. `(constants = …,)`) is stored on the result so `compute_uq`
+Mirrors the built-in MCMC path exactly: the point-estimate slot is filled with the
+posterior mean of the fixed effects (richer posterior summaries come from the chain via
+`summarize`/`compute_uq`), and `observed` defaults to the model's observed-outcome
+columns. Pass `n_adapt` when the chain still contains adaptation draws - summaries and
+chain UQ drop that many warm-up rows by default. `fit_kwargs` (e.g. `(constants = …,)`) is stored on the result so `compute_uq`
 resolves the same settings the fit used. Dispatch is on the `chain` argument, so the
 frequentist `build_fit_result(dm, method, θ; kind=…)` is unaffected.
 """
@@ -117,12 +117,28 @@ function build_fit_result(dm::DataModel, method::FittingMethod, chain::MCMCChain
         store_data_model::Bool = true,
         fit_args::Tuple = (), fit_kwargs = NamedTuple())
     result = MCMCResult(chain, sampler, n_samples, notes, observed)
-    summary = FitSummary(NaN, missing,
+    summary = FitSummary(_mcmc_objective(chain, n_adapt), missing,
         FitParameters(ComponentArray(), ComponentArray()), notes)
     diagnostics = FitDiagnostics(
         (;), (sampler = sampler,), (n_samples = n_samples, n_adapt = n_adapt), notes)
-    return FitResult(method, result, summary, diagnostics,
+    res = FitResult(method, result, summary, diagnostics,
         store_data_model ? dm : nothing, fit_args, fit_kwargs)
+    return _with_posterior_params(res, dm; rng = Random.default_rng())
+end
+
+# Objective for a posterior chain: the mean negative log posterior density over the
+# post-warmup draws, so `get_objective` keeps the "lower is better" sign convention of
+# the optimization methods. NaN when the sampler records no log-density column.
+function _mcmc_objective(chain::MCMCChains.Chains, n_adapt::Integer)
+    internals = MCMCChains.names(chain, :internals)
+    key = :lp in internals ? :lp : (:logjoint in internals ? :logjoint : nothing)
+    key === nothing && return NaN
+    arr = Array(getfield(MCMCChains.get(chain, key), key))
+    vals = ndims(arr) == 1 ? reshape(arr, :, 1) : arr
+    n_iter = size(vals, 1)
+    rows = (min(Int(n_adapt), n_iter - 1) + 1):n_iter
+    finite = filter(isfinite, vec(vals[rows, :]))
+    return isempty(finite) ? NaN : -mean(finite)
 end
 
 @inline function _mcmc_sampler_kind(sampler)
@@ -539,12 +555,13 @@ function _fit_model(dm::DataModel, method::MCMC, args...;
     chain = Turing.sample(rng, model, sampler, n_samples; adapt = n_adapt, turing_kwargs...)
 
     obs = get_df(dm)[:, get_obs_cols(dm)]
-    summary = FitSummary(NaN, missing,
+    summary = FitSummary(_mcmc_objective(chain, n_adapt), missing,
         FitParameters(ComponentArray(), ComponentArray()),
         NamedTuple())
     diagnostics = FitDiagnostics(
         (;), (sampler = sampler,), (n_samples = n_samples, n_adapt = n_adapt), NamedTuple())
     result = MCMCResult(chain, sampler, n_samples, NamedTuple(), obs)
-    return FitResult(method, result, summary, diagnostics,
+    res = FitResult(method, result, summary, diagnostics,
         store_data_model ? dm : nothing, args, fit_kwargs)
+    return _with_posterior_params(res, dm; rng = rng)
 end

--- a/src/estimation/vi_turing.jl
+++ b/src/estimation/vi_turing.jl
@@ -118,19 +118,27 @@ function _vi_converged(
     return maximum(deltas) <= atol + rtol * scale
 end
 
-function _vi_coord_names(varinfo)
+function _vi_coord_names(varinfo, θ0_u::ComponentArray)
     # DynamicPPL >=0.41 removed `syms`, the `varinfo.metadata` layout, and `varinfo[vn]`.
     # Build per-coordinate names from `keys(varinfo)` (the VarNames, in VarInfo order)
     # expanded by each variable's internal (flattened) length — matching the flat order
-    # AdvancedVI uses for the variational parameters.
+    # AdvancedVI uses for the variational parameters. Array-valued blocks are spelled
+    # with their Cartesian index ("Ω[1,1]"), the coordinate-key convention every chain
+    # consumer looks up; `getindex_internal` flattens column-major, as does
+    # `CartesianIndices`.
     names = Symbol[]
     for vn in keys(varinfo)
-        val = DynamicPPL.getindex_internal(varinfo, vn)
-        n = length(val)
+        base = string(vn)
+        n = length(DynamicPPL.getindex_internal(varinfo, vn))
+        sym = Symbol(base)
+        val = hasproperty(θ0_u, sym) ? getproperty(θ0_u, sym) : nothing
         if n == 1
-            push!(names, Symbol(string(vn)))
+            push!(names, sym)
+        elseif val isa AbstractArray && length(val) == n
+            for idx in CartesianIndices(val)
+                push!(names, Symbol(base, "[", join(Tuple(idx), ","), "]"))
+            end
         else
-            base = string(vn)
             for i in 1:n
                 push!(names, Symbol(base, "[", i, "]"))
             end
@@ -148,19 +156,20 @@ function _vi_unlink_draws(res::VIResult, linked::AbstractMatrix)
     model = res.model
     vil = DynamicPPL.link(DynamicPPL.VarInfo(model), model)
     ks = collect(keys(vil))
-    out = similar(linked)
-    @inbounds for r in axes(linked, 1)
+    out = nothing
+    for r in axes(linked, 1)
         z = collect(@view linked[r, :])
         vn = DynamicPPL.invlink!!(DynamicPPL.unflatten!!(deepcopy(vil), z), model)
-        pos = 1
+        vals = Float64[]
         for k in ks
-            for x in DynamicPPL.getindex_internal(vn, k)
-                out[r, pos] = x
-                pos += 1
-            end
+            append!(vals, DynamicPPL.getindex_internal(vn, k))
         end
+        # The constrained space can be wider than the linked one (a PSD block links to
+        # its n(n+1)/2 free coordinates), so size the output from the unlinked row.
+        out === nothing && (out = Matrix{Float64}(undef, size(linked, 1), length(vals)))
+        out[r, :] .= vals
     end
-    return out
+    return out === nothing ? linked : out
 end
 
 function sample_posterior(res::VIResult; n_draws::Int = 1000,
@@ -297,7 +306,7 @@ function _fit_model(dm::DataModel, method::VI, args...;
         trace, max_iter; window = conv_window, rtol = conv_rtol, atol = conv_atol)
 
     varinfo = DynamicPPL.VarInfo(model)
-    coord_names = _vi_coord_names(varinfo)
+    coord_names = _vi_coord_names(varinfo, get_θ0_untransformed(fe))
     obs = get_df(dm)[:, get_obs_cols(dm)]
     summary = FitSummary(final_elbo, converged,
         FitParameters(ComponentArray(), ComponentArray()),
@@ -312,6 +321,7 @@ function _fit_model(dm::DataModel, method::VI, args...;
             convergence_atol = conv_atol))
     result = VIResult(posterior, trace, state, n_iter, max_iter, final_elbo, converged,
         NamedTuple(), obs, coord_names, model)
-    return FitResult(method, result, summary, diagnostics,
+    res = FitResult(method, result, summary, diagnostics,
         store_data_model ? dm : nothing, args, fit_kwargs)
+    return _with_posterior_params(res, dm; rng = rng)
 end

--- a/src/plotting/plotting.jl
+++ b/src/plotting/plotting.jl
@@ -385,16 +385,32 @@ function _mcmc_param_means(chain::Chains;
     return Dict{Symbol, Float64}((names_all[i] => means[i]) for i in eachindex(names_all))
 end
 
+# Probe `lookup` with every accepted spelling of a coordinate key (see
+# `_chain_key_variants`), so MCMCChains' "name[1, 1]" matches the flat "name[1,1]".
+@inline function _lookup_coord(lookup, key::AbstractString)
+    for k in _chain_key_variants(key)
+        v = lookup(k)
+        v === nothing || return v
+    end
+    return nothing
+end
+
 # Reconstruct a fixed-effect ComponentArray coordinate-by-coordinate. `lookup(key)`
 # maps a coordinate key string ("name" for scalars, "name[i,j]" for array elements) to
 # its value, or `nothing` when absent — in which case the initial value is used and a
-# `source`-tagged warning is emitted. Shared by the MCMC/VI mean and draw paths.
-function _coordwise_fixed_from_means(dm::DataModel, source::AbstractString, lookup)
+# `source`-tagged warning is emitted. Names in `overrides` bypass the lookup (constants
+# never appear in a chain). Shared by the MCMC/VI mean and draw paths.
+function _coordwise_fixed_from_means(dm::DataModel, source::AbstractString, lookup;
+        overrides::NamedTuple = NamedTuple())
     fe_names = get_names(get_fixed(get_model(dm)))
     θ0_u = get_θ0_untransformed(get_fixed(get_model(dm)))
     pairs = Pair{Symbol, Any}[]
     for name in fe_names
-        v = lookup(string(name))
+        if haskey(overrides, name)
+            push!(pairs, name => getfield(overrides, name))
+            continue
+        end
+        v = _lookup_coord(lookup, string(name))
         if v !== nothing
             push!(pairs, name => v)
         else
@@ -403,7 +419,7 @@ function _coordwise_fixed_from_means(dm::DataModel, source::AbstractString, look
                 vals = similar(val0, Float64)
                 for idx in CartesianIndices(val0)
                     idx_txt = join(Tuple(idx), ",")
-                    ve = lookup(string(name, "[", idx_txt, "]"))
+                    ve = _lookup_coord(lookup, string(name, "[", idx_txt, "]"))
                     if ve !== nothing
                         vals[idx] = ve
                     else
@@ -458,12 +474,14 @@ end
 function _mcmc_fixed_means(res::FitResult,
         dm::DataModel;
         max_draws::Int = typemax(Int),
-        rng::AbstractRNG = Random.default_rng())
+        rng::AbstractRNG = Random.default_rng(),
+        overrides::NamedTuple = NamedTuple())
     chain = get_chain(res)
     n_adapt = _mcmc_warmup(res)
     means = _mcmc_param_means(chain; n_adapt = n_adapt, max_draws = max_draws, rng = rng)
     θ = _coordwise_fixed_from_means(dm, "MCMC chain",
-        key -> (sym = Symbol(key); haskey(means, sym) ? means[sym] : nothing))
+        key -> (sym = Symbol(key); haskey(means, sym) ? means[sym] : nothing);
+        overrides = overrides)
     return θ, chain
 end
 
@@ -483,21 +501,26 @@ end
 function _vi_fixed_means(res::FitResult,
         dm::DataModel;
         max_draws::Int = typemax(Int),
-        rng::AbstractRNG = Random.default_rng())
+        rng::AbstractRNG = Random.default_rng(),
+        overrides::NamedTuple = NamedTuple())
     means = _vi_param_means(res; max_draws = max_draws, rng = rng)
     θ = _coordwise_fixed_from_means(dm, "VI posterior",
-        key -> (sym = Symbol(key); haskey(means, sym) ? means[sym] : nothing))
+        key -> (sym = Symbol(key); haskey(means, sym) ? means[sym] : nothing);
+        overrides = overrides)
     return θ, nothing
 end
 
 function _posterior_fixed_means(res::FitResult,
         dm::DataModel;
         max_draws::Int = typemax(Int),
-        rng::AbstractRNG = Random.default_rng())
+        rng::AbstractRNG = Random.default_rng(),
+        overrides::NamedTuple = NamedTuple())
     if get_result(res) isa MCMCResult
-        return _mcmc_fixed_means(res, dm; max_draws = max_draws, rng = rng)
+        return _mcmc_fixed_means(
+            res, dm; max_draws = max_draws, rng = rng, overrides = overrides)
     elseif get_result(res) isa VIResult
-        return _vi_fixed_means(res, dm; max_draws = max_draws, rng = rng)
+        return _vi_fixed_means(
+            res, dm; max_draws = max_draws, rng = rng, overrides = overrides)
     end
     return get_params(res; scale = :untransformed), nothing
 end

--- a/src/uq/common.jl
+++ b/src/uq/common.jl
@@ -113,9 +113,8 @@ end
             push!(out, idx <= layout.n ? exp(p_full[idx]) : p_full[idx])
         end
         return out
-    elseif natural &&
-           (spec.kind == :expm || spec.kind == :cholesky ||
-            (spec.kind == :lie && spec.lie === nothing)) &&
+    elseif natural && (spec.kind == :expm ||
+                       (spec.kind == :lie && spec.lie === nothing)) &&
            value isa AbstractMatrix
         n = size(value, 1)
         out = Float64[]

--- a/src/uq/common.jl
+++ b/src/uq/common.jl
@@ -113,8 +113,9 @@ end
             push!(out, idx <= layout.n ? exp(p_full[idx]) : p_full[idx])
         end
         return out
-    elseif natural && (spec.kind == :expm ||
-                       (spec.kind == :lie && spec.lie === nothing)) &&
+    elseif natural &&
+           (spec.kind == :expm || spec.kind == :cholesky ||
+            (spec.kind == :lie && spec.lie === nothing)) &&
            value isa AbstractMatrix
         n = size(value, 1)
         out = Float64[]

--- a/src/uq/mcmc.jl
+++ b/src/uq/mcmc.jl
@@ -16,7 +16,7 @@ function _chain_keys_for_free(fe::FixedEffects, free_names::Vector{Symbol})
             for k in eachindex(spec.lie.free_idx)
                 push!(out, string(name, "[", k, "]"))
             end
-        elseif (spec.kind == :expm ||
+        elseif (spec.kind == :expm || spec.kind == :cholesky ||
                 (spec.kind == :lie && spec.lie === nothing)) && v isa AbstractMatrix
             n = size(v, 1)
             for j in 1:n
@@ -56,12 +56,17 @@ function _chain_keys_for_free(fe::FixedEffects, free_names::Vector{Symbol})
     return out
 end
 
+# Accepted spellings of one coordinate key. MCMCChains prints matrix indices as
+# "Ω[1, 1]" while the package's flat-name convention writes "Ω[1,1]"; the single
+# naming authority is this variant list, used by every chain/posterior lookup.
+@inline function _chain_key_variants(key::AbstractString)
+    return (String(key), replace(key, "," => ", "), replace(key, " " => ""))
+end
+
 @inline function _lookup_chain_index(idx_map::Dict{String, Int}, key::String)
-    haskey(idx_map, key) && return idx_map[key]
-    key2 = replace(key, "," => ", ")
-    haskey(idx_map, key2) && return idx_map[key2]
-    key3 = replace(key, " " => "")
-    haskey(idx_map, key3) && return idx_map[key3]
+    for k in _chain_key_variants(key)
+        haskey(idx_map, k) && return idx_map[k]
+    end
     return 0
 end
 

--- a/test/estimation_mcmc_tests.jl
+++ b/test/estimation_mcmc_tests.jl
@@ -1,7 +1,9 @@
 using Test
 using NoLimits
+using ComponentArrays
 using DataFrames
 using Distributions
+using LinearAlgebra
 using Turing
 using MCMCChains
 using Lux
@@ -298,4 +300,48 @@ end
     @test res isa FitResult
     @test NoLimits.get_chain(res) isa MCMCChains.Chains
     @test NoLimits.get_observed(res).y == df.y
+end
+
+@testset "MCMC params keep the full fixed-effect layout (#99)" begin
+    model = @Model begin
+        @fixedEffects begin
+            β = RealVector([0.5, 0.2]; prior = MvNormal(zeros(2), LinearAlgebra.I(2)))
+            Ω = RealPSDMatrix([1.0 0.0; 0.0 1.0]; calculate_se = true,
+                prior = InverseWishart(4.0, Matrix(1.0 * LinearAlgebra.I, 2, 2)))
+            σ = RealNumber(0.5; scale = :log, prior = LogNormal(0.0, 0.5))
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η = RandomEffect(MvNormal(zeros(2), Ω); column = :ID)
+        end
+        @formulas begin
+            mu = β[1] + η[1] + (β[2] + η[2]) * t
+            y ~ Normal(mu, σ)
+        end
+    end
+
+    df = DataFrame(ID = repeat(1:4, inner = 3), t = repeat([0.0, 1.0, 2.0], 4),
+        y = [1.0, 1.4, 2.1, 0.8, 1.5, 2.4, 1.2, 1.7, 2.0, 0.9, 1.3, 1.9])
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+
+    logger = Test.TestLogger()
+    res = Base.CoreLogging.with_logger(logger) do
+        fit_model(dm,
+            NoLimits.MCMC(; sampler = MH(),
+                turing_kwargs = (n_samples = 30, n_adapt = 5, progress = false)))
+    end
+    @test !any(r -> occursin("missing fixed effect", r.message), logger.logs)
+
+    θ = NoLimits.get_params(res; scale = :untransformed)
+    res_l = fit_model(dm, NoLimits.Laplace())
+    @test ComponentArrays.labels(θ) ==
+          ComponentArrays.labels(NoLimits.get_params(res_l; scale = :untransformed))
+    @test all(isfinite, θ)
+    @test isfinite(NoLimits.get_objective(res))
+
+    # Same chain-key layout feeds chain UQ (#100): 2 β + 3 Ω cholesky coords + σ.
+    uq = compute_uq(res; method = :chain, mcmc_draws = 10, rng = Random.Xoshiro(99))
+    @test length(get_uq_parameter_names(uq)) == 6
 end


### PR DESCRIPTION
Closes #99
Closes #100

## Root cause

Two independent defects in the same chain-key ↔ fixed-effect-layout machinery:

1. **`get_params` was empty for every chain fit.** `MCMC` and `VI` built their
   `FitSummary` with `FitParameters(ComponentArray(), ComponentArray())` and never
   filled it, so `get_params(res)` returned nothing at all — hence the
   `UndefVarError`/`FieldError` from `complete_data_loglikelihood`, the
   "theta_untransformed is missing parameter …" from `simulate_data`, and the NaN
   objective.
2. **The coordinate reconstruction was mis-keyed for array blocks.**
   `_coordwise_fixed_from_means` probed `"Ω[1,1]"`, but MCMCChains spells matrix
   coordinates `"Ω[1, 1]"` (with a space). Every matrix element missed, fell back to
   its initial value, and emitted one "missing fixed effect element" warning — the
   6,016-warning storm. On the VI side the same family had two more bugs:
   `_vi_unlink_draws` sized its output matrix from the *linked* width under
   `@inbounds` (silently truncating constrained draws whenever a bijector changes
   dimension, e.g. a PSD block), and `_vi_coord_names` spelled array blocks with a
   flat index (`Ω[3]`) instead of the Cartesian coordinate key.

Additionally, `:cholesky` — the default `RealPSDMatrix` scale — was missing from the
triangular branches of `_chain_keys_for_free` and `_coords_for_param`, so a
cholesky-scaled matrix produced `n²` natural-scale coordinates against `n(n+1)/2`
transformed ones. That is exactly the `Internal UQ error: chain-key layout does not
match fixed-effect layout` of #100.

## Fix

Everything lands at the shared points; no second naming scheme was introduced.

- `src/uq/mcmc.jl`: `_chain_key_variants` is now the single authority on accepted
  coordinate-key spellings. `_lookup_chain_index` (UQ) and the new `_lookup_coord`
  (reconstruction) both route through it.
- `src/plotting/plotting.jl`: `_coordwise_fixed_from_means` probes every variant, and
  gained an `overrides` keyword so pinned constants are taken from the fit's own
  kwargs rather than looked up in a chain that never contains them (otherwise the fix
  would have introduced a fresh warning storm for `constants`).
- `src/estimation/common.jl`: `_with_posterior_params` fills the point-estimate slot
  from `_posterior_fixed_means` — the helper that already existed for plotting. Used by
  the `MCMC` fit path, the `VI` fit path, and `build_fit_result(dm, method, chain)`.
- `src/estimation/mcmc_turing.jl`: `_mcmc_objective` reports the mean negative log
  posterior density over the post-warmup draws (`lp`, falling back to `logjoint`), so
  `get_objective` keeps the "lower is better" convention instead of returning NaN.
- `src/estimation/vi_turing.jl`: `_vi_unlink_draws` sizes its output from the unlinked
  row; `_vi_coord_names` emits Cartesian coordinate keys for array blocks.
- `src/uq/{mcmc,common}.jl`: `:cholesky` added to the two triangular branches.

## Verification

Repro model: `RealVector` + `RealPSDMatrix` (default `:cholesky`) + `RealNumber`, with
a 2-d MvNormal random effect. Before the fix: 4 warnings per reconstruction, empty
`get_params`, NaN objective, and both UQ calls erroring.

#99's acceptance criteria, after:

```
warnings 'missing fixed effect': 0
labels equal Laplace:            true
objective finite:                true
complete_data_loglikelihood:     -15.69
simulate_data rows:              12
```

#100's two acceptance criteria — **both verified**:

```
compute_uq(res_mcmc; method = :chain)       -> [:β_1, :β_2, :Ω_1_1, :Ω_2_1, :Ω_2_2, :σ]
compute_uq(res_laplace; method = :mcmc_refit,
           mcmc_turing_kwargs = (n_samples = 300, n_adapt = 150, progress = false))
    -> same 6 coordinates; natural-scale intervals contain the estimates: true
```

i.e. intervals for every `calculate_se = true` coordinate including the 3 Ω cholesky
coordinates, so `Closes #100` is included.

New regression test (`test/estimation_mcmc_tests.jl`, tiny MH sampler): on a
vector+matrix model, `ComponentArrays.labels(get_params(res; scale = :untransformed))`
equals the Laplace fit's labels, zero "missing fixed effect" warnings,
`get_objective` finite, and chain UQ returns all 6 coordinates.

Test files run through the `Pkg.test` sandbox, all green:

- `estimation_mcmc_tests.jl` — 35/35
- `estimation_vi_tests.jl` — 19/19
- `uq_tests.jl` — 154/154
- `estimation_mcmc_re_tests.jl,serialization_tests.jl,summaries_fit_uq_tests.jl,api_primitives_tests.jl` — 235/235
- `integration_plotting.jl,vpc_tests.jl,residual_plots_tests.jl,uq_edge_cases_tests.jl,aqua_tests.jl` — 18/18 (3 batches)

JuliaFormatter v1 (sciml, pinned scratch env): no diff on untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
