### PR TITLE
fix: constants_re fits broke get_residuals / plot_fits / predict

### DIFF
--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -508,12 +508,15 @@ function Base.show(io::IO, ::MIME"text/plain", res::FitResult)
     print(io, _nl_fitresult_show_line(res))
 end
 
-function _res_constants_re(res::FitResult, constants_re::NamedTuple)
+# Constants inherited from the fit. Pass `dm` when it may differ from the fitted data
+# (predict/plot on new data): levels that data lacks are dropped instead of throwing.
+function _res_constants_re(res::FitResult, constants_re::NamedTuple,
+        dm::Union{Nothing, DataModel} = nothing)
     isempty(constants_re) || return constants_re
-    if haskey(get_fit_kwargs(res), :constants_re)
-        return getfield(get_fit_kwargs(res), :constants_re)
-    end
-    return constants_re
+    haskey(get_fit_kwargs(res), :constants_re) || return constants_re
+    inherited = getfield(get_fit_kwargs(res), :constants_re)
+    dm === nothing && return inherited
+    return _normalize_constants_re(dm, inherited; strict = false)
 end
 
 """
@@ -1393,6 +1396,9 @@ end
 
 function _resolve_bstars_for_re(dm::DataModel, res::FitResult, constants_re::NamedTuple;
         θ = nothing, rng::AbstractRNG = Random.default_rng())
+    # The stored EB modes were computed with the fit's constants_re; the batch layout
+    # must match them, so inherit it when the caller passed none.
+    constants_re = _res_constants_re(res, constants_re)
     if get_result(res) isa FrequentistREResult || get_result(res) isa GHQuadratureResult
         θu = θ === nothing ? get_params(res; scale = :untransformed) : θ
         ode_args = _fit_kw(res, :ode_args, ())
@@ -1811,7 +1817,7 @@ function reestimate_ebes(dm::DataModel,
         ebe_rescue_multistart_k, ebe_rescue_max_rounds,
         ebe_rescue_grad_tol, ebe_rescue_multistart_sampling)
     θu = get_params(res; scale = :untransformed)
-    constants_re = _res_constants_re(res, constants_re)
+    constants_re = _res_constants_re(res, constants_re, dm)
     if get_result(res) isa SAEMResult
         constants_re = _saem_anneal_constants_re(
             dm, θu, _saem_anneal_names(res), constants_re)

--- a/src/estimation/re_batch.jl
+++ b/src/estimation/re_batch.jl
@@ -10,7 +10,8 @@ struct REConstantsCache{M, S, V}
     scalar_vals::S
     vector_vals::V
 end
-function _normalize_constants_re(dm::DataModel, constants_re::NamedTuple)
+function _normalize_constants_re(dm::DataModel, constants_re::NamedTuple;
+        strict::Bool = true)
     isempty(constants_re) && return NamedTuple()
     re_names = get_re_names(dm.model.random.random)
     isempty(re_names) && return NamedTuple()
@@ -43,8 +44,13 @@ function _normalize_constants_re(dm::DataModel, constants_re::NamedTuple)
                     break
                 end
             end
-            matched ||
-                error("constants_re for $(re) includes level $(k) not found in column $(col). The value must be present in that column.")
+            # `strict = false` (constants inherited from a fit, applied to other data)
+            # skips a level this data lacks; the constant simply has nothing to pin.
+            if !matched
+                strict &&
+                    error("constants_re for $(re) includes level $(k) not found in column $(col). The value must be present in that column.")
+                @warn "constants_re for $(re) includes level $(k), which is absent from column $(col); ignoring it." maxlog=1
+            end
         end
         push!(pairs, re => dict)
     end
@@ -52,6 +58,9 @@ function _normalize_constants_re(dm::DataModel, constants_re::NamedTuple)
 end
 
 function _build_constants_cache(dm::DataModel, constants_re::NamedTuple)
+    # Normalize here (idempotent) so callers holding the raw user-facing
+    # `constants_re` — level keys as Symbols, data levels as Strings — still match.
+    constants_re = _normalize_constants_re(dm, constants_re)
     cache = dm.re_group_info.laplace_cache
     cache === nothing && return REConstantsCache(
         BitVector[], Vector{Vector{Float64}}(), Vector{Vector{Vector{Float64}}}())

--- a/src/plotting/plotting.jl
+++ b/src/plotting/plotting.jl
@@ -993,7 +993,7 @@ function build_plot_cache(res::FitResult;
     dm === nothing && (dm = get_data_model(res))
     dm === nothing &&
         error("This fit result does not store a DataModel; pass dm=... to build_plot_cache.")
-    constants_re = _res_constants_re(res, constants_re)
+    constants_re = _res_constants_re(res, constants_re, dm)
 
     if _is_posterior_draw_fit(res)
         mcmc_draws >= 1 || error("mcmc_draws must be >= 1.")

--- a/src/plotting/plotting_residuals.jl
+++ b/src/plotting/plotting_residuals.jl
@@ -307,7 +307,7 @@ function get_residuals(res::FitResult;
         rng::AbstractRNG = Random.default_rng(),
         return_draw_level::Bool = false)
     dm = _get_dm(res, dm)
-    constants_re_use = _res_constants_re(res, constants_re)
+    constants_re_use = _res_constants_re(res, constants_re, dm)
     residual_list = _validate_residual_metrics(residuals)
     obs_list = _resolve_residual_observables(dm, observables)
     inds = _resolve_individuals(dm, individuals_idx; default_all = true)

--- a/test/residual_plots_tests.jl
+++ b/test/residual_plots_tests.jl
@@ -47,6 +47,45 @@ end
     @test plot_residuals(res) !== nothing
 end
 
+# Regression for #106: string-valued RE levels (Symbol keys in constants_re) broke
+# every downstream consumer of a constants_re fit; new data lacking the level must
+# ignore that constant rather than error.
+@testset "constants_re with string levels: residuals and predict" begin
+    model = @Model begin
+        @fixedEffects begin
+            a = RealNumber(0.1)
+            σ = RealNumber(0.3, scale = :log)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η = RandomEffect(Normal(0.0, 0.5); column = :ID)
+        end
+        @formulas begin
+            y ~ Normal(a + η + 0.2 * t, σ)
+        end
+    end
+    df = DataFrame(ID = repeat(["id_001", "id_002", "id_003"], inner = 2),
+        t = repeat([0.0, 1.0], outer = 3),
+        y = [0.1, 0.3, 0.0, 0.25, 0.15, 0.35])
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+    res = fit_model(dm, NoLimits.Laplace(; optim_kwargs = (maxiters = 2,));
+        constants_re = (; η = (; id_001 = 0.0)),
+        serialization = NoLimits.EnsembleSerial())
+
+    η_df = get_random_effects(res).η
+    @test η_df[η_df.ID .== "id_001", :η_1][1] == 0.0
+    @test nrow(get_residuals(res)) == nrow(df)
+
+    df_wo = df[df.ID .!= "id_001", :]
+    for mode in (:population, :ebe, :reestimate, :marginal)
+        @test nrow(NoLimits.predict(res, df; re_mode = mode)) == nrow(df)
+        # The pinned level is absent here — it must be ignored, not fatal.
+        @test nrow(NoLimits.predict(res, df_wo; re_mode = mode)) == nrow(df_wo)
+    end
+end
+
 @testset "residuals MCMC summary and draw-level outputs" begin
     res = fx_mcmc()                       # shared no-RE MCMC fit
     df = fx_nore_df()


### PR DESCRIPTION
Closes #106

## Root cause

Two independent defects, both hit only when a fit used `constants_re`.

**(a) "level not found" on the same DataModel - a key-normalization bug.**
`_normalize_constants_re` maps the user-facing level keys (Symbols) onto the actual
values of the grouping column (Strings, Symbols, Ints, ...). `_build_constants_cache`
then looks levels up in `LaplaceREIndex.level_to_index`, a `Dict{eltype(column), Int}`,
so it is only correct on an *already normalized* map. `eta_from_modes` (common.jl) hands
it the raw `constants_re` straight from the fit kwargs, so with a `String` ID column the
Symbol key `:id_001` never matches and it threw

```
constants_re for η includes level id_001 not found in column ID.
```

on the very data the fit succeeded on. Every downstream consumer routes through
`eta_from_modes` via `build_plot_cache` -> `_default_random_effects`, hence
`get_residuals`, `plot_fits` and `predict(:reestimate)` all failed. It escaped the suite
because the `constants_re` fixtures use Symbol-valued grouping columns, where the raw
keys happen to match.

Fix: normalize inside `_build_constants_cache` (idempotent - a normalized map passes
through unchanged), so every caller is covered by one guard rather than four.

**(b) BoundsError in `predict(:marginal)` / `predict(:ebe)` - inherited constants dropped.**
`_resolve_bstars_for_re` used the `constants_re` its caller passed, and `predict` passes
its own keyword, which defaults to empty. The stored EB modes, however, were computed
*with* the fit's `constants_re`: the pinned level's batch has `n_b = 0`. Rebuilding the
batch layout without the constants made the layout claim slots the modes do not have, so
indexing them threw `BoundsError` (0-element vector for the scalar case, index 6 of a
5-element vector on the crossed design). Fix: inherit the fit's `constants_re` inside
`_resolve_bstars_for_re`.

**(c) Policy: a level absent from new data was fatal.** `predict(res, newdata)` inherits
the fit's `constants_re`, but new data may legitimately not contain the pinned level.
`_normalize_constants_re` gained `strict::Bool = true`; `_res_constants_re` takes the
target `DataModel` and re-normalizes inherited constants with `strict = false`, dropping
absent levels with a `@warn` (`maxlog = 1`). An explicitly passed unknown level still
errors, so `test/estimation_laplace_tests.jl` "Laplace batching with constant RE levels"
keeps its `@test_throws`.

## Fix

- `src/estimation/re_batch.jl` - `_build_constants_cache` normalizes its input;
  `_normalize_constants_re(...; strict)`.
- `src/estimation/common.jl` - `_res_constants_re(res, constants_re, dm = nothing)`
  filters inherited constants against `dm`; `_resolve_bstars_for_re` inherits the fit's
  constants; `reestimate_ebes` passes its `dm`.
- `src/plotting/plotting.jl`, `src/plotting/plotting_residuals.jl` - pass `dm` to
  `_res_constants_re` (`build_plot_cache`, `get_residuals`), the two entry points where
  the data can differ from the fitted data.

## Verification

Reproduced first on the base commit with a Laplace fit using
`constants_re = (; η = (; id_001 = [0.0, 0.0]))` on a String-ID column, and with the
crossed variant `(; η_rater = (; R1 = 0.0))`. Before: `get_residuals` and
`predict(:reestimate)` threw the level-not-found error, `predict(:marginal)` (scalar) and
`predict(:ebe)` (crossed) threw `BoundsError`. After: `get_random_effects`,
`get_residuals` and all four `predict` re_modes run, on data both containing and lacking
the pinned level (the latter warns once and ignores it).

Test files run in this worktree, all green:

- `residual_plots_tests.jl` (86), `estimation_laplace_tests.jl` (72)
- `plotting_functions_tests.jl` + `plot_random_effects_tests.jl` (147),
  `estimation_cv_tests.jl` (70)
- `estimation_mcmc_re_tests.jl` (run together with the Laplace file in an earlier round)

New regression test in `test/residual_plots_tests.jl`: a Laplace fit with
`constants_re` on string levels - the pinned η is 0, `get_residuals` covers every row,
and all four `predict` re_modes run on data with and without the pinned level.

Formatted with JuliaFormatter v1 (pinned scratch env); no unrelated files touched.

## Overlap

Touches `src/estimation/common.jl`, which #101 (PR #134) also touches - the changes here
are confined to `_res_constants_re` / `_resolve_bstars_for_re` / `reestimate_ebes` and do
not go near `_cdll_terms` / `build_eta_i`. The `:marginal` BoundsError fixed here is the
constants-layout mismatch described in (b), not #103's posterior/prior draw bug (PR #129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
