### PR TITLE
ci: weekly fresh-install check against the registered version

### DIFF
--- a/.github/workflows/RegistryInstall.yml
+++ b/.github/workflows/RegistryInstall.yml
@@ -1,0 +1,34 @@
+name: Registry install
+
+# CI builds the working tree, whose [compat] is whatever Project.toml says today.
+# The version already published to the General registry keeps the bounds it was
+# registered with, so an upstream release can break `Pkg.add("NoLimits")` while
+# every PR stays green (see #133: Optimization 5.7 dropped the SciMLBase
+# re-export that LikelihoodProfiler 1.x relies on). This job installs the
+# PUBLISHED package into a clean environment and loads it.
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  install:
+    name: fresh install of the registered version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: julia-actions/setup-julia@v3
+        with:
+          # Latest release, not the pinned CI version: a new user gets whatever
+          # is current. Revisit if julia compat is widened (#37).
+          version: "1"
+      # No checkout and no cache on purpose: this must resolve against the
+      # registry exactly as a new user's machine would.
+      - name: Pkg.add and load
+        run: |
+          julia --color=yes -e '
+            using Pkg
+            Pkg.activate(; temp = true)
+            Pkg.add("NoLimits")
+            Pkg.status()
+            using NoLimits
+            @info "loaded NoLimits" version = pkgversion(NoLimits)'


### PR DESCRIPTION
## Why

CI builds the working tree, whose `[compat]` is whatever `Project.toml` says today. The version already published to the General registry keeps the bounds it was registered with, permanently. So an upstream release can break `Pkg.add("NoLimits")` for every new user while every PR stays green.

That is not hypothetical - it is #133. `Optimization` 5.7.0 dropped the `SciMLBase` re-export that `LikelihoodProfiler` 1.x depends on. `main` was capped the same week (`be2b7876`), but the registered 0.2.0 still resolves to the broken combination and fails to precompile. Nothing in CI does what a new user does.

## What

One scheduled job (weekly, plus `workflow_dispatch`) that installs the **published** package into a clean temp environment and loads it. Deliberately no `actions/checkout` and no `julia-actions/cache`, so it resolves against the registry exactly as a fresh machine would.

Julia `"1"` rather than the CI-pinned 1.12, since a new user gets whatever is current; worth revisiting if julia compat is widened (#37).

## Verification

Not vacuous - running the job's commands locally today reproduces the #133 failure, so the job goes red on the bug it exists to catch:

```
ERROR: LoadError: UndefVarError: `SciMLBase` not defined in `LikelihoodProfiler`
in expression starting at .../NoLimits/Kjinj/src/uq/profile.jl:1
in expression starting at .../NoLimits/Kjinj/src/NoLimits.jl:1
```

It will keep failing until 0.2.1 is released with the existing cap - which is the actual fix for #133.

Refs #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)