### PR TITLE
docs+test: permutation invariance is per-individual exact; fit divergence on pathological data is conditioning (Refs #116)

### DIFF
--- a/docs/src/estimation/index.md
+++ b/docs/src/estimation/index.md
@@ -65,6 +65,23 @@ Several keyword arguments are shared across methods (though not all apply to eve
 - `PooledMap` requires a prior on at least one fixed effect.
 - `MCEM` and `SAEM` do not incorporate fixed-effect priors in their objective.
 
+## Reproducibility and Individual Order
+
+Every per-individual quantity - the conditional log-likelihood, the empirical Bayes mode, the per-individual Laplace/FOCEI marginal and its analytic gradient - is computed from that individual's own data alone and is keyed by identity, not by row position. Permuting the individuals in the data frame or relabeling their IDs therefore leaves each per-individual term bitwise unchanged, and refitting the same `DataModel` with the same `rng` and the same `serialization` reproduces a previous fit exactly.
+
+What a permutation does change is the order in which those terms are added into the population objective and gradient. Floating-point addition is not associative, so the sums can differ in their last bits: relative differences at the 1e-16 level. A gradient-based optimizer amplifies that seed, taking slightly different steps and stopping at a slightly different point.
+
+How large the amplification gets depends on the conditioning of the data. On well-scaled data it stays negligible. On badly conditioned data - observation times spanning many orders of magnitude, responses spanning several orders, very ragged numbers of observations per individual - the objective is nearly flat around the optimum and the difference becomes visible in the reported estimates. Measured with `Laplace` on 120 individuals (permuted and relabeled, `EnsembleSerial()`):
+
+| Quantity, original vs. permuted | Well-scaled data | Badly conditioned data |
+| --- | --- | --- |
+| per-individual terms and EB modes | bitwise equal | bitwise equal |
+| objective and gradient at a fixed θ | ≤ 1e-15 relative | ≤ 1e-15 relative |
+| fitted objective | 5.1e-11 relative | 7.0e-11 relative |
+| fitted parameters | 3.6e-7 relative | 1.9e-5 relative |
+
+The guarantee is therefore: exact permutation invariance of every per-individual quantity, invariance of the population objective and gradient up to floating-point summation order, and invariance of the fitted parameters only up to the conditioning of the problem. To check permutation invariance sharply, compare the objective and gradient at a fixed θ rather than the fitted values. When comparing whole fits, choose a tolerance that reflects the data: 1e-6 relative on the parameters is realistic for well-scaled data, while badly conditioned data can need 1e-4 or looser.
+
 ## Multistart Wrapper
 
 For optimization-based methods, the solution found can depend on the initial parameter values. `Multistart` addresses this sensitivity by running multiple fits from different starting points and selecting the best result:

--- a/test/api_primitives_tests.jl
+++ b/test/api_primitives_tests.jl
@@ -279,6 +279,42 @@ struct APITestBayes <: NoLimits.FittingMethod end
             dm, θhat, 1; serialization = NoLimits.EnsembleSerial()) isa ComponentArray
     end
 
+    # Issue #116: per-individual quantities must key off identity, not row position, so
+    # permuting/relabelling individuals may only change the order of the outer sum.
+    @testset "per-individual terms are position-independent" begin
+        df = fx_re_df()
+        ids = unique(df.ID)
+        perm = [4, 1, 6, 2, 5, 3]
+        subs = DataFrame[]
+        for (j, p) in enumerate(perm)
+            sub = df[df.ID .== ids[p], :]
+            sub.ID = fill("P$j", nrow(sub))
+            push!(subs, sub)
+        end
+        dfp = reduce(vcat, subs)
+        model = fx_re_model()
+        dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+        dmp = DataModel(model, dfp; primary_id = :ID, time_col = :t)
+        θ = NoLimits.get_θ0_untransformed(NoLimits.get_fixed(model))
+        ctx = NoLimits.build_fit_context(dm)
+        ctxp = NoLimits.build_fit_context(dmp)
+        infos = NoLimits.get_batch_infos(ctx)
+        infosp = NoLimits.get_batch_infos(ctxp)
+        bs = NoLimits.empirical_bayes(ctx, θ)
+        bsp = NoLimits.empirical_bayes(ctxp, θ)
+        @test length(infosp) == length(infos)
+        # batch order need not follow individual order: match batches through the
+        # individual each one holds, mapped back through the permutation.
+        batch_of = Dict(first(NoLimits.get_inds(infos[i])) => i for i in eachindex(infos))
+        lm(d, c, info, b) = NoLimits.laplace_marginal(
+            d, θ, info, b; const_cache = c.const_cache, cache = c.cache)
+        for j in eachindex(infosp)
+            i = batch_of[perm[first(NoLimits.get_inds(infosp[j]))]]
+            @test bsp[j] == bs[i]
+            @test lm(dmp, ctxp, infosp[j], bsp[j]) === lm(dm, ctx, infos[i], bs[i])
+        end
+    end
+
     @testset "quadrature marginal / Fisher info / posterior sampling" begin
         dm = fx_re_dm()
         θ = NoLimits.get_θ0_untransformed(NoLimits.get_fixed(NoLimits.get_model(dm)))


### PR DESCRIPTION
Refs #116.

Verdict: **(a) benign floating-point summation-order sensitivity, amplified through the optimizer by ill-conditioned data.** No correctness bug, no source change. Recommended resolution of #116 is to relax the stress-suite gate for pathological-data models (numbers below).

## Evidence

Own pathological fixture (no ODE, 120 individuals, 859 rows, times `1.0e-3 .. 5.0e3`, `|y|` over ~3.5 orders, 30% single-observation ids, one 300-observation id, `y ~ Normal(exp(a+η)*exp(-k*t), σa + σp*|μ|)`), permuted individual order plus relabeled string IDs, `EnsembleSerial()`, `-t 1`.

**1. Objective at a fixed θ.** Per-individual Laplace marginals and EB modes, matched by ID:

```
per-individual term max |Δ|:  0.000e+00     (120/120 bitwise equal)
per-individual EB mode:                     (120/120 bitwise equal)
naive sum orig     : -1585.150506876339
naive sum permuted : -1585.150506876339     rel Δ 0.0
```

Repeated at 6 further random θ: terms and modes bitwise equal at every one; the summed objective differs by `0.0 .. 4.2e-16` relative. Reference scale `n·eps·Σ|terms| = 4.3e-11`, so the observed sums are well inside reassociation noise.

**2. Gradient at a fixed θ** (the analytic gradient the fit actually uses, `_laplace_grad_batch`):

```
per-individual gradient max |Δ| (matched by ID): 0.000e+00
summed gradient max rel Δ: 1.19e-15   (across 7 θ points: 3.3e-16 .. 7.7e-16)
```

**3. Compensated summation.** Since the per-individual terms are *bitwise identical* in both orders, the compensated-summation check degenerates to its strongest form: Kahan sums agree exactly, and so do sums taken in |value| order. The only order effect is the accumulation itself.

**4. The fits nevertheless diverge** (same fixture, same serial path):

| | dObj (rel) | dParam (rel) | iterations |
| --- | --- | --- | --- |
| Laplace | 7.0e-11 | **1.9e-5** | 25 vs 28 |
| FOCEI | 5.5e-10 | 2.9e-6 | 28 vs 26 |

**5. Conditioning is the discriminator.** The same model and code path on well-scaled data (times 0.5..10, `|y|` ~ one order, 6 obs/id):

```
well-scaled : dObj 5.1e-11, dParam 3.6e-7   (passes 1e-8 / 1e-6)
pathological: dObj 7.0e-11, dParam 1.9e-5   (fails 1e-6)
```

This reproduces the issue's M03-passes / M18-fails pattern with nothing changed but the data conditioning.

**6. Flatness at the optimum.** At the two Laplace solutions: `‖Δθ‖₂ = 2.6e-5` on the transformed scale moves the objective by `1.1e-7` absolute (`8e-11` relative). Both points sit inside the optimizer's own stopping region on a flat valley; the parameter gap carries no information the objective can resolve.

**Conclusion.** A `1e-16` reassociation seed in the gradient is amplified ~1e10 by the L-BFGS trajectory (different steps, different stopping iterate) on a nearly flat, badly conditioned objective. That is an ill-conditioned optimization, not an order dependence in the model: nothing per-individual leaks, no index is built from position.

## What is in this PR

- `docs/src/estimation/index.md`: a "Reproducibility and Individual Order" section stating exactly what NoLimits guarantees (exact per-individual invariance; population objective/gradient invariant up to summation order; fitted parameters invariant only up to conditioning) with the measured numbers and the advice to check invariance at a fixed θ.
- `test/api_primitives_tests.jl`: a small regression guard that permutes and relabels individuals and asserts the EB modes and per-individual Laplace marginals are bitwise equal when matched by identity. This is the property that would silently break if someone ever cached per-individual state by position.

No source change. Compensated summation of the per-individual terms was considered and dropped: it is not order-exact either, so it would not make a fit permutation-invariant, and it would add code to the accumulation loops for nothing.

## Recommended gate for the stress suite

Keep `1e-8` relative objective / `1e-6` relative parameters for well-scaled models. For pathological-data models, either

- move the permutation check to a **fixed θ** (objective and gradient), where the gate can be tight, `1e-12` relative, and is exact in practice (measured `≤ 1e-15`); or
- keep it on the fit and relax to **`1e-3` relative objective / `1e-4` relative parameters**, which clears the reported M18 values (5.1e-4 / 6.3e-6) and my measured 1.9e-5 with margin, while still catching a genuine order bug (which shows up as a per-individual difference orders of magnitude larger).

## Coordination

Touches no file under `src/`, so no overlap with the concurrent #115 (threaded Laplace/FOCEI) work or PR #136 in `src/estimation/laplace.jl`. All measurements here are single-threaded and `EnsembleSerial()`, so threading is a separate axis and is deliberately not claimed in the doc note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
