### PR TITLE
Investigate #115: threaded objective divergence is a harness seed confound, not a package bug

### DIFF
--- a/test/estimation_laplace_tests.jl
+++ b/test/estimation_laplace_tests.jl
@@ -1,5 +1,6 @@
 using Test
 using DataFrames
+using DataInterpolations
 using NoLimits
 using FiniteDifferences
 using LineSearches
@@ -309,6 +310,62 @@ end
     @test rs.summary.objective == rt.summary.objective
     @test collect(NoLimits.get_params(rs, scale = :untransformed)) ==
           collect(NoLimits.get_params(rt, scale = :untransformed))
+end
+
+@testset "Laplace serial == threaded with dynamic covariates (#115)" begin
+    # Dynamic-covariate interpolants and a DE signal read per-individual state that the
+    # threaded path must not share across tasks.
+    if Threads.nthreads() < 2
+        @info "skipped: needs Threads.nthreads() > 1"
+        @test true
+        return
+    end
+    model = @Model begin
+        @fixedEffects begin
+            k = RealNumber(0.5; scale = :log)
+            α = RealNumber(0.2)
+            ω = RealNumber(0.4; scale = :log)
+            σ = RealNumber(0.3; scale = :log)
+            σ2 = RealNumber(0.1; scale = :log)
+        end
+        @covariates begin
+            t = Covariate()
+            w = DynamicCovariate(; interpolation = LinearInterpolation)
+        end
+        @randomEffects begin
+            η = RandomEffect(Normal(0.0, ω); column = :ID)
+        end
+        @DifferentialEquation begin
+            s(t) = x1 / (1 + x1)
+            D(x1) ~ -k * x1 + α * w(t)
+        end
+        @initialDE begin
+            x1 = exp(η)
+        end
+        @formulas begin
+            y ~ Normal(x1(t), σ)
+            y2 ~ Normal(s(t), σ2)
+        end
+    end
+    rng = MersenneTwister(4)
+    rows = NamedTuple[]
+    for i in 1:8
+        η = 0.3 * randn(rng)
+        for tt in 0.0:0.5:2.0
+            x = exp(η - 0.4 * tt)
+            obs = tt > 0.0
+            push!(rows,
+                (; ID = "id_$i", t = tt, w = 0.5 + rand(rng),
+                    y = obs ? x + 0.2 * randn(rng) : missing,
+                    y2 = obs ? x / (1 + x) + 0.05 * randn(rng) : missing))
+        end
+    end
+    dm = DataModel(model, DataFrame(rows); primary_id = :ID, time_col = :t)
+    method = NoLimits.Laplace(; optim_kwargs = (maxiters = 3,))
+    obj(ser) = NoLimits.get_objective(
+        fit_model(dm, method; serialization = ser, rng = MersenneTwister(99)))
+    o_serial = obj(EnsembleSerial())
+    @test isapprox(obj(EnsembleThreads()), o_serial; rtol = 1e-10)
 end
 
 @testset "Laplace fit with BlackBoxOptim requires bounds" begin


### PR DESCRIPTION
Closes #115

## TL;DR

There is no threading bug behind the M12/M08/M14 numbers in #115. The stress harness fit the "threads" twin of every cell with a **different rng seed** than its serial cell, and Laplace/FOCEI legitimately depend on that seed (default `multistart_n = 50` EBE multistart, plus every cell reporting `converged: false`). With the seed held fixed, serial and `EnsembleThreads()` agree bit-for-bit.

This PR therefore changes no source. It adds the regression test that was missing so the invariant is locked.

## Evidence

**1. The harness seeds differ.** `fit_seed(k, cell.index, replicate)` folds in the cell index, and the threads twin is a separate cell. Straight from the stored cell JSONs (`results_full/`):

| cell | `data_seed` | `seed` | objective |
|---|---|---|---|
| M12 Laplace primary r0 | 20260823 | 202731**18** | -950.74 |
| M12 Laplace primary threads r0 | 20260823 | 202731**21** | 112.49 |
| M12 FOCEI primary r0 | 20260823 | 202731**23** | 451.15 |
| M12 FOCEI primary threads r0 | 20260823 | 202731**26** | 112.23 |
| M08 Laplace primary r0 | 20260819 | 202690**20** | 531.19 |
| M08 Laplace primary threads r0 | 20260819 | 202690**21** | 532.07 |
| M14 Laplace primary r0 | 20260825 | 202751**69** | 342.43 |
| M14 Laplace primary threads r0 | 20260825 | 202751**72** | 342.51 |

Same data, different rng. The premise "identical data and rng" does not hold.

**2. Fixed seed, threaded == serial.** M12-shaped reproducer (two dynamic covariates driving the DE, a DE signal, `Tsit5`, `abstol/reltol = 1e-10`, `saveat_mode = :auto`), 8 Julia threads, `OPENBLAS_NUM_THREADS=1`:

| check | serial | threaded | rel. diff |
|---|---|---|---|
| `loglikelihood` at fixed θ, η (8 threaded repeats) | -5805.723327617792 | identical | **0** |
| `laplace_marginal` + `empirical_bayes` at fixed θ (6 repeats) | -3159.461577646461 | identical | **0** |
| Laplace fit, 25 / 40 / 70 individuals | — | identical | **0** |
| FOCEI fit, 25 individuals | -301.84553597063706 | identical | **0** |

So a single fixed-θ objective evaluation does **not** diverge, and neither does a whole fit.

**3. The seed alone reproduces the effect.** Same reproducer, 70 individuals, both fits **serial**, seeds 307 vs 310: 228.7589 vs 227.6443, rel. 4.9e-3. On the real M12 (objective crossing zero between the two optima, non-converged fits) the same mechanism produces the reported rel. 1.118.

**4. M08 is the known residual.** With the seed fixed, M08 (planar-flow RE, nonlinear in η, 200 ids) still gives 578.2299 serial vs 578.2329 threaded — rel. **5.2e-6**. That is the documented intermittent nonlinear-in-η race (~1e-7 per evaluation) amplified over ~180 outer iterations, previously judged unfixable without introducing another race. Out of scope here.

## What this PR adds

One test in `test/estimation_laplace_tests.jl`: a model with a dynamic covariate inside the DE plus a DE signal must give the same Laplace objective serial and under `EnsembleThreads()` (`rtol = 1e-10`; it is exact in practice). Skipped with a note when `Threads.nthreads() == 1`.

Verified with `JULIA_NUM_THREADS=8 NL_TEST_FILES="estimation_laplace_tests.jl" julia --project -e 'using Pkg; Pkg.test()'` — 89/89 pass.

## Notes

- Disjoint from PR #136 (`fix/ghq-marginal-integrand`), which touches `src/estimation/laplace.jl`; this PR touches only `test/`.
- The pre-existing `"Laplace fit single-thread vs multithread (if available)"` testset asserts **bit** equality and failed once during this work under `Pkg.test`'s `-O0`: -28.005033710360706 (serial) vs -28.005033710360745 (threaded), rel. 1.4e-15, on a model that is linear in η. It passed on the re-run and is bit-identical at `-O2` across 4 serial and 6 threaded repeats. Flagging it as a latent flake, not touched here.
- Suggested harness fix (local-only `NoLimitsStressTests`, out of this repo): give the `threads` twin the primary cell's `fseed`, otherwise the D2 comparison keeps measuring the seed rather than the ensemble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
