### PR TITLE
release: v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.2.1
+
 ### Bug fixes
 
 - `compute_uq(res; method = :profile)` returned all-`NaN` intervals under every

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NoLimits"
 uuid = "1d491b74-35a5-408f-ae19-cf8524c3769d"
 license = "MIT"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Manuel Huth", "Jonas Arruda", "Clemens Peiter", "Roy Gusinow", "Nina Schmid", "Jan Hasenauer"]
 
 [deps]


### PR DESCRIPTION
Version bump to 0.2.1 and the changelog heading for it. No source changes.

## Why now

The published 0.2.0 does not install. It carries an uncapped `Optimization = "5.4.0"`, so a fresh `Pkg.add("NoLimits")` resolves Optimization 5.7 + LikelihoodProfiler 1.x and fails to precompile with `UndefVarError: SciMLBase not defined in LikelihoodProfiler` (#133). `main` has carried the cap since `be2b7876`, but a version already in the General registry keeps the bounds it was registered with - only a new release reaches users.

This also ships the 23 PRs merged via #143: issues #8, #98, #99, #100, #101, #102, #103, #104, #105, #106, #108, #109, #110, #111, #112, #113, #114, #117, #130, #139, plus the #115/#116 investigations.

## Contents

- `Project.toml`: `version = "0.2.0"` -> `"0.2.1"`.
- `CHANGELOG.md`: the accumulated `## Unreleased` entries are now headed `## v0.2.1`, with a fresh empty `## Unreleased` above them.

## After merge

Per the manual release procedure (TagBot cannot push tags here - the deploy key is blocked on commits touching `.github/workflows/` and `TAGBOT_PAT` is unset):

1. `@JuliaRegistrator register` on the merge commit.
2. Once the General PR merges, hand-create the annotated tag and the GitHub release at that commit, verifying the commit's tree hash against the registry's `git-tree-sha1` first.

The `Registry install` workflow added in #141 is currently red against the published 0.2.0 by design; it should go green once 0.2.1 is registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)