### PR TITLE
fix: GHQuadrature objective was order-dependent on ill-conditioned batches (#151)

### DIFF
--- a/src/estimation/ghquadrature.jl
+++ b/src/estimation/ghquadrature.jl
@@ -408,8 +408,11 @@ function _fit_model_scalar(dm::DataModel, method::GHQuadrature, args...;
             rng = rng,
             serialization = serialization)
 
-        total = if ll_cache isa AbstractVector
-            results = Vector{T}(undef, length(batch_infos))
+        # Both branches fill the same per-batch vector and reduce it with the same
+        # `sum`, so the objective is bit-identical under `EnsembleSerial` and
+        # `EnsembleThreads` instead of differing by the accumulation order (#151).
+        results = Vector{T}(undef, length(batch_infos))
+        if ll_cache isa AbstractVector
             bad = Threads.Atomic{Bool}(false)
             # Chunk-indexed cache assignment — `Threads.threadid()` indexing is
             # unsafe under task migration (two tasks could share one cache slot).
@@ -434,17 +437,15 @@ function _fit_model_scalar(dm::DataModel, method::GHQuadrature, args...;
                 end
             end
             bad[] && return infT
-            sum(results)
         else
-            s = zero(T)
             for (bi, info) in enumerate(batch_infos)
                 bll = _ghq_batch_ll(dm, info, θu_re, const_cache, ll_cache,
                     method.level, bstars[bi])
                 bll == -Inf && return infT
-                s += bll
+                results[bi] = convert(T, bll)
             end
-            s
         end
+        total = sum(results)
         return -total + convert(T, _penalty_value(θu, penalty)) +
                (extra_objective === nothing ? zero(T) : convert(T, extra_objective(θu)))
     end

--- a/src/estimation/remeasure.jl
+++ b/src/estimation/remeasure.jl
@@ -575,9 +575,10 @@ Base.eltype(::CenteredREMeasure{T}) where {T} = T
 Build a `CenteredREMeasure` for AGHQ, centering the quadrature nodes at `b_star`
 and scaling by the inverse Cholesky of the negative log-posterior Hessian at b*.
 
-Returns `nothing` if the Cholesky factorization of `-H` fails (e.g. due to a
-near-flat or indefinite Hessian). The caller is responsible for handling this case,
-for example by falling back to a sampling-based marginal likelihood estimator.
+Returns `nothing` if `-H` does not factor without jitter, i.e. if it is indefinite
+(`b_star` is not a mode). Ill-conditioning alone is fine — `S` only places the nodes.
+The caller is responsible for handling `nothing`, for example by falling back to a
+sampling-based marginal likelihood estimator.
 
 `θ_prior` supplies the parameters used inside the prior term of the correction. It
 defaults to `θu` and only differs on the AD path, where `θu` is the Float64 value
@@ -601,11 +602,15 @@ function build_centered_re_measure(
     b_star = Vector{Float64}(b_star)
     T = Float64
     H = _laplace_hessian_b(dm, batch_info, θu, b_star, const_cache, ll_cache, nothing, bi)
-    # A jitter-only-definite -H would set the quadrature scale from the regularisation;
-    # `nothing` routes the caller to MC sampling, which cannot exceed the ceiling.
-    negH_definite_without_jitter(H) || return nothing
-    chol, _ = _laplace_cholesky_negH(H; jitter = jitter, max_tries = max_tries)
-    (chol === nothing || chol.info != 0) && return nothing
+    # S only places the nodes — the change-of-variables correction compensates any
+    # invertible scaling exactly — so the admissibility test is plain definiteness of -H,
+    # not the relative-conditioning test `negH_definite_without_jitter` applies to the
+    # Laplace *value* (where 1/jitter would masquerade as a posterior variance). Rejecting
+    # a merely ill-conditioned -H sent well-behaved batches back to the prior-centered
+    # rule of issue #98, whose signed sum turns negative, which makes the objective jump
+    # to +Inf for those θ (issue #151).
+    chol, used_jitter = _laplace_cholesky_negH(H; jitter = jitter, max_tries = max_tries)
+    (chol === nothing || chol.info != 0 || !iszero(used_jitter)) && return nothing
     L = chol.L  # lower triangular, L*L' = -H
     # The struct's invariant is S*S' = (-H)^{-1}, which is what whitens the integrand
     # (S'(-H)S = I). That is the lower Cholesky factor of the INVERSE, not inv(L):

--- a/test/estimation_ghquadrature_tests.jl
+++ b/test/estimation_ghquadrature_tests.jl
@@ -1677,3 +1677,125 @@ end
         @test isapprox(get_objective(res_g), get_objective(res_l); rtol = 1e-4)
     end
 end
+
+# Issue #151: on ill-conditioned batches the adaptive rule was rejected by the
+# *Laplace* admissibility test (λmin > 1e-8·λmax), which sent those batches back to
+# the prior-centered rule of #98; its signed sum turns negative, the batch marginal
+# becomes -Inf and the whole objective +Inf. That cliff amplified the 1e-16
+# reduction-order noise of a threaded/permuted run into an O(1) objective gap.
+@testset "GHQuadrature is order-invariant on ill-conditioned data (issue #151)" begin
+    ill_model = @Model begin
+        @fixedEffects begin
+            a = RealNumber(1.0)
+            b = RealNumber(0.0)
+            σ = RealNumber(0.5, scale = :log)
+            Ω = RealPSDMatrix([0.3 0.0; 0.0 0.3], scale = :cholesky)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η = RandomEffect(MvNormal(zeros(2), Ω); column = :ID)
+        end
+        @formulas begin
+            mu = (a + η[1]) + (b + η[2]) * t
+            y ~ Normal(mu, σ)
+        end
+    end
+
+    # Mimics stress model M18: times over 1e-3..5e3, |y| over ~4 orders, 1-obs ids
+    # alongside one heavily observed id, Ω eigenvalues 0.25 vs 1e-6.
+    Ω_true = [0.25 2.0e-4; 2.0e-4 1.0e-6]
+    function _ill_df()
+        rng = Xoshiro(151)
+        L = cholesky(Symmetric(Ω_true)).L
+        rows = NamedTuple[]
+        function add!(id, n)
+            η = L * randn(rng, 2)
+            for _ in 1:n
+                t = 10.0^(rand(rng) * (log10(5000.0) + 3.0) - 3.0)
+                μ = (5.0 + η[1]) + (-0.002 + η[2]) * t
+                push!(rows, (; ID = id, t = t, y = μ + 0.3 * randn(rng)))
+            end
+        end
+        add!("id_01", 40)
+        for i in 2:9
+            add!("id_" * lpad(string(i), 2, '0'), 1)
+        end
+        for i in 10:24
+            add!("id_" * lpad(string(i), 2, '0'), 8)
+        end
+        df = DataFrame(rows)
+        return df[randperm(Xoshiro(3), nrow(df)), :]
+    end
+
+    df = _ill_df()
+    method = NoLimits.GHQuadrature(level = 3)
+
+    @testset "ill-conditioned but definite -H keeps the adaptive rule" begin
+        # One observation at a large time: -H = inv(Ω) + (1/σ²)[1 t; t t²] is positive
+        # definite but has condition number ≫ 1e8, which the Laplace test rejects.
+        df1 = DataFrame(ID = ["a"], t = [5000.0], y = [-5.0])
+        dm1 = DataModel(ill_model, df1; primary_id = :ID, time_col = :t)
+        θ0 = get_θ0_untransformed(NoLimits.get_fixed(NoLimits.get_model(dm1)))
+        θ = ComponentArray(copy(θ0), getaxes(θ0))
+        θ.σ = 0.3
+        θ.Ω = [4.0 0.0; 0.0 4.0]
+        θ_re = NoLimits.symmetrize_psd_parameters(
+            θ, NoLimits.get_fixed(NoLimits.get_model(dm1)))
+        _, infos, cc = NoLimits.build_re_batch_infos(dm1, NamedTuple())
+        cache = NoLimits.build_likelihood_cache(dm1; force_saveat = true)
+        bstars = NoLimits.empirical_bayes(dm1, θ; rng = Xoshiro(2))
+        H = NoLimits._laplace_hessian_b(dm1, infos[1], θ_re,
+            Vector{Float64}(bstars[1]), cc, cache, nothing, 1)
+        @test !NoLimits.negH_definite_without_jitter(H)   # what used to force the fallback
+        rm = NoLimits.build_centered_re_measure(
+            bstars[1], infos[1], 1, θ_re, cc, dm1, cache)
+        @test rm !== nothing
+        @test isapprox(rm.S' * (-H) * rm.S, I(2); rtol = 1e-6, atol = 1e-6)
+        @test isfinite(NoLimits._ghq_batch_ll(dm1, infos[1], θ_re, cc, cache, 3, bstars[1]))
+    end
+
+    @testset "serial == threaded" begin
+        if Threads.nthreads() < 2
+            @info "skipped: needs Threads.nthreads() > 1"
+            @test true
+            return
+        end
+        dm_s = DataModel(ill_model, df; primary_id = :ID, time_col = :t,
+            serialization = NoLimits.EnsembleSerial())
+        dm_t = DataModel(ill_model, df; primary_id = :ID, time_col = :t,
+            serialization = NoLimits.EnsembleThreads())
+        o_s = get_objective(fit_model(
+            dm_s, method; serialization = NoLimits.EnsembleSerial()))
+        o_t = get_objective(fit_model(
+            dm_t, method; serialization = NoLimits.EnsembleThreads()))
+        @test isfinite(o_s)
+        @test isapprox(o_s, o_t; rtol = 1e-6)
+    end
+
+    @testset "permuting and relabelling individuals" begin
+        dm = DataModel(ill_model, df; primary_id = :ID, time_col = :t,
+            serialization = NoLimits.EnsembleSerial())
+        ids = unique(df.ID)
+        perm = randperm(Xoshiro(7), length(ids))
+        relabel = Dict(ids[i] => "z" * lpad(string(perm[i]), 3, '0')
+        for i in eachindex(ids))
+        df2 = copy(df)
+        df2.ID = [relabel[i] for i in df.ID]
+        df2 = df2[sortperm(df2.ID), :]
+        dm2 = DataModel(ill_model, df2; primary_id = :ID, time_col = :t,
+            serialization = NoLimits.EnsembleSerial())
+        kw = (; serialization = NoLimits.EnsembleSerial())
+        res_a = fit_model(dm, method; kw...)
+        res_b = fit_model(dm2, method; kw...)
+        oa = get_objective(res_a)
+        ob = get_objective(res_b)
+        @test isfinite(oa)
+        @test abs(oa - ob) <= 1e-8 * max(abs(oa), 1.0)
+        # qualified: MCMCChains also exports get_params, ambiguous when batched
+        pa = NoLimits.get_params(res_a; scale = :untransformed)
+        pb = NoLimits.get_params(res_b; scale = :untransformed)
+        @test maximum(abs.(collect(pa) .- collect(pb))) <= 1e-6
+    end
+end


### PR DESCRIPTION
Closes #151.

## Measured mechanism

Rebuilt stress model M18 locally (150 ids, times log-spread over 1e-3..5e3, 30% one-obs
ids, one 300-obs id, `Ω` eigenvalues 0.25 vs 1e-6) and reproduced the regression on
`876485b6`: GHQ level 5, serial objective `1212.909572367665` vs threaded
`651.6318856201289` (rel 4.6e-01), with **1567** `batch marginal likelihood estimate is
negative` warnings, the serial run landing at `a = 2.28, Ω₁₁ = 7.76` (truth 5.0 / 0.25).

Two hypotheses were on the table. The numbers pick one:

**`b*` drift: refuted.** At a fixed θ, with cold caches, the batch modes are *bitwise*
identical between `EnsembleSerial()` and `EnsembleThreads()`:

| θ | max abs(b\*_serial − b\*_threaded) |
|---|---|
| θ₀ | `0.0` |
| truth | `0.0` |
| the θ the diverged serial fit ended at | `0.0` |

**Branch flipping: confirmed, and it makes the objective `+Inf`.** Per-batch branch counts
at the same three θ (`n = 150` batches, on `main`):

| θ | `-H` rejected | fell back to the prior-centered rule | batches → −Inf | objective |
|---|---|---|---|---|
| θ₀ | 0 | 0 | 0 | finite |
| truth | 0 | 0 | 0 | finite |
| diverged-serial θ | **3** | **3** | **1** | **+Inf** |

The three rejected batches are all one-observation individuals at large `t`, and their
`-H` is *perfectly positive definite* — `cholesky` succeeds, `λ = [0.129, 2.7e7]`,
`[0.129, 2.3e8]`, `[0.129, 2.4e7]`. What rejected them was
`negH_definite_without_jitter(H)` (`λmin > 1e-8·λmax`), i.e. the **conditioning** test, not
definiteness. `build_centered_re_measure` then returned `nothing`, `_ghq_adaptive_measure`
fell back to the prior-centered rule of #98, whose signed Smolyak sum came out negative for
one of them → batch marginal `-Inf` → whole objective `+Inf`.

So the GHQ objective is `+Inf` on a region of θ-space whose boundary is an exact float
predicate. The O(1) serial/threaded gap is the 1e-16 reduction-order noise being amplified
by that cliff: one run gets trapped against the barrier (`converged`, 131 iters, garbage θ),
the other walks past it. `b*` drift alone could never produce 0.46 relative.

## Fix

`negH_definite_without_jitter` is the validity condition for the Laplace *value*, where a
jitter-only-definite `-H` makes `−½logdet(-H)` measure the regularisation instead of the
data. It is the wrong test for a quadrature *measure*: `S` only places the nodes, and
`logcorrection(z) = log p(b*+Sz|θ) + log|det S| + ½‖z‖² + ½d·log(2π)` compensates any
invertible scaling exactly. So `build_centered_re_measure` now accepts every `-H` that
factors **without jitter** and only returns `nothing` for a genuinely indefinite one (`b*`
not a mode) — 2 lines.

Second, one line of symmetry: the serial branch of the objective now fills the same
per-batch vector and reduces it with the same `sum` as the threaded branch, so the two
differ by nothing at all rather than by the accumulation order.

Nothing else changes. The rule stays frozen w.r.t. the outer derivative, non-Gaussian REs
keep the prior-centered rule, `level = 1` keeps its documented caveat, and `_ghq_batch_ll`
stays the single evaluation point. The fix can only make *more* batches use the adaptive
rule, never fewer.

## Gates

**1. #98 stays fixed.** The 2-dim random-intercept+slope model (120 ids × 8 obs, `a = 2`,
`b = -0.5`, `σ = 0.3`, `Ω = [0.4 0.15; 0.15 0.25]`), `GHQuadrature(level = 5)`, three data
draws:

| seed | GHQ objective | Laplace objective | σ̂ (rel err) | max abs(GHQ − Laplace) over all params |
|---|---|---|---|---|
| 98 | `507.80744475543037` | `507.8074447501709` | 0.30085 (0.28%) | 5.1e-9 |
| 99 | `511.7658860710713` | `511.7658860416664` | 0.30517 (1.7%) | 4.5e-9 |
| 100 | `504.61200090132195` | `504.6120008857575` | 0.30563 (1.9%) | 6.8e-9 |

All finite, σ within 2%, GHQ = Laplace to 9 digits. `Ω̂`'s worst element is 15–25% off the
*truth* (seed 98: `[0.4164 0.1170; 0.1170 0.2856]`), but only 14–19% off the empirical
covariance of the 120 drawn ηs (`[0.386 0.1356; 0.1356 0.2829]`) — that is sampling noise
in the smallest element `Ω₁₂` at n = 120, and GHQ reproduces Laplace's estimate to 5e-9, so
it is not a quadrature defect. The path is also provably untouched by this PR: on this model
the old test rejected **0 of 120** batches at θ₀ and **0 of 120** at θ̂, so `build_centered_re_measure`
returns exactly what it returned before. The in-repo `"GHQuadrature is adaptive (issue #98)"`
testset (exact analytic marginals at `rtol = 1e-5`) passes unchanged.

**2. Serial == threaded** on the M18-style ill-conditioned model (`JULIA_NUM_THREADS=8`):

| | before | after |
|---|---|---|
| serial | `1212.909572367665` | `578.5592746687120` |
| threaded | `651.6318856201289` | `578.5592746687116` |
| rel gap | 4.63e-01 | **5.89e-16** |

Both now recover the truth (`a = 4.977 / 5.0`, `b = -0.002064 / -0.002`, `σ = 0.2944 / 0.3`,
`Ω = [0.2375 2.08e-4; 2.08e-4 8.78e-7]` vs `[0.25 2e-4; 2e-4 1e-6]`), parameters agreeing to
1e-9 between the two. Not bit-identical: the residual 6e-16 is the EBE inner solve, which
seeds its multistart from the passed `rng`; it is well inside the 1e-6 gate and shared with
Laplace/FOCEI.

**3. Permutation invariance** (permute individuals + relabel IDs, same model):
`578.5592746687116` vs `578.5592746687120`, rel **5.89e-16** (gate 1e-8); max parameter
difference **4.6e-11** (gate 1e-6).

**4. No warning storm.** `batch marginal likelihood estimate is negative`: **1567 → 0** over
the whole fit. `Cholesky of -H failed … falling back`: **0**. As a side effect the accessor
and the fit objective now agree — `get_marginal_likelihood(dm, res; level = 5)` returns
`-578.5592746687123` against the fit's `578.5592746687122` (1.1e-13). `get_loglikelihood_quadrature`
has its own copy of the per-batch loop, but it shares `build_centered_re_measure`, so it
inherits the fix and stops taking its MC fallback here.

## Tests

New testset `"GHQuadrature is order-invariant on ill-conditioned data (issue #151)"` in
`test/estimation_ghquadrature_tests.jl`:
- a unit test pinning the root cause: a one-observation batch at `t = 5000` whose `-H` fails
  `negH_definite_without_jitter` still gets an adaptive measure, and that measure whitens
  (`S'(-H)S = I`);
- serial vs threaded on a small M18-style dataset (guarded by `Threads.nthreads() > 1`);
- permutation + relabelling, 1e-8 on the objective and 1e-6 on the parameters.

`NL_TEST_FILES="estimation_ghquadrature_tests.jl"` → 386 pass, 0 fail (2m41s, 8 threads).
`NL_TEST_FILES="api_primitives_tests.jl,estimation_laplace_tests.jl"` → 254 pass, 0 fail.
Formatted with JuliaFormatter v1.0.62, sciml style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
