### PR TITLE
fix: Wald natural-scale vcov could be all-Inf; make the PSD UQ fixture identifiable

### DIFF
--- a/src/uq/common.jl
+++ b/src/uq/common.jl
@@ -344,6 +344,16 @@ function _sample_gaussian_draws(rng::AbstractRNG,
     return permutedims(X)
 end
 
+# A natural-scale Wald draw need not reach `Inf` to poison the summaries: a finite `1e159`
+# squares to `Inf` in the covariance sum, so an `isfinite` test alone still let
+# `get_uq_vcov()` return an all-`Inf` matrix (#159). The bound is the largest magnitude
+# whose squared deviations still sum over `n_draws` rows without overflowing; `NaN`/`Inf`
+# fail the comparison too, so this one predicate subsumes the finiteness test.
+function _wald_usable_draw_row(row, n_draws::Int)
+    lim = sqrt(floatmax(Float64) / max(n_draws, 1)) / 2
+    return all(x -> abs(x) < lim, row)
+end
+
 function _cov_from_draws(draws::Matrix{Float64})
     n, p = size(draws)
     p == 0 && return zeros(Float64, 0, 0)

--- a/src/uq/wald.jl
+++ b/src/uq/wald.jl
@@ -30,7 +30,10 @@ function _finalize_wald_uqresult(fe, θ_hat_t, θ_hat_u, free_names, active_idx,
     # (its default is `scale = :natural`) and the intervals threw on quantiles of NaN. The
     # transformed-scale covariance is unaffected and stays exact; only the natural-scale
     # summaries drop the offending rows, and the count is reported so it cannot pass unnoticed.
-    finite_rows = [all(isfinite, @view(draws_n[i, :])) for i in 1:size(draws_n, 1)]
+    # `_wald_usable_draw_row` rejects rows that are merely too large to square, not just the
+    # non-finite ones - see its definition for why an `isfinite` test alone was not enough.
+    finite_rows = [_wald_usable_draw_row(@view(draws_n[i, :]), n_draws)
+                   for i in 1:size(draws_n, 1)]
     n_nonfinite = count(!, finite_rows)
     n_nonfinite == length(finite_rows) &&
         error("Wald natural-scale summaries unavailable: all $(n_nonfinite) draws overflowed " *
@@ -54,7 +57,8 @@ function _finalize_wald_uqresult(fe, θ_hat_t, θ_hat_u, free_names, active_idx,
     intervals_n_use = ext !== nothing ? ext[4] : intervals_n
     # Covariance from the finite rows only, of whatever the stickbreak extension produced.
     Vn_src = draws_n_use !== nothing ? draws_n_use : draws_n
-    Vn_rows = [all(isfinite, @view(Vn_src[i, :])) for i in 1:size(Vn_src, 1)]
+    Vn_rows = [_wald_usable_draw_row(@view(Vn_src[i, :]), n_draws)
+               for i in 1:size(Vn_src, 1)]
     Vn_use = _cov_from_draws(all(Vn_rows) ? Vn_src : Vn_src[Vn_rows, :])
 
     diag = merge(

--- a/test/uq_tests.jl
+++ b/test/uq_tests.jl
@@ -248,7 +248,7 @@ function _uq_psd_re_model(scale::Symbol)
                 η = RandomEffect(MvNormal([0.0, 0.0], Ω); column = :ID)
             end
             @formulas begin
-                y ~ Normal(a + η[1], σ)
+                y ~ Normal(a + η[1] + η[2] * t, σ)
             end
         end
     end
@@ -265,17 +265,16 @@ function _uq_psd_re_model(scale::Symbol)
             η = RandomEffect(MvNormal([0.0, 0.0], Ω); column = :ID)
         end
         @formulas begin
-            y ~ Normal(a + η[1], σ)
+            y ~ Normal(a + η[1] + η[2] * t, σ)
         end
     end
 end
 
-# 12 subjects x 3 observations. A 2x2 random-effect covariance has 3 free coordinates and
-# cannot be identified from the 3 subjects this fixture used to carry, so its Wald Hessian was
-# near-singular by construction: the test passed only because a 2-iteration fit and the
-# unconditional Cholesky jitter together kept it away from the boundary. With the covariance
-# actually identified, the Hessian exists and the testset asserts what it is named for - that
-# Wald works in every PSD scale - rather than a knife-edge.
+# 12 subjects x 3 observations, random intercept AND random slope: with only `η[1]` in the
+# formula the second random effect never reached the likelihood, so two of the three Ω
+# coordinates were structurally unidentified and their Wald variance was ~1e12 - draws then
+# overflowed on the natural scale and `get_uq_vcov` was a coin flip on where the optimizer
+# landed (#159). Both effects must enter the observation for the covariance to be estimable.
 function _uq_psd_re_df()
     ids = [Symbol("S", i) for i in 1:12]
     y = [0.10, 0.21, 0.32, 0.02, -0.08, -0.15, 0.15, 0.19, 0.27, -0.05, 0.04, 0.11,
@@ -290,11 +289,9 @@ end
     for (scale, n_coords, seed) in ((:cholesky, 3, 31), (:expm, 3, 32), (:lie, 3, 33))
         model = _uq_psd_re_model(scale)
         dm = DataModel(model, _uq_psd_re_df(); primary_id = :ID, time_col = :t)
-        # This PSD covariance is weakly identified, so the Wald Hessian is only finite at a
-        # properly converged estimate - at a degenerate point it is NaN and `compute_uq` now
-        # says so rather than returning NaN silently. The step cap is what keeps the fit out of
-        # that region; a 2-iteration fit used to land somewhere usable only because the
-        # unconditional Hessian jitter was regularising the log-det.
+        # The Wald Hessian is only finite at a properly converged estimate - at a degenerate
+        # point it is NaN and `compute_uq` says so rather than returning NaN silently. The step
+        # cap is what keeps the fit out of that region.
         res = fit_model(dm,
             NoLimits.Laplace(;
                 optimizer = OptimizationOptimJL.LBFGS(
@@ -313,6 +310,17 @@ end
         @test isapprox(V, V'; rtol = 1e-10, atol = 1e-10)
         @test size(get_uq_draws(uq)) == (40, n_coords)
     end
+end
+
+@testset "Wald natural-scale draw filter rejects unsquarable rows" begin
+    # Row observed in the #159 reproduction: every entry is finite, so the old `isfinite`
+    # filter kept it, and 4.19e159 squared is Inf - which made get_uq_vcov() all-Inf.
+    row = [5.152933056233719e158, 1.4685718986792252e159, 4.185389947927327e159]
+    @test all(isfinite, row)
+    @test !NoLimits._wald_usable_draw_row(row, 40)
+    @test NoLimits._wald_usable_draw_row([0.0134, -4.48e-7, 1.49e-11], 40)
+    @test !NoLimits._wald_usable_draw_row([Inf, 0.0, 0.0], 40)
+    @test !NoLimits._wald_usable_draw_row([NaN, 0.0, 0.0], 40)
 end
 
 @testset "UQ profile for MLE" begin


### PR DESCRIPTION
Closes #159.

The v0.2.1 release gate flipped on byte-identical source: `main` @ `876485b6` failed `uq_tests.jl:312 all(isfinite, V)` on its first CI run and passed on a re-run of the same commit. Two independent defects, both fixed here.

## (a) Source: the non-finite draw filter had a hole

`_finalize_wald_uqresult` already drops natural-scale draws that overflow, reports the count as `n_draws_nonfinite_natural`, and documents that this is what keeps `get_uq_vcov()` finite. But the predicate was `all(isfinite, row)`, and a draw does not have to reach `Inf` to break the covariance - it only has to be too large to **square**.

Reproduced deterministically on macOS with the old fixture (`:expm`, UQ rng seed 87). One of the 19 surviving rows was

```
transformed: [-3.276448490557647, 130.15393962941423, 321.99025261284004]
natural:     [5.152933056233719e158, 1.4685718986792252e159, 4.185389947927327e159]
```

Every entry finite, so the filter kept it; `4.19e159^2 ≈ 1.75e319` overflows inside `_cov_from_draws`, and `V` is all-`Inf`. Before: `V = [Inf Inf Inf; Inf Inf Inf; Inf Inf Inf]`. After, same seed, same fixture: `V = [9.03e-5 1.60e-8 1.58e-12; ...]`, and the reported drop count moves 21 -> 22, i.e. the offending row is now accounted for rather than silently poisoning the result.

The fix replaces the predicate with `_wald_usable_draw_row(row, n_draws)`: reject anything at or above the largest magnitude whose squared deviations still sum over `n_draws` rows without overflowing. `NaN`/`Inf` fail the same comparison, so one predicate subsumes the old finiteness test and both filter sites (interval draws and covariance draws) use it.

This is user-facing on its own merits: any weakly identified `RealPSDMatrix`/`RealLiePSDMatrix` could hand back an `Inf`/`NaN` Wald covariance and SEs with no error and no diagnostic.

## (b) Fixture: the second random effect never reached the likelihood

`_uq_psd_re_model` declares a 2x2 `Ω` over `η = [η₁, η₂]` but observed `y ~ Normal(a + η[1], σ)`. `η[2]` appears nowhere, so `Ω[1,2]` and `Ω[2,2]` were **structurally** unidentified, not "weakly identified" as the old comment claimed. Measured margin on the old fixture:

| | `:cholesky` | `:expm` | `:lie` |
|---|---|---|---|
| `Vt[3,3]` (transformed variance, 3rd coord) | - | `1.05e12` | `1.05e12` |
| draws dropped, mean over 120 seeds | 0 / 40 | **20.0 / 40** | **20.0 / 40** |
| draws dropped, max over 120 seeds | 0 / 40 | 28 / 40 | 28 / 40 |
| seeds producing non-finite `V` | none | 87 | 87 |

`exp` overflows at an argument of 709 while the draw sd on that coordinate is ~1.0e6, so essentially every draw either underflows to 0 or overflows to `Inf` - there was no margin at all. Worse, a landing point where all 40 overflow trips the "all draws overflowed" `error`, so the same fixture could also fail as an error rather than a test failure.

Adding the random slope (`y ~ Normal(a + η[1] + η[2] * t, σ)`) makes all three `Ω` coordinates estimable. After the change, over the same 120-seed sweep x 3 scales: **0 draws dropped, every seed, every scale**, and no non-finite `V`. The testset now exercises the PSD coordinate layout it is named for instead of an overflow lottery.

`all(isfinite, V)` is kept exactly as it was - it is the assertion that caught this.

`_coords_for_param(...; natural = true)` returning the lower triangle via `_vech_lower` (#120 / #104) is untouched; it is a correct fix and was not the cause, it only made the third natural coordinate `Ω[2,2] = L21² + exp(2·l22)` and so surfaced the overflow sooner.

## Tests

- New `@testset "Wald natural-scale draw filter rejects unsquarable rows"` pins the guard directly against the row from the reproduction - deterministic, platform-independent, and red before this change.
- `NL_TEST_FILES="uq_tests.jl,summaries_fit_uq_tests.jl"` green; `uq_edge_cases_tests.jl,stickbreak_uq_natural_extension_tests.jl,uq_plotting_tests.jl` green; `aqua_tests.jl` green. Formatted with JuliaFormatter v1.0.62 in a pinned scratch env, no stray diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
