### PR TITLE
test: cheap invariance oracles for the estimators (#98, #151)

### DIFF
--- a/test/api_primitives_tests.jl
+++ b/test/api_primitives_tests.jl
@@ -131,6 +131,18 @@ end
 # packages a posterior chain via the chain method of build_fit_result.
 struct APITestBayes <: NoLimits.FittingMethod end
 
+# Rebuild `df` with its individuals reordered by `perm` AND relabelled to strings, so a
+# quantity that keys off row position instead of identity cannot come out unchanged.
+function permute_relabel_ids(df::DataFrame, perm::Vector{Int}; prefix::String = "P")
+    ids = unique(df.ID)
+    subs = [let sub = df[df.ID .== ids[p], :]
+                sub.ID = fill("$(prefix)$(j)", nrow(sub))
+                sub
+            end
+            for (j, p) in enumerate(perm)]
+    return reduce(vcat, subs)
+end
+
 @testset "dev-API primitives" begin
     @testset "public names alias the internals (===)" begin
         @test NoLimits.symmetrize_psd_parameters === NoLimits._symmetrize_psd_params
@@ -283,15 +295,8 @@ struct APITestBayes <: NoLimits.FittingMethod end
     # permuting/relabelling individuals may only change the order of the outer sum.
     @testset "per-individual terms are position-independent" begin
         df = fx_re_df()
-        ids = unique(df.ID)
         perm = [4, 1, 6, 2, 5, 3]
-        subs = DataFrame[]
-        for (j, p) in enumerate(perm)
-            sub = df[df.ID .== ids[p], :]
-            sub.ID = fill("P$j", nrow(sub))
-            push!(subs, sub)
-        end
-        dfp = reduce(vcat, subs)
+        dfp = permute_relabel_ids(df, perm)
         model = fx_re_model()
         dm = DataModel(model, df; primary_id = :ID, time_col = :t)
         dmp = DataModel(model, dfp; primary_id = :ID, time_col = :t)
@@ -308,11 +313,26 @@ struct APITestBayes <: NoLimits.FittingMethod end
         batch_of = Dict(first(NoLimits.get_inds(infos[i])) => i for i in eachindex(infos))
         lm(d, c, info, b) = NoLimits.laplace_marginal(
             d, θ, info, b; const_cache = c.const_cache, cache = c.cache)
+        gm(d, c, info) = NoLimits.ghq_marginal(
+            d, θ, info; level = 2, const_cache = c.const_cache, cache = c.cache)
         for j in eachindex(infosp)
             i = batch_of[perm[first(NoLimits.get_inds(infosp[j]))]]
             @test bsp[j] == bs[i]
             @test lm(dmp, ctxp, infosp[j], bsp[j]) === lm(dm, ctx, infos[i], bs[i])
+            # Issue #151 at the primitive level: the adaptive quadrature rule must be
+            # placed from the batch's own data, not from where the batch happens to sit.
+            @test gm(dmp, ctxp, infosp[j]) === gm(dm, ctx, infos[i])
         end
+
+        # The other half of the oracle: only the ORDER of the outer sum may change,
+        # so the population objective at a fixed θ is invariant up to reassociation.
+        ser = NoLimits.EnsembleSerial()
+        @test NoLimits.laplace_marginal(dmp, θ;
+            serialization = ser)≈
+        NoLimits.laplace_marginal(dm, θ; serialization = ser) rtol=1e-12
+        @test NoLimits.ghq_marginal(
+            dmp, θ; level = 2)≈
+        NoLimits.ghq_marginal(dm, θ; level = 2) rtol=1e-12
     end
 
     @testset "quadrature marginal / Fisher info / posterior sampling" begin

--- a/test/estimation_common_tests.jl
+++ b/test/estimation_common_tests.jl
@@ -652,3 +652,90 @@ end
     θ_bad.a = -1.0                      # sqrt(-1) throws inside the RE distribution
     @test NoLimits.re_logprior(dm, batch, θ_bad, b; const_cache = cc, cache = cache) == -Inf
 end
+
+# ── Invariance oracles ───────────────────────────────────────────────────────
+#
+# Properties that hold whatever the fit's quality is, so the fixtures stay tiny
+# and the tolerance sits on the INVARIANCE rather than on the estimate. These are
+# the cheap CI stand-ins for oracles that until now only the external stress run
+# (533 cells, hours on a cluster) checked. GHQuadrature's own serial-vs-threaded
+# and permutation guards live in estimation_ghquadrature_tests.jl (#151).
+
+const _INV_SER = NoLimits.EnsembleSerial()
+
+@testset "objective is invariant to EnsembleSerial vs EnsembleThreads" begin
+    # Issue #151: GHQuadrature accumulated batch marginals in completion order under
+    # EnsembleThreads, so its objective moved with the thread schedule (relative gaps
+    # up to 0.74). Nothing in the suite asserted this for any estimator.
+    if Threads.nthreads() < 2
+        @info "SKIPPED serial-vs-threaded invariance: needs Threads.nthreads() > 1, " *
+              "got $(Threads.nthreads()). Run julia with `-t auto` to exercise it."
+        @test true
+    else
+        # Serial arm = the shared fixture fit, so the method must mirror fixtures.jl.
+        cases = (
+            ("MLE", fx_mle(), fx_nore_dm(),
+                NoLimits.MLE(; optim_kwargs = (maxiters = 3,))),
+            ("MAP", fx_map(), fx_nore_prior_dm(),
+                NoLimits.MAP(; optim_kwargs = (maxiters = 3,))),
+            ("Laplace", fx_laplace(), fx_re_dm(),
+                NoLimits.Laplace(; optim_kwargs = (maxiters = 3,))),
+            ("FOCEI", fx_focei(), fx_re_dm(),
+                NoLimits.FOCEI(; multistart_n = 1, multistart_k = 1,
+                    optim_kwargs = (maxiters = 3,))),
+            ("Pooled", fx_pooled(), fx_re_dm(),
+                NoLimits.Pooled(; optim_kwargs = (maxiters = 3,))))
+        # rtol: MLE/MAP/FOCEI/Pooled came out bit-identical over repeats, but the
+        # threaded Laplace intermittently drifts (worst observed 9e-10 relative) --
+        # the thread schedule perturbs the EB modes and the outer optimizer walks a
+        # marginally different path from there. #151-class breakage is O(0.1).
+        for (name, res_serial, dm, method) in cases
+            @testset "$name" begin
+                res_threaded = fit_model(dm, method; serialization = EnsembleThreads())
+                @test isapprox(get_objective(res_serial), get_objective(res_threaded);
+                    rtol = 1e-6)
+            end
+        end
+    end
+end
+
+@testset "marginal-likelihood accessor agrees with the fit objective" begin
+    # Issue #98: the GHQ fit integrated against the mode-centred measure while the
+    # accessor still used the prior-centred one, whose signed Smolyak sum drifts with
+    # the level and can turn negative. Pinning the two together catches that directly.
+    res_g = fx_ghq()                       # GHQuadrature(level = 2), no penalty
+    ml2 = get_marginal_likelihood(res_g; level = 2, serialization = _INV_SER)
+    @test isapprox(ml2, -get_objective(res_g); rtol = 1e-10)
+    # AGHQ is exact for this linear-Gaussian fixture at any level; the prior-centred
+    # rule of #98 drifted away as the level rose.
+    @test isapprox(get_marginal_likelihood(res_g; level = 3, serialization = _INV_SER),
+        ml2; rtol = 1e-8)
+
+    # Laplace: the accessor re-solves the EB modes instead of reusing the fit's, and
+    # -½logdet(-H(b*)) is not stationary in b*, so the gap tracks the mode tolerance
+    # (measured 1.9e-10 relative at -O0). A #98-shaped measure mismatch is O(1).
+    res_l = fx_laplace()
+    θ_l = NoLimits.get_params(res_l; scale = :untransformed)
+    @test isapprox(NoLimits.laplace_marginal(fx_re_dm(), θ_l; serialization = _INV_SER),
+        -get_objective(res_l); rtol = 1e-6)
+end
+
+@testset "objectives are finite at the fitted estimate" begin
+    # 32 GHQuadrature cells of the external stress run reported `Inf` objectives while
+    # CI stayed green, because nothing here asserted finiteness on a good fixture.
+    for (name, res) in (("MLE", fx_mle()), ("MAP", fx_map()), ("VI", fx_vi()),
+        ("Pooled", fx_pooled()), ("Laplace", fx_laplace()), ("FOCEI", fx_focei()),
+        ("GHQuadrature", fx_ghq()), ("SAEM", fx_saem()), ("MCEM", fx_mcem()))
+        @testset "$name" begin
+            @test isfinite(get_objective(res))
+        end
+    end
+    for (name, res) in (("Laplace", fx_laplace()), ("FOCEI", fx_focei()),
+        ("GHQuadrature", fx_ghq()), ("SAEM", fx_saem()), ("MCEM", fx_mcem()))
+        @testset "$name likelihoods" begin
+            @test isfinite(get_loglikelihood(res))
+            @test isfinite(get_marginal_likelihood(
+                res; level = 2, serialization = _INV_SER))
+        end
+    end
+end


### PR DESCRIPTION
Issue #151 was a genuine regression - `GHQuadrature`'s objective became dependent on
individual order and on `EnsembleSerial()` vs `EnsembleThreads()`, with relative gaps of
0.62-0.74 - and CI was green the whole time, because nothing in `test/` asserts that an
estimator's objective is invariant to either of those. It took a 533-cell stress run on a
cluster to surface it, after v0.2.1 had already been registered. PR #155 added exactly two
such guards, for GHQ. This generalizes them to the rest of the estimators.

The principle: an oracle that is cheap to state and cheap to run belongs here, where it
blocks a PR in seconds. The stress suite should only be doing what genuinely needs 533
cells and simulated-truth recovery.

Everything runs on the existing `test/fixtures.jl` archetypes (`fx_nore_dm`, `fx_re_dm`)
and the memoized per-method fits, so no new `@Model` is compiled. Both touched files
already live in test group B4, which already builds every fit these tests use.

## What each test replaces, and what it would have caught

### 1. Serial vs `EnsembleThreads()` objective invariance - `estimation_common_tests.jl`

`MLE`, `MAP`, `Laplace`, `FOCEI`, `Pooled`. The serial arm is the shared fixture fit, so
only the threaded arm is a new fit. GHQ is deliberately absent - #155 covers it, on a
model built to be ill-conditioned.

This is the direct **#151** oracle: GHQ accumulated batch marginals in completion order
under `EnsembleThreads`, so the objective moved with the thread schedule.

Skips loudly (`@info` + a passing marker) when `Threads.nthreads() == 1`, which is how CI
runs today, so on CI this costs nothing and asserts nothing. It is a local / opt-in guard
until the workflow sets `JULIA_NUM_THREADS`; I did not flip that here, because turning the
whole suite threaded would also expose the known intermittent threaded-Laplace
nondeterminism across ~577 models, which is a separate decision.

Tolerance is `rtol = 1e-6`, not bitwise: `MLE`/`MAP`/`FOCEI`/`Pooled` came out
bit-identical over repeats, but the threaded `Laplace` fit intermittently drifts (worst
observed 9e-10 relative - the schedule perturbs the EB modes and the outer optimizer walks
a marginally different path from there). #151-class breakage is O(0.1), so there are three
orders of margin. The measured number is in the comment.

### 2. Permutation / relabelling invariance - `api_primitives_tests.jl`

Extends the #116 / PR #142 guard rather than adding a second one. The inline
permute-and-relabel block is factored into `permute_relabel_ids(df, perm)`, and the
testset now also asserts:

- `ghq_marginal` per batch is **bitwise** (`===`) identical when batches are matched by
  identity - the #151 fault line at the primitive level, where #155 pins it at the fit
  level;
- the other half of the oracle, which the existing test did not cover: the **population**
  objective at a fixed θ (`laplace_marginal`, `ghq_marginal`) is invariant, since only the
  order of the outer sum may change. Both came out exactly equal; asserted at `rtol=1e-12`.

Deliberately at fixed θ rather than through `fit_model`: see "rejected" below.

### 3. Fit-vs-accessor agreement - `estimation_common_tests.jl`

`get_marginal_likelihood(res_ghq; level = 2)` is pinned to `-get_objective(res_ghq)`
(measured exactly equal, asserted at `rtol=1e-10`), plus level-2 vs level-3 stability, plus
the same identity for `laplace_marginal` on a `Laplace` fit.

This is the exact fault line of **#98**: the fit integrated against the mode-centred
measure while the accessor still used the prior-centred one, whose signed Smolyak sum
drifts with the level and can turn negative. A test pinning the two together would have
caught #98 directly, and it recurred as a near-miss in #151.

The Laplace arm uses `rtol = 1e-6`, because the accessor re-solves the EB modes instead of
reusing the fit's and `-½logdet(-H(b*))` is not stationary in `b*` (measured 1.9e-10
relative at `-O0`). That is still far tighter than the pre-existing `atol=1e-3` assertion
in `api_primitives_tests.jl`.

### 4. Objective finiteness at a converged fit - `estimation_common_tests.jl`

`isfinite(get_objective(...))` for all nine estimators on a well-conditioned fixture, plus
`get_loglikelihood` and `get_marginal_likelihood` for the five RE methods. 32 GHQ cells of
the stress run reported `Inf` objectives while nothing in CI complained.

## Rejected

**Fit-level permutation invariance** (permuting individuals, then running `fit_model` and
comparing objectives) for `Laplace` / `FOCEI` / `Pooled`. It cost ~85s and it is not
actually an invariance: the optimizer trajectory diverges from the 1e-16 reassociation in
the reduction. Measured relative gaps at the fitted optimum were 3.7e-13 (Laplace),
3.1e-14 (FOCEI), 2.0e-16 (Pooled) - real, non-zero, and unbounded in principle. The fixed-θ
population version in (2) is exact (0.0), ~7x cheaper, and tests the same property. #155
already keeps a fit-level version for GHQ, where the ill-conditioned fixture makes it
load-bearing.

## Measured runtime

`NL_TEST_FILES="estimation_common_tests.jl,api_primitives_tests.jl,accessors_tests.jl,estimation_vi_tests.jl"`,
through the real `Pkg.test` sandbox at `-O0` (the suite's own configuration), so shared
fixture cost is counted correctly:

| config | before | after | added | assertions |
|---|---|---|---|---|
| 1 thread (CI) | 111.0s / 246 | 117.4s / 277 | **+6.4s** | +31 |
| 4 threads | 130.1s / 246 | 138.7s / 281 | **+8.6s** | +35 |

Well under the ~2 min budget. Green on both configurations; the 4-thread run was repeated
to check the Laplace arm for flakiness (281/281 twice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
