### PR TITLE
Integration: CI sharding + invariance oracles + Wald PSD fix + GHQ/predict fixes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Pkgimages embed native code for the machine that precompiled them, and the
+# runner fleet mixes CPU generations - without a pinned multi-target, a depot
+# cache saved on one VM is ~fully invalid on the next (observed: 785 of 827
+# deps recompiled, 16 min, on a freshly restored cache). This is the official
+# Julia x86_64 binary target string, so cached pkgimages load on any runner.
+env:
+  JULIA_CPU_TARGET: "generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+
 jobs:
   # One job per fixture-affine group in test/runtests.jl (NL_TEST_GROUP=i). The
   # groups used to run as sequential subprocess batches inside a single job,

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,15 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: "1.12"
+      # Shard depots are identical, so all shards share ONE cache family:
+      # per-matrix keys would hold 7 near-identical multi-GB caches against
+      # the repo's 10GB limit and evict each other. The save key includes the
+      # run id, so within a run the first finished shard saves and the rest
+      # no-op; delete-old-caches prunes prior runs.
       - uses: julia-actions/cache@v3
+        with:
+          cache-name: julia-test
+          include-matrix: "false"
       - uses: julia-actions/julia-buildpkg@v1
       # --check-bounds=auto reuses buildpkg's cached precompile instead of
       # forcing Pkg.test's default --check-bounds=yes full recompile.
@@ -35,20 +43,47 @@ jobs:
           NL_TEST_GROUP: ${{ matrix.group }}
         run: julia --color=yes --project=. -e 'using Pkg; Pkg.test(; julia_args=["--check-bounds=auto"])'
 
+  # The serial-vs-EnsembleThreads() invariance oracles only mean something with
+  # more than one thread, and the rest of CI runs single-threaded on purpose:
+  # the whole suite threaded would expose the known unlocalized threaded-Laplace
+  # race repo-wide. So exactly the two files carrying those oracles run threaded
+  # here. This is the guard that would have caught #151 (GHQ objective differing
+  # by 0.62-0.74 relative between serial and threaded).
+  threaded:
+    name: test threaded (invariance oracles)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "1.12"
+      - uses: julia-actions/cache@v3
+        with:
+          cache-name: julia-test
+      - uses: julia-actions/julia-buildpkg@v1
+      - name: Run invariance oracles with 4 threads
+        env:
+          JULIA_NUM_THREADS: "4"
+          NL_TEST_FILES: "estimation_common_tests.jl,api_primitives_tests.jl,estimation_ghquadrature_tests.jl"
+        run: julia --color=yes --project=. -e 'using Pkg; Pkg.test(; julia_args=["--check-bounds=auto"])'
+
   # Aggregator. Keeps the exact check name branch protection requires, so the
   # shard count can change without touching the protection settings. Fails if
-  # any shard failed, was cancelled, or was skipped - `needs.*.result` must be
-  # checked explicitly, since a failed dependency otherwise just skips this job.
+  # any dependency failed, was cancelled, or was skipped - `needs.*.result` must
+  # be checked explicitly, since a failed dependency otherwise just skips this
+  # job, and a skipped required check reads as "not run" rather than "failed".
   test:
     name: test (Julia 1.12, ubuntu)
     runs-on: ubuntu-latest
-    needs: shard
+    needs: [shard, threaded]
     if: always()
     steps:
-      - name: Check shard results
+      - name: Check results
         run: |
-          if [ "${{ needs.shard.result }}" != "success" ]; then
-            echo "shard matrix result: ${{ needs.shard.result }}"
-            exit 1
-          fi
-          echo "all shards passed"
+          failed=0
+          for r in "shard:${{ needs.shard.result }}" "threaded:${{ needs.threaded.result }}"; do
+            echo "$r"
+            [ "${r#*:}" = "success" ] || failed=1
+          done
+          [ "$failed" = "0" ] || exit 1
+          echo "all shards and the threaded oracles passed"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2, 3, 4, 5, 6, 7]
+        group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,19 +10,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Single-job test run (no sharding, no coverage). The suite shares model
-  # fixtures (test/fixtures.jl) to keep distinct-model compilation down.
-  # Coverage is measured separately (Coverage.yml) since instrumentation is ~4x
-  # slower and would blow past this gate's budget.
-  test:
-    name: test (Julia 1.12, ubuntu)
+  # One job per fixture-affine group in test/runtests.jl (NL_TEST_GROUP=i). The
+  # groups used to run as sequential subprocess batches inside a single job,
+  # which made the gate ~2.5h and, with branch protection's `strict`, forced
+  # every queued PR to re-run against a moved base.
+  shard:
+    name: test shard ${{ matrix.group }}
     runs-on: ubuntu-latest
-    # The suite runs as sequential subprocess batches (test/runtests.jl) at -O0,
-    # which bounds memory (no stall) but is compile-bound on ~577 distinct
-    # @Models, so on GitHub's 2-vCPU runner the full run is long (~2.5h). No
-    # timeout-minutes is set, so the job uses GitHub's default 6h cap; batching
-    # precludes a real hang, so an explicit shorter limit would only cause
-    # spurious cancellations.
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4, 5, 6, 7]
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
@@ -33,4 +31,24 @@ jobs:
       # --check-bounds=auto reuses buildpkg's cached precompile instead of
       # forcing Pkg.test's default --check-bounds=yes full recompile.
       - name: Run tests
+        env:
+          NL_TEST_GROUP: ${{ matrix.group }}
         run: julia --color=yes --project=. -e 'using Pkg; Pkg.test(; julia_args=["--check-bounds=auto"])'
+
+  # Aggregator. Keeps the exact check name branch protection requires, so the
+  # shard count can change without touching the protection settings. Fails if
+  # any shard failed, was cancelled, or was skipped - `needs.*.result` must be
+  # checked explicitly, since a failed dependency otherwise just skips this job.
+  test:
+    name: test (Julia 1.12, ubuntu)
+    runs-on: ubuntu-latest
+    needs: shard
+    if: always()
+    steps:
+      - name: Check shard results
+        run: |
+          if [ "${{ needs.shard.result }}" != "success" ]; then
+            echo "shard matrix result: ${{ needs.shard.result }}"
+            exit 1
+          fi
+          echo "all shards passed"

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -2,7 +2,8 @@ name: Coverage
 
 # Coverage instrumentation is ~4x slower than a plain test run, so it is kept
 # OUT of the PR gate (CI.yml) and runs here: on pushes to main and on demand.
-# Single, non-blocking job (no sharding); uploads the merged lcov to Codecov.
+# Sharded like CI.yml; each shard uploads its lcov and Codecov merges all
+# uploads for the commit. Non-blocking (fail_ci_if_error: false).
 
 on:
   push:
@@ -15,19 +16,28 @@ concurrency:
 
 jobs:
   coverage:
-    name: coverage (Julia 1.12, ubuntu)
+    name: coverage shard ${{ matrix.group }}
     runs-on: ubuntu-latest
-    timeout-minutes: 350
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: "1.12"
+      # Shared cache family across shards; see the note in CI.yml. Kept
+      # separate from the test cache (julia-cov) as before.
       - uses: julia-actions/cache@v3
         with:
           cache-name: julia-cov
+          include-matrix: "false"
       - uses: julia-actions/julia-buildpkg@v1
       - name: Run tests with coverage
+        env:
+          NL_TEST_GROUP: ${{ matrix.group }}
         run: julia --color=yes --project=. -e 'using Pkg; Pkg.test(; coverage=true, julia_args=["--check-bounds=auto"])'
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Cross-runner-portable pkgimages; see the note in CI.yml.
+env:
+  JULIA_CPU_TARGET: "generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+
 jobs:
   coverage:
     name: coverage shard ${{ matrix.group }}

--- a/test/ad_model_full.jl
+++ b/test/ad_model_full.jl
@@ -59,8 +59,6 @@ using DataInterpolations
     affect!(integrator) = (integrator.u[1] = integrator.u[1])
     cb = ContinuousCallback(condition, affect!)
 
-    inverse_transform = get_inverse_transform(model.fixed.fixed)
-
     function objective_fd(θt)
         pre = calculate_prede(model, θt, η, const_covariates_i)
         pc = (;
@@ -82,45 +80,9 @@ using DataInterpolations
         return logpdf(obs.obs, 1.0)
     end
 
-    function objective_zyg(θt)
-        f!_local = (du, u, θp, t) -> begin
-            fe = inverse_transform(ComponentArray((a = θp[1], b = θp[2], σ = θp[3])))
-            pre = calculate_prede(model, fe, η, const_covariates_i)
-            pc = (;
-                fixed_effects = fe,
-                random_effects = η,
-                constant_covariates = const_covariates_i,
-                varying_covariates = varying_covariates,
-                helpers = helpers,
-                model_funs = model_funs,
-                preDE = pre
-            )
-            compiled = get_de_compiler(model.de.de)(pc)
-            get_de_f!(model.de.de)(du, u, compiled, t)
-            return nothing
-        end
-        fe0 = inverse_transform(ComponentArray((a = θt[1], b = θt[2], σ = θt[3])))
-        u0 = calculate_initial_state(model, fe0, η, const_covariates_i)
-        prob = ODEProblem(f!_local, u0, tspan, θt)
-        sol = solve(prob, Tsit5();
-            callback = cb, abstol = 1e-9, reltol = 1e-9)
-        sol_accessors = get_de_accessors_builder(model.de.de)(sol,
-            get_de_compiler(model.de.de)((;
-                fixed_effects = fe0,
-                random_effects = η,
-                constant_covariates = const_covariates_i,
-                varying_covariates = varying_covariates,
-                helpers = helpers,
-                model_funs = model_funs,
-                preDE = calculate_prede(model, fe0, η, const_covariates_i)
-            )))
-        obs = calculate_formulas_obs(
-            model, fe0, η, const_covariates_i, varying_covariates, sol_accessors)
-        return logpdf(obs.obs, 1.0)
-    end
-
     θ0 = get_θ0_transformed(model.fixed.fixed)
 
     grad_fwd = ForwardDiff.gradient(objective_fd, θ0)
     grad_fd = FiniteDifferences.grad(FiniteDifferences.central_fdm(5, 1), objective_fd, θ0)
+    @test isapprox(grad_fwd, grad_fd[1]; rtol = 1e-5, atol = 1e-8)
 end

--- a/test/api_primitives_tests.jl
+++ b/test/api_primitives_tests.jl
@@ -131,6 +131,18 @@ end
 # packages a posterior chain via the chain method of build_fit_result.
 struct APITestBayes <: NoLimits.FittingMethod end
 
+# Rebuild `df` with its individuals reordered by `perm` AND relabelled to strings, so a
+# quantity that keys off row position instead of identity cannot come out unchanged.
+function permute_relabel_ids(df::DataFrame, perm::Vector{Int}; prefix::String = "P")
+    ids = unique(df.ID)
+    subs = [let sub = df[df.ID .== ids[p], :]
+                sub.ID = fill("$(prefix)$(j)", nrow(sub))
+                sub
+            end
+            for (j, p) in enumerate(perm)]
+    return reduce(vcat, subs)
+end
+
 @testset "dev-API primitives" begin
     @testset "public names alias the internals (===)" begin
         @test NoLimits.symmetrize_psd_parameters === NoLimits._symmetrize_psd_params
@@ -283,15 +295,8 @@ struct APITestBayes <: NoLimits.FittingMethod end
     # permuting/relabelling individuals may only change the order of the outer sum.
     @testset "per-individual terms are position-independent" begin
         df = fx_re_df()
-        ids = unique(df.ID)
         perm = [4, 1, 6, 2, 5, 3]
-        subs = DataFrame[]
-        for (j, p) in enumerate(perm)
-            sub = df[df.ID .== ids[p], :]
-            sub.ID = fill("P$j", nrow(sub))
-            push!(subs, sub)
-        end
-        dfp = reduce(vcat, subs)
+        dfp = permute_relabel_ids(df, perm)
         model = fx_re_model()
         dm = DataModel(model, df; primary_id = :ID, time_col = :t)
         dmp = DataModel(model, dfp; primary_id = :ID, time_col = :t)
@@ -308,11 +313,26 @@ struct APITestBayes <: NoLimits.FittingMethod end
         batch_of = Dict(first(NoLimits.get_inds(infos[i])) => i for i in eachindex(infos))
         lm(d, c, info, b) = NoLimits.laplace_marginal(
             d, θ, info, b; const_cache = c.const_cache, cache = c.cache)
+        gm(d, c, info) = NoLimits.ghq_marginal(
+            d, θ, info; level = 2, const_cache = c.const_cache, cache = c.cache)
         for j in eachindex(infosp)
             i = batch_of[perm[first(NoLimits.get_inds(infosp[j]))]]
             @test bsp[j] == bs[i]
             @test lm(dmp, ctxp, infosp[j], bsp[j]) === lm(dm, ctx, infos[i], bs[i])
+            # Issue #151 at the primitive level: the adaptive quadrature rule must be
+            # placed from the batch's own data, not from where the batch happens to sit.
+            @test gm(dmp, ctxp, infosp[j]) === gm(dm, ctx, infos[i])
         end
+
+        # The other half of the oracle: only the ORDER of the outer sum may change,
+        # so the population objective at a fixed θ is invariant up to reassociation.
+        ser = NoLimits.EnsembleSerial()
+        @test NoLimits.laplace_marginal(dmp, θ;
+            serialization = ser)≈
+        NoLimits.laplace_marginal(dm, θ; serialization = ser) rtol=1e-12
+        @test NoLimits.ghq_marginal(
+            dmp, θ; level = 2)≈
+        NoLimits.ghq_marginal(dm, θ; level = 2) rtol=1e-12
     end
 
     @testset "quadrature marginal / Fisher info / posterior sampling" begin

--- a/test/data_model_ode_tests.jl
+++ b/test/data_model_ode_tests.jl
@@ -87,6 +87,7 @@ end
             model_saveat, θ, η, const_covariates_i, varying_covariates, sol_accessors)
         loglik += logpdf(obs.y, y)
     end
+    @test isfinite(loglik)
 end
 
 @testset "DataModel ODE logpdf with time offsets" begin
@@ -151,6 +152,7 @@ end
             model_saveat, θ, η, const_covariates_i, varying_covariates, sol_accessors)
         loglik += logpdf(obs.y, y)
     end
+    @test isfinite(loglik)
 end
 
 @testset "DataModel ODE logpdf with covariate interpolation" begin
@@ -217,6 +219,7 @@ end
             model_saveat, θ, η, const_covariates_i, varying_covariates, sol_accessors)
         loglik += logpdf(obs.y, y)
     end
+    @test isfinite(loglik)
 end
 
 @testset "DataModel ODE logpdf with NN/SoftTree/Spline + multiple RE groups (1)" begin
@@ -304,6 +307,7 @@ end
             model_saveat, θ, η, const_covariates_i, varying_covariates, sol_accessors)
         loglik += logpdf(obs.y, y)
     end
+    @test isfinite(loglik)
 end
 
 @testset "DataModel ODE logpdf with NN/SoftTree/Spline + multiple RE groups (2)" begin
@@ -395,6 +399,7 @@ end
             model_saveat, θ, η, const_covariates_i, varying_covariates, sol_accessors)
         loglik += logpdf(obs.y, y)
     end
+    @test isfinite(loglik)
 end
 
 @testset "DataModel ODE logpdf with NN/SoftTree/Spline + multiple RE groups (3)" begin
@@ -486,4 +491,5 @@ end
             model_saveat, θ, η, const_covariates_i, varying_covariates, sol_accessors)
         loglik += logpdf(obs.y, y)
     end
+    @test isfinite(loglik)
 end

--- a/test/estimation_common_tests.jl
+++ b/test/estimation_common_tests.jl
@@ -652,3 +652,90 @@ end
     θ_bad.a = -1.0                      # sqrt(-1) throws inside the RE distribution
     @test NoLimits.re_logprior(dm, batch, θ_bad, b; const_cache = cc, cache = cache) == -Inf
 end
+
+# ── Invariance oracles ───────────────────────────────────────────────────────
+#
+# Properties that hold whatever the fit's quality is, so the fixtures stay tiny
+# and the tolerance sits on the INVARIANCE rather than on the estimate. These are
+# the cheap CI stand-ins for oracles that until now only the external stress run
+# (533 cells, hours on a cluster) checked. GHQuadrature's own serial-vs-threaded
+# and permutation guards live in estimation_ghquadrature_tests.jl (#151).
+
+const _INV_SER = NoLimits.EnsembleSerial()
+
+@testset "objective is invariant to EnsembleSerial vs EnsembleThreads" begin
+    # Issue #151: GHQuadrature accumulated batch marginals in completion order under
+    # EnsembleThreads, so its objective moved with the thread schedule (relative gaps
+    # up to 0.74). Nothing in the suite asserted this for any estimator.
+    if Threads.nthreads() < 2
+        @info "SKIPPED serial-vs-threaded invariance: needs Threads.nthreads() > 1, " *
+              "got $(Threads.nthreads()). Run julia with `-t auto` to exercise it."
+        @test true
+    else
+        # Serial arm = the shared fixture fit, so the method must mirror fixtures.jl.
+        cases = (
+            ("MLE", fx_mle(), fx_nore_dm(),
+                NoLimits.MLE(; optim_kwargs = (maxiters = 3,))),
+            ("MAP", fx_map(), fx_nore_prior_dm(),
+                NoLimits.MAP(; optim_kwargs = (maxiters = 3,))),
+            ("Laplace", fx_laplace(), fx_re_dm(),
+                NoLimits.Laplace(; optim_kwargs = (maxiters = 3,))),
+            ("FOCEI", fx_focei(), fx_re_dm(),
+                NoLimits.FOCEI(; multistart_n = 1, multistart_k = 1,
+                    optim_kwargs = (maxiters = 3,))),
+            ("Pooled", fx_pooled(), fx_re_dm(),
+                NoLimits.Pooled(; optim_kwargs = (maxiters = 3,))))
+        # rtol: MLE/MAP/FOCEI/Pooled came out bit-identical over repeats, but the
+        # threaded Laplace intermittently drifts (worst observed 9e-10 relative) --
+        # the thread schedule perturbs the EB modes and the outer optimizer walks a
+        # marginally different path from there. #151-class breakage is O(0.1).
+        for (name, res_serial, dm, method) in cases
+            @testset "$name" begin
+                res_threaded = fit_model(dm, method; serialization = EnsembleThreads())
+                @test isapprox(get_objective(res_serial), get_objective(res_threaded);
+                    rtol = 1e-6)
+            end
+        end
+    end
+end
+
+@testset "marginal-likelihood accessor agrees with the fit objective" begin
+    # Issue #98: the GHQ fit integrated against the mode-centred measure while the
+    # accessor still used the prior-centred one, whose signed Smolyak sum drifts with
+    # the level and can turn negative. Pinning the two together catches that directly.
+    res_g = fx_ghq()                       # GHQuadrature(level = 2), no penalty
+    ml2 = get_marginal_likelihood(res_g; level = 2, serialization = _INV_SER)
+    @test isapprox(ml2, -get_objective(res_g); rtol = 1e-10)
+    # AGHQ is exact for this linear-Gaussian fixture at any level; the prior-centred
+    # rule of #98 drifted away as the level rose.
+    @test isapprox(get_marginal_likelihood(res_g; level = 3, serialization = _INV_SER),
+        ml2; rtol = 1e-8)
+
+    # Laplace: the accessor re-solves the EB modes instead of reusing the fit's, and
+    # -½logdet(-H(b*)) is not stationary in b*, so the gap tracks the mode tolerance
+    # (measured 1.9e-10 relative at -O0). A #98-shaped measure mismatch is O(1).
+    res_l = fx_laplace()
+    θ_l = NoLimits.get_params(res_l; scale = :untransformed)
+    @test isapprox(NoLimits.laplace_marginal(fx_re_dm(), θ_l; serialization = _INV_SER),
+        -get_objective(res_l); rtol = 1e-6)
+end
+
+@testset "objectives are finite at the fitted estimate" begin
+    # 32 GHQuadrature cells of the external stress run reported `Inf` objectives while
+    # CI stayed green, because nothing here asserted finiteness on a good fixture.
+    for (name, res) in (("MLE", fx_mle()), ("MAP", fx_map()), ("VI", fx_vi()),
+        ("Pooled", fx_pooled()), ("Laplace", fx_laplace()), ("FOCEI", fx_focei()),
+        ("GHQuadrature", fx_ghq()), ("SAEM", fx_saem()), ("MCEM", fx_mcem()))
+        @testset "$name" begin
+            @test isfinite(get_objective(res))
+        end
+    end
+    for (name, res) in (("Laplace", fx_laplace()), ("FOCEI", fx_focei()),
+        ("GHQuadrature", fx_ghq()), ("SAEM", fx_saem()), ("MCEM", fx_mcem()))
+        @testset "$name likelihoods" begin
+            @test isfinite(get_loglikelihood(res))
+            @test isfinite(get_marginal_likelihood(
+                res; level = 2, serialization = _INV_SER))
+        end
+    end
+end

--- a/test/parallel.sh
+++ b/test/parallel.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Run the test suite as parallel NL_TEST_GROUP shards (the same split CI uses),
+# so a full local run costs the slowest group instead of the sequential sum.
+# Each group is its own julia process (a few GB RAM each; plan ~7 concurrent).
+#
+# Usage: test/parallel.sh          # all groups
+#        test/parallel.sh 4 5     # only groups 4 and 5
+set -u
+cd "$(dirname "$0")/.."
+
+# Group count = TEST_GROUPS elements in runtests.jl (each opens with `["...`).
+total=$(grep -cE '^\s+\["' test/runtests.jl)
+groups=("$@")
+[ ${#groups[@]} -eq 0 ] && groups=($(seq 1 "$total"))
+
+logdir=$(mktemp -d)
+echo "logs: $logdir"
+pids=()
+for g in "${groups[@]}"; do
+    NL_TEST_GROUP=$g julia --color=yes --project -e \
+        'using Pkg; Pkg.test(; julia_args=["--check-bounds=auto"])' \
+        >"$logdir/group$g.log" 2>&1 &
+    pids+=($!)
+done
+
+fail=0
+for i in "${!groups[@]}"; do
+    if wait "${pids[$i]}"; then
+        echo "group ${groups[$i]}: PASS"
+    else
+        echo "group ${groups[$i]}: FAIL  (log: $logdir/group${groups[$i]}.log)"
+        fail=1
+    fi
+done
+exit $fail

--- a/test/run_batch.jl
+++ b/test/run_batch.jl
@@ -15,7 +15,8 @@ include(joinpath(@__DIR__, "fixtures.jl"))
 # A failing @test inside an inner @testset is recorded (not thrown); the
 # outermost @testset throws a TestSetException at the end if anything failed,
 # which makes this subprocess exit non-zero so the orchestrator sees it.
-@testset "batch" begin
+# verbose: print per-file times in the summary (shard balancing depends on them)
+@testset "batch" verbose=true begin
     for f in ARGS
         @testset "$f" begin
             include(joinpath(@__DIR__, f))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -125,9 +125,21 @@ const TEST_FILES = reduce(vcat, TEST_GROUPS)
 # NoLimits). This is the supported way to run single files now that test-only
 # deps live in test/Project.toml, e.g.:
 #   NL_TEST_FILES="aqua_tests.jl" julia --project -e 'using Pkg; Pkg.test()'
+# CI shards by fixture-affine group: NL_TEST_GROUP=i runs only TEST_GROUPS[i], so
+# the groups run as parallel jobs instead of ~2.5h of sequential batches.
+const _GROUP = strip(get(ENV, "NL_TEST_GROUP", ""))
+const _GROUP_FILES = if isempty(_GROUP)
+    TEST_FILES
+else
+    i = parse(Int, _GROUP)
+    checkbounds(Bool, TEST_GROUPS, i) ||
+        error("NL_TEST_GROUP=$i out of range 1:$(length(TEST_GROUPS))")
+    TEST_GROUPS[i]
+end
+
 const _FILTER = strip(get(ENV, "NL_TEST_FILES", ""))
 const _SELECTED_FILES = if isempty(_FILTER)
-    TEST_FILES
+    _GROUP_FILES
 else
     requested = strip.(split(_FILTER, ","))
     unknown = setdiff(requested, TEST_FILES)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,7 +66,10 @@ const TEST_GROUPS = [
         "plot_random_effects_tests.jl",
         "uq_plotting_tests.jl",
         "integration_plotting.jl"],
-    # ── B4: estimation core (shares fx_nore/re/mg/mvn/mvnp/ode/pois/bern) ────
+    # B4/B5 are split for CI wall-clock (per-file times measured 2026-08-13,
+    # local arm64 -O0): each sub-group re-builds the shared fixtures it touches,
+    # trading a little total CPU for a much shorter slowest shard.
+    # ── B4a: estimation API + samplers + cv (~6m local) ─────────────────────
     ["estimation_common_tests.jl",
         "complete_data_loglikelihood_tests.jl",
         "api_primitives_tests.jl",
@@ -77,23 +80,26 @@ const TEST_GROUPS = [
         "estimation_vi_tests.jl",
         "estimation_mcmc_tests.jl",
         "estimation_mcmc_re_tests.jl",
-        "estimation_laplace_tests.jl",
-        "estimation_focei_tests.jl",
-        "estimation_pooled_tests.jl",
         "estimation_cv_tests.jl"],
-    # ── B5: EM / quadrature / UQ ─────────────────────────────────────────────
-    ["estimation_mcem_tests.jl",
-        "estimation_mcem_is_tests.jl",
-        "estimation_saem_tests.jl",
+    # ── B4b: Laplace-family estimators (~7.4m local: laplace 4m09) ──────────
+    ["estimation_laplace_tests.jl",
+        "estimation_focei_tests.jl",
+        "estimation_pooled_tests.jl"],
+    # ── B5a: SAEM (~6.4m local) ──────────────────────────────────────────────
+    ["estimation_saem_tests.jl",
         "saem_mh_kernel_tests.jl",
         "estimation_saem_autodetect_tests.jl",
         "saem_schedule_tests.jl",
         "saem_multichain_tests.jl",
         "saem_sa_anneal_tests.jl",
-        "saem_var_lb_tests.jl",
+        "saem_var_lb_tests.jl"],
+    # ── B5b: quadrature / multistart / precondition (~7m local) ─────────────
+    ["estimation_ghquadrature_tests.jl",
         "estimation_multistart_tests.jl",
-        "estimation_ghquadrature_tests.jl",
-        "estimation_precondition_tests.jl",
+        "estimation_precondition_tests.jl"],
+    # ── B5c: MCEM / UQ / extra objective (~6m local) ────────────────────────
+    ["estimation_mcem_tests.jl",
+        "estimation_mcem_is_tests.jl",
         "extra_objective_tests.jl",
         "uq_tests.jl",
         "uq_edge_cases_tests.jl"],


### PR DESCRIPTION
Bundles the currently open PRs into one gate so they merge on a single sharded CI run:

- #158 — CI sharding: 10 fixture-affine shard jobs (B4/B5 split by measured per-file times), threaded invariance-oracle job, shared depot cache family, sharded Coverage.yml, `test/parallel.sh` local driver
- #161 — cheap invariance oracles for the estimators (#98, #151)
- #160 — Wald natural-scale vcov all-Inf fix + PSD UQ fixture (#159)
- #156 — GHQ order dependence (#151) + predict `constants_re` (#147), itself bundling #155 and #150

Validation on the merged tree (local, arm64):
- all four branches merge cleanly onto `origin/main` with no conflicts
- the files touched across the PRs (`estimation_common_tests.jl`, `api_primitives_tests.jl`, `uq_tests.jl`, `estimation_ghquadrature_tests.jl`) pass serial AND with `JULIA_NUM_THREADS=4`
- TEST_GROUPS wiring verified complete after the merge (88 files, no duplicates)

The constituent PRs can be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)