### PR TITLE
fix: predict bugs - reestimate EBE leak (#146), silent t0 mismatch (#148), crossed-RE marginal (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- `predict(res, dm_new; re_mode = :reestimate, reestimate_kwargs = (individuals = [...],))`
+  leaked the training fit's empirical-Bayes estimates into every individual of `dm_new`
+  that was not named in `individuals`, matched purely by batch position (#146). The
+  stored-mode merge now applies only when the passed DataModel is the fit's own stored
+  one; on any other DataModel, unrequested individuals get the population value
+  (random-effect prior mean), so their predictions match `re_mode = :population`.
+- `predict(res, dm_new::DataModel)` silently integrated ODEs from `t0 = 0.0` when
+  `dm_new` was built without repeating the fit's `t0` (#148). The integration start is
+  baked into each individual's time span at DataModel construction, so `predict` now
+  raises an informative error on a `t0` mismatch instead of returning wrong numbers;
+  the DataFrame path already reused the fit's `t0` (#130) and is unchanged.
+- `predict(res, newdata; re_mode = :marginal)` threw an uninformative `BoundsError` on
+  models with crossed random-effect groups whenever a grouping column varies within an
+  individual (#152). Monte-Carlo draws are now made per free random-effect level and
+  assembled per individual with the same shape logic as `re_mode = :population`, which
+  also makes individuals sharing a level share its draw within a draw and keeps
+  `constants_re`-fixed levels at their fixed values.
+
 ## v0.2.1
 
 ### Bug fixes

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -1792,8 +1792,11 @@ Supported methods: `Laplace`, `MCEM`, `SAEM`.
 - `ebe_rescue_multistart_sampling::Symbol`: sampling for rescue (default: `:lhs`).
 - `constants_re::NamedTuple`: fix specific RE levels at given values (natural scale).
 - `individuals`: `nothing` (all) or a vector of primary IDs. When provided, only batches
-  containing at least one listed individual are re-optimized; the remaining batches retain
-  the `eb_modes` already stored in `res`. Co-batch individuals are always re-optimized.
+  containing at least one listed individual are re-optimized; co-batch individuals are
+  always re-optimized. The remaining batches retain the `eb_modes` already stored in
+  `res` when `dm` is the fit's own stored DataModel, and fall back to the population
+  value (RE prior mean) on any other `dm`, where the stored modes have no positional
+  meaning.
 - `ode_args::Tuple`, `ode_kwargs::NamedTuple`: forwarded to the ODE solver.
 - `rng::AbstractRNG`: random number generator.
 - `progress::Bool`: show progress bar (default: `false`).
@@ -1863,14 +1866,26 @@ function reestimate_ebes(dm::DataModel,
         active_batch_indices = active_batch_indices)
     new_eb_modes = if individuals !== nothing
         existing = get_eb_modes(get_result(res))
-        if existing !== nothing && length(existing) == length(bstars)
-            active_set = Set(active_batch_indices)
+        active_set = Set(active_batch_indices)
+        # The stored-mode merge is positional, so it is only valid on the very
+        # DataModel the fit stored; on any other dm the training modes would leak
+        # into whichever individuals happen to occupy the same batch slot (#146).
+        if dm === get_data_model(res) && existing !== nothing &&
+           length(existing) == length(bstars)
             merged = copy(existing)
             for bi in active_set
                 merged[bi] = bstars[bi]
             end
             merged
         else
+            # Unrequested batches were skipped by _compute_bstars (empty b);
+            # give them the population default (RE prior mean) instead.
+            ll_cache_local = ll_cache isa Vector ? ll_cache[1] : ll_cache
+            for bi in eachindex(bstars)
+                bi ∈ active_set && continue
+                bstars[bi] = _laplace_default_b0(
+                    dm, batch_infos[bi], θu, const_cache_pre, ll_cache_local)
+            end
             bstars
         end
     else

--- a/src/plotting/plotting_residuals.jl
+++ b/src/plotting/plotting_residuals.jl
@@ -684,6 +684,15 @@ function predict(res::FitResult, dm_new::DataModel;
         ode_args::Tuple = (),
         ode_kwargs::NamedTuple = NamedTuple(),
         kwargs...)
+    # t0 is baked into every individual's tspan at DataModel construction, so a
+    # dm_new built with a different t0 silently integrates from the wrong start (#148).
+    dm_old = get_data_model(res)
+    if dm_old !== nothing && !isequal(get_t0(dm_old), get_t0(dm_new))
+        error("predict: dm_new was built with t0 = $(get_t0(dm_new)), but the fit " *
+              "used t0 = $(get_t0(dm_old)). Rebuild it as DataModel(...; t0 = " *
+              "$(get_t0(dm_old))), or pass the new data as a DataFrame, which " *
+              "reuses the fit's t0 automatically.")
+    end
     θ = get_params(res; scale = :untransformed)
     if re_mode == :population
         constants_re = _res_constants_re(res, constants_re, dm_new)
@@ -792,11 +801,17 @@ function _predict_marginal(dm_new::DataModel, θ::ComponentArray;
     model_funs = get_model_funs(get_model(dm_new))
     helpers = get_helper_funs(get_model(dm_new))
     re_names = get_re_names(get_random(get_model(dm_new)))
+    # Draw one value per free RE level and assemble per individual (same shape logic
+    # as :population). A per-individual scalar draw breaks crossed designs where a
+    # grouping column varies within an individual (#152), and drawing by level also
+    # shares a draw between individuals on the same level and keeps constants_re
+    # levels fixed.
+    fixed_maps = _normalize_constants_re(dm_new, constants_re)
+    re_meta = _re_free_meta(
+        dm_new, θ, fixed_maps, re_names, dists_builder, model_funs, helpers)
+    level_dims = Dict{Symbol, Int}(re => re_meta[re].dim for re in re_names)
     sample_rngs = _spawn_child_rngs(rng, marginal_draws)
     n_new = length(get_individuals(dm_new))
-    # θ is fixed, so each individual's RE priors are the same for every draw.
-    dists_vec = [dists_builder(θ, get_const_cov(get_individuals(dm_new)[j]),
-                     model_funs, helpers) for j in 1:n_new]
 
     sum_acc = Float64[]
     cnt_acc = Int[]
@@ -805,11 +820,20 @@ function _predict_marginal(dm_new::DataModel, θ::ComponentArray;
     obs_col = nothing
     for s in 1:marginal_draws
         srng = sample_rngs[s]
+        level_vals = Dict{Symbol, Dict{Any, Any}}()
+        for re in re_names
+            m = Dict{Any, Any}()
+            for lvl in re_meta[re].levels_free
+                m[lvl] = rand(srng, re_meta[re].dist)
+            end
+            level_vals[re] = m
+        end
+        get_free_value = (re, lvl, dim) -> level_vals[re][lvl]
         η_vec = Vector{ComponentArray}(undef, n_new)
         for j in 1:n_new
-            η_vec[j] = ComponentArray(NamedTuple((re => rand(srng,
-                                                      getproperty(dists_vec[j], re))
-            for re in re_names)))
+            η_vec[j] = _assemble_individual_eta(
+                get_individuals(dm_new)[j], re_names, level_dims, fixed_maps,
+                get_free_value)
         end
         cache = _fill_plot_cache(dm_new, θ, η_vec, constants_re, true,
             ode_args, ode_kwargs)

--- a/test/residual_plots_tests.jl
+++ b/test/residual_plots_tests.jl
@@ -447,4 +447,106 @@ end
     on_newdata = NoLimits.predict(res, df)
     @test isapprox(collect(on_newdata.prediction), collect(in_sample.prediction);
         atol = 1e-8)
+
+    # #148: a manually built DataModel must carry the fit's t0 — the silent default
+    # t0 = 0.0 would integrate from the wrong start.
+    dm5 = DataModel(model, df; primary_id = :ID, time_col = :t, t0 = 5.0)
+    res5 = fit_model(dm5, NoLimits.MLE(; optim_kwargs = (maxiters = 5,)))
+    dm_wrong = DataModel(model, df; primary_id = :ID, time_col = :t)
+    @test_throws "t0 = 5.0" NoLimits.predict(res5, dm_wrong)
+    dm_match = DataModel(model, df; primary_id = :ID, time_col = :t, t0 = 5.0)
+    pred_dm = NoLimits.predict(res5, dm_match)
+    pred_df = NoLimits.predict(res5, df)
+    @test isapprox(collect(pred_dm.prediction), collect(pred_df.prediction); atol = 1e-8)
+end
+
+@testset "reestimate on a new DataModel never leaks training EBEs (#146)" begin
+    model = @Model begin
+        @fixedEffects begin
+            a = RealNumber(1.0)
+            σ = RealNumber(0.4, scale = :log)
+            ω = RealNumber(0.7, scale = :log)
+        end
+        @randomEffects begin
+            η = RandomEffect(Normal(0.0, ω); column = :ID)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @formulas begin
+            y ~ Normal(a + η, σ)
+        end
+    end
+    df = DataFrame(ID = repeat([1, 2, 3]; inner = 3),
+        t = repeat([0.0, 1.0, 2.0]; outer = 3),
+        y = [2.9, 3.1, 3.0, 0.9, 1.1, 1.0, -1.1, -0.9, -1.0])
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+    res = fit_model(dm, NoLimits.Laplace())
+
+    # New individuals, same count as training, so the old positional merge would
+    # have copied training EBEs into IDs 12/13 by batch slot.
+    df_new = DataFrame(ID = repeat([11, 12, 13]; inner = 3),
+        t = repeat([0.0, 1.0, 2.0]; outer = 3),
+        y = [2.0, 2.2, 2.1, missing, missing, missing, missing, missing, missing])
+    dm_new = DataModel(model, df_new; primary_id = :ID, time_col = :t)
+    reest = NoLimits.predict(res, dm_new; re_mode = :reestimate,
+        reestimate_kwargs = (individuals = [11],))
+    pop = NoLimits.predict(res, dm_new)
+    for id in (12, 13)
+        @test isapprox(collect(reest[reest.id .== id, :prediction]),
+            collect(pop[pop.id .== id, :prediction]); atol = 1e-8)
+    end
+    @test !isapprox(collect(reest[reest.id .== 11, :prediction]),
+        collect(pop[pop.id .== 11, :prediction]); atol = 1e-3)
+
+    # Same-dm partial reestimate still keeps the stored modes for unrequested batches.
+    res2 = NoLimits.reestimate_ebes(res; individuals = [1])
+    ebe_before = NoLimits.get_random_effects(res)
+    ebe_after = NoLimits.get_random_effects(res2)
+    @test isapprox(Matrix(ebe_before.η[2:3, 2:end]), Matrix(ebe_after.η[2:3, 2:end]);
+        atol = 1e-12)
+end
+
+@testset "predict marginal on crossed RE groups (#152)" begin
+    model = @Model begin
+        @fixedEffects begin
+            a = RealNumber(1.0)
+            b = RealNumber(0.5)
+            ω_id = RealNumber(0.5, scale = :log)
+            ω_r = RealNumber(0.5, scale = :log)
+            σ = RealNumber(0.3, scale = :log)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η_id = RandomEffect(Normal(0.0, ω_id); column = :ID)
+            η_rater = RandomEffect(Normal(0.0, ω_r); column = :RATER)
+        end
+        @formulas begin
+            y ~ Normal(a + b * t + η_id + η_rater, σ)
+        end
+    end
+    # The rater rotates within each subject, so RATER varies within ID and each
+    # subject's η_rater needs one entry per level it sees.
+    raters = [:R1, :R2, :R3]
+    mkdf(ids) = DataFrame(
+        ID = repeat(ids, inner = 3),
+        RATER = [raters[mod(i + j, 3) + 1] for i in eachindex(ids) for j in 1:3],
+        t = repeat([0.0, 1.0, 2.0], length(ids)),
+        y = [1.0 + 0.5 * j + 0.1 * i for i in eachindex(ids) for j in 1:3])
+    df = mkdf(["id_$k" for k in 1:6])
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+    res = fit_model(dm, NoLimits.Laplace(optim_kwargs = (maxiters = 10,)))
+
+    holdout = mkdf(["new_$k" for k in 1:3])
+    holdout.y = fill(missing, nrow(holdout))
+    pred = NoLimits.predict(res, holdout; re_mode = :marginal, marginal_draws = 10,
+        rng = MersenneTwister(3))
+    @test nrow(pred) == nrow(holdout)
+    @test !any(ismissing, pred.prediction)
+    @test all(isfinite, collect(pred.prediction))
+    # Mean-zero REs enter the mean linearly, so marginal ≈ population up to MC error.
+    pop = NoLimits.predict(res, holdout)
+    @test isapprox(collect(pred.prediction), collect(pop.prediction); atol = 1.0)
 end


### PR DESCRIPTION
Fixes the three open predict issues, each verified against its issue reproducer before and after:

- **#146** — `predict(re_mode=:reestimate, reestimate_kwargs=(individuals=[...],))` leaked training EBEs into unrequested individuals of a new DataModel by batch position (leak reproduced as exactly the training η values; now 0.0 difference vs `:population`). The stored-mode merge now applies only on the fit's own stored DataModel; the documented same-dm partial-reestimate behavior is preserved (regression-tested both ways).
- **#148** — `predict(res, dm_new::DataModel)` silently used `dm_new`'s `t0` (default 0.0) instead of the fit's. Since t0 is baked into every tspan at construction, a mismatch now raises an informative error naming both values; matching-t0 DataModels and the DataFrame path behave exactly as before.
- **#152** — `predict(re_mode=:marginal)` threw `BoundsError: attempt to access Float64 at index [2]` on crossed RE designs where a grouping column varies within an individual (reproduced with the stress suite's M07 rotation pattern). Draws are now per free RE level, assembled per individual with the same shape logic as `:population` — which also shares a level's draw between individuals within a draw and keeps `constants_re` levels fixed.

Regression testsets added to `test/residual_plots_tests.jl` (file green locally, 93/93). CHANGELOG updated under Unreleased; v0.2.2 release to follow.

Fixes #146
Fixes #148
Fixes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)