### PR TITLE
release: v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.2.2
+
 ### Bug fixes
 
 - `predict(res, dm_new; re_mode = :reestimate, reestimate_kwargs = (individuals = [...],))`

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NoLimits"
 uuid = "1d491b74-35a5-408f-ae19-cf8524c3769d"
 license = "MIT"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Manuel Huth", "Jonas Arruda", "Clemens Peiter", "Roy Gusinow", "Nina Schmid", "Jan Hasenauer"]
 
 [deps]


### PR DESCRIPTION
Patch release. Contents (all already on main via #163):

- predict `:reestimate` no longer leaks training EBEs into unrequested individuals of a new DataModel (#146)
- predict on a manually built DataModel errors on a `t0` mismatch instead of silently integrating from the wrong start (#148)
- predict `:marginal` works on crossed random-effect designs (#152)

After merge: verify CI green on the exact post-merge main commit, then `@JuliaRegistrator register`, then manual tag + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)