### PR TITLE
fix: five bughunt issues (#166, #168, #170, #174, #175)

### DIFF
--- a/src/data_model/DataModel.jl
+++ b/src/data_model/DataModel.jl
@@ -271,6 +271,13 @@ function _validate_schema(model, df, config::DataModelConfig)
             _check_missing(_get_col(df, config.amt_col)[evt_idx], config.amt_col)
             _check_missing(_get_col(df, config.rate_col)[evt_idx], config.rate_col)
             _check_missing(_get_col(df, config.cmt_col)[evt_idx], config.cmt_col)
+            # Without a DE block, EVID only excludes rows from the observations -- the
+            # dose amounts have nowhere to go (#174).
+            if model.de.de === nothing &&
+               (any(!=(0), _get_col(df, config.amt_col)[evt_idx]) ||
+                any(!=(0), _get_col(df, config.rate_col)[evt_idx]))
+                @warn "Model has no @DifferentialEquation block, so the nonzero $(config.amt_col)/$(config.rate_col) values on $(config.evid_col) event rows are ignored; those rows only drop out of the observations."
+            end
         end
     end
 
@@ -1034,6 +1041,10 @@ function _build_callbacks(model, df, rows, config::DataModelConfig)
         cmt_i = _resolve_cmt(cmt[i])
         (1 <= cmt_i <= n_states) ||
             error("CMT $(cmt_i) is out of bounds for $(n_states) ODE states.")
+        # RATE only sets infusion speed; AMT sets dose direction (NONMEM convention).
+        if ev == 1 && rate_i != 0.0 && amt_i != 0.0 && sign(rate_i) != sign(amt_i)
+            error("Infusion event at time $(t) has AMT=$(amt_i) and RATE=$(rate_i) with opposite signs. RATE must share AMT's sign.")
+        end
 
         if ev == 1
             if t == t0

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -787,12 +787,13 @@ function validate_constant_names(fe::FixedEffects, constants::NamedTuple)
     _validate_constant_names(Set(get_names(fe)), constants)
 end
 
-# True when the model's fixed effects declare at least one non-`Priorless` prior
-# (the priors-present check MAP/PooledMap require). Mirrors the previous inline logic.
-function _has_fixed_priors(fe)
+# True when at least one *free* fixed effect declares a non-`Priorless` prior (the
+# priors-present check MAP/PooledMap require). A prior on a `constants=` parameter is
+# only an additive offset, so it must not satisfy the gate.
+function _has_fixed_priors(fe, constants::NamedTuple = NamedTuple())
     priors = get_priors(fe)
-    return !isempty(keys(priors)) &&
-           any(!(getfield(priors, k) isa Priorless) for k in keys(priors))
+    return any(k -> !(k in keys(constants)) && !(getfield(priors, k) isa Priorless),
+        keys(priors))
 end
 
 # Resolve the transformed free-parameter optimizer bounds shared by the fixed-effect

--- a/src/estimation/map.jl
+++ b/src/estimation/map.jl
@@ -77,9 +77,9 @@ function _fit_model(dm::DataModel, method::MAP, args...;
         theta_0_untransformed::Union{Nothing, ComponentArray} = nothing,
         store_data_model::Bool = true)
     fe = get_fixed(get_model(dm))
-    has_prior = _has_fixed_priors(fe)
+    has_prior = _has_fixed_priors(fe, constants)
     has_prior ||
-        error("MAP requires priors on fixed effects. Define priors in @fixedEffects (e.g., RealNumber(...; prior=Normal(...))) or use MLE instead.")
+        error("MAP requires priors on free fixed effects. Define priors in @fixedEffects (e.g., RealNumber(...; prior=Normal(...))), drop the prior-carrying parameters from `constants`, or use MLE instead.")
 
     add_term = _combine_add_terms(_MAPTerm(fe), extra_objective)
     fit_kwargs = (constants = constants,

--- a/src/estimation/pooled.jl
+++ b/src/estimation/pooled.jl
@@ -1248,9 +1248,10 @@ function _fit_model(dm::DataModel, method::PooledMap, args...;
           "Use MAP() for fixed-effects-only models.")
 
     fe = get_fixed(get_model(dm))
-    has_prior = _has_fixed_priors(fe)
-    has_prior || error("PooledMap() requires priors on fixed effects. Define priors in " *
-          "@fixedEffects (e.g. RealNumber(...; prior=Normal(...))) or use Pooled() instead.")
+    has_prior = _has_fixed_priors(fe, constants)
+    has_prior ||
+        error("PooledMap() requires priors on free fixed effects. Define priors in " *
+              "@fixedEffects (e.g. RealNumber(...; prior=Normal(...))) or use Pooled() instead.")
 
     return _fit_pooled(dm, method;
         constants = constants,

--- a/src/model/FixedEffects.jl
+++ b/src/model/FixedEffects.jl
@@ -778,6 +778,11 @@ function _logprior_eval(prior::Distribution, val)
     return logpdf(prior, val)
 end
 
+# RealDiagonalMatrix stores only the diagonal; matrix-variate priors need the n x n form.
+function _logprior_eval(prior::MatrixDistribution, val::AbstractVector)
+    return logpdf(prior, Matrix(Diagonal(val)))
+end
+
 function _logprior_eval(prior::AbstractVector{<:Distribution}, val::AbstractVector)
     length(prior) == length(val) ||
         error("Prior length mismatch. Expected $(length(val)); got $(length(prior)).")

--- a/src/plotting/plotting.jl
+++ b/src/plotting/plotting.jl
@@ -934,6 +934,14 @@ function _default_random_effects(res::FitResult,
     return fill(ComponentArray(NamedTuple()), length(get_individuals(dm)))
 end
 
+# Population mean for RE distributions without an analytic `mean` (e.g. planar flows).
+# Fixed seed so predictions stay reproducible across calls.
+function _mc_mean(dist, dim::Int; n::Int = 2000)
+    draws = rand(Xoshiro(0), dist, n)
+    m = draws isa AbstractMatrix ? vec(mean(draws; dims = 2)) : [mean(draws)]
+    return dim == 1 ? m[1] : m
+end
+
 function _default_random_effects_from_dm(dm::DataModel,
         constants_re::NamedTuple,
         θ::ComponentArray)
@@ -963,7 +971,9 @@ function _default_random_effects_from_dm(dm::DataModel,
         v0 = try
             Distributions.mean(re_meta[re].dist)
         catch
-            dim == 1 ? 0.0 : zeros(Float64, dim)
+            @warn "Random effect $(re): its distribution has no analytic mean; "*
+            "using a Monte Carlo estimate of the population value." maxlog=1
+            _mc_mean(re_meta[re].dist, dim)
         end
         re_map = Dict{Any, Any}()
         for lvl in levels_free

--- a/test/data_model_tests.jl
+++ b/test/data_model_tests.jl
@@ -275,6 +275,12 @@ end
     ind1 = get_individual(dm, 1)
     @test ind1.series.obs.y == [1.1, 1.2]
     @test ind1.callbacks === nothing
+
+    # Without a DE block the dose amounts go nowhere -- warn instead of silently
+    # dropping them (#174).
+    @test_logs (:warn, r"no @DifferentialEquation") match_mode=:any DataModel(model, df;
+        primary_id = :ID, time_col = :t, evid_col = :EVID,
+        amt_col = :AMT, rate_col = :RATE, cmt_col = :CMT)
 end
 
 @testset "DataModel serialization config (EnsembleThreads)" begin

--- a/test/estimation_map_tests.jl
+++ b/test/estimation_map_tests.jl
@@ -2,6 +2,7 @@ using Test
 using NoLimits
 using DataFrames
 using Distributions
+using LinearAlgebra
 
 # Testsets shared with MLE (ODE, bounds, constants, free-fixed-effect, vector
 # parameters, +Inf objective) live in estimation_mle_tests.jl as MLE/MAP loops.
@@ -34,6 +35,50 @@ end
 
     dm = DataModel(model, df; primary_id = :ID, time_col = :t)
     @test_throws ErrorException fit_model(dm, NoLimits.MAP())
+
+    # A prior only on a `constants=` parameter is an additive offset, so MAP would
+    # silently degenerate to MLE (#166).
+    model_c = @Model begin
+        @covariates begin
+            t = Covariate()
+        end
+
+        @fixedEffects begin
+            a = RealNumber(0.2; prior = Normal(0.0, 1.0))
+            b = RealNumber(0.2)
+        end
+
+        @formulas begin
+            y ~ Normal(a + b, 0.3)
+        end
+    end
+    dm_c = DataModel(model_c, df; primary_id = :ID, time_col = :t)
+    @test_throws ErrorException fit_model(dm_c, NoLimits.MAP(); constants = (a = 0.3,))
+    @test fit_model(dm_c, NoLimits.MAP()) isa FitResult
+end
+
+@testset "MAP with a matrix-variate prior on RealDiagonalMatrix" begin
+    # The diagonal is stored as a vector; Wishart's logpdf needs the n x n form (#168).
+    model = @Model begin
+        @fixedEffects begin
+            Σ = RealDiagonalMatrix([1.0, 1.0];
+                prior = Wishart(4.0, Matrix{Float64}(I, 2, 2)))
+            a = RealNumber(1.0; prior = Normal(0.0, 1.0))
+        end
+
+        @covariates begin
+            t = Covariate()
+        end
+
+        @formulas begin
+            y ~ Normal(a, 0.5)
+        end
+    end
+
+    df = DataFrame(ID = [1, 1], t = [0.0, 1.0], y = [1.0, 1.05])
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+    res = fit_model(dm, NoLimits.MAP(; optim_kwargs = (; maxiters = 5)))
+    @test isfinite(NoLimits.get_objective(res))
 end
 
 @testset "MAP non-normal Bernoulli outcome" begin

--- a/test/ode_callbacks_tests.jl
+++ b/test/ode_callbacks_tests.jl
@@ -146,6 +146,13 @@ using OrdinaryDiffEq
         ll_second = NoLimits.loglikelihood(dm_evt, θ, ComponentArray())
         @test isfinite(ll_first)
         @test ll_first == ll_second
+
+        # A RATE opposing AMT would silently reverse the dose direction (#170).
+        df_bad = copy(df_evt)
+        df_bad.RATE = [0.0, -0.5, 0.0]
+        @test_throws ErrorException DataModel(model, df_bad; primary_id = :ID,
+            time_col = :t, evid_col = :EVID, amt_col = :AMT, rate_col = :RATE,
+            cmt_col = :CMT)
     end
 
     @testset "Reset" begin

--- a/test/residual_plots_tests.jl
+++ b/test/residual_plots_tests.jl
@@ -394,6 +394,10 @@ end
     @test isapprox(collect(ebe_new.prediction), collect(pop_new.prediction); atol = 1e-8)
     @test isapprox(collect(marg_new.prediction), collect(pop_new.prediction); atol = 0.3)
 
+    # RE distributions without an analytic mean used to fall back to a hard zero (#175).
+    @test NoLimits._mc_mean(Normal(3.0, 1.0), 1)≈3.0 atol=0.1
+    @test NoLimits._mc_mean(MvNormal([2.0, -1.0], [1.0 0.0; 0.0 1.0]), 2)≈[2.0, -1.0] atol=0.1
+
     # Unsupported combinations error clearly.
     model_fo = @Model begin
         @fixedEffects begin


### PR DESCRIPTION
Closes #166, closes #168, closes #170, closes #174, closes #175.

Five low-difficulty bughunt issues, each a localized guard or missing dispatch.

### #166 — MAP silently degenerates to MLE
`_has_fixed_priors` counted priors on parameters held via `constants=`, which contribute
only an additive offset. MAP therefore passed its own "requires priors" gate and produced
bit-identical MLE results. The gate now only counts *free* fixed effects
(`src/estimation/common.jl`); `MAP` and `PooledMap` pass `constants` through.

### #168 — Wishart prior on `RealDiagonalMatrix` crashed MAP
`RealDiagonalMatrix` stores only the diagonal, so a matrix-variate prior got a vector and
threw `DimensionMismatch`. Added
`_logprior_eval(::MatrixDistribution, ::AbstractVector)` which expands to the n x n form.

### #170 — sign-mismatched infusion silently reversed the dose
`_build_callbacks` applied `RATE` verbatim, so `AMT=+100, RATE=-50` drove the compartment
negative. Per the NONMEM convention (AMT sets direction, RATE sets speed) this is now an
error at `DataModel` construction.

### #174 — dosing events discarded without a DE block
`evid_col` on a non-ODE model is legitimate — EVID rows drop out of the observations, and
the suite relies on that. What was silent was the *dose amount* going nowhere. Construction
now warns when event rows carry nonzero AMT/RATE and the model has no
`@DifferentialEquation` block, instead of erroring on the supported filtering use.

### #175 — `predict(re_mode=:population)` fabricated a zero mean
When `Distributions.mean` has no method for the fitted RE distribution (normalizing flows),
the `catch` substituted `0.0`/`zeros(dim)` with no diagnostic. It now warns and uses a
fixed-seed Monte Carlo mean, so the result is reproducible and actually the prior mean.

### Tests

Extensions to existing testsets only (no new files):
`data_model_tests.jl` (#174 warning), `ode_callbacks_tests.jl` (#170),
`estimation_map_tests.jl` (#166, #168), `residual_plots_tests.jl` (#175 `_mc_mean`).

Locally green: `closed_form_ode`, `data_model`, `summaries_data_model`, `data_simulation`,
`ode_callbacks`, `plot_observation_distributions`, `estimation_map`, `estimation_pooled`,
`residual_plots`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)