### PR TITLE
fix: five bughunt issues (#165, #167, #169, #173, #176)

### DIFF
--- a/src/Constants.jl
+++ b/src/Constants.jl
@@ -8,3 +8,9 @@ const PROBABILITY_SCALES = (:stickbreak,)
 const TRANSITION_SCALES = (:stickbreakrows,)
 const RATE_MATRIX_SCALES = (:lograterows,)
 const EPSILON = 0.0
+
+# `logit_forward`/`logit_inverse` clamp the transformed scale to ±LOGIT_CLAMP so the
+# sigmoid never saturates to an exact 0/1. Anything that reasons about the logit scale
+# (declared bounds, round-trip checks) must use this same limit or it will describe a
+# region the transform cannot reach (issue #167).
+const LOGIT_CLAMP = 20.0

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -787,6 +787,100 @@ function validate_constant_names(fe::FixedEffects, constants::NamedTuple)
     _validate_constant_names(Set(get_names(fe)), constants)
 end
 
+# Natural-scale domain of a scalar scale kind, or `nothing` when the kind has no
+# simple element-wise domain (matrix/simplex parameterizations).
+function _scale_domain(kind::Symbol)
+    kind === :log ? ("positive values", >(0.0)) :
+    kind === :logit ? ("values in (0, 1)", x -> 0.0 < x < 1.0) :
+    nothing
+end
+
+function _validate_constant_domain(name::Symbol, spec::TransformSpec, val)
+    if spec.kind === :elementwise && spec.mask !== nothing
+        v = collect(val)
+        for j in eachindex(spec.mask)
+            _validate_constant_domain(
+                name, TransformSpec(name, spec.mask[j], (1, 1), nothing),
+                v[j])
+        end
+        return nothing
+    end
+    dom = _scale_domain(spec.kind)
+    dom === nothing && return nothing
+    desc, ok = dom
+    all(ok, val) ||
+        error("Invalid constant $(name)=$(val): scale :$(spec.kind) requires $(desc) on the " *
+              "natural (untransformed) scale.")
+    return nothing
+end
+
+# Validate the per-parameter `constants=` / `penalty=` overrides passed to `fit_model`
+# before any transform or objective math runs, so a bad name or an out-of-domain value
+# reports itself here instead of as a raw `DomainError`/`FieldError` from deep inside
+# the optimizer (issue #169).
+function _validate_fit_overrides(dm::DataModel, kwargs::NamedTuple)
+    constants = get(kwargs, :constants, NamedTuple())
+    penalty = get(kwargs, :penalty, NamedTuple())
+    (isempty(keys(constants)) && isempty(keys(penalty))) && return nothing
+    fe = get_fixed(get_model(dm))
+    fixed_set = Set(get_names(fe))
+    _validate_constant_names(fixed_set, constants)
+    for name in keys(penalty)
+        name in fixed_set || error("Unknown penalty parameter $(name).")
+    end
+    if !isempty(keys(constants))
+        ft = get_transform(fe)
+        for (i, name) in enumerate(ft.names)
+            haskey(constants, name) &&
+                _validate_constant_domain(name, ft.specs[i], getfield(constants, name))
+        end
+    end
+    return nothing
+end
+
+# The objective's `isinf(add) && return Inf` short-circuit returns a `Dual` whose partials
+# are all zero, so an infeasible STARTING point looks to the optimizer like a zero-gradient
+# optimum and gets reported as converged. Reject it here instead (issue #165).
+function _check_add_term_at_start(add_term, θ_start_u)
+    add0 = add_term(θ_start_u)
+    isfinite(add0) && return nothing
+    reason = add0 == Inf ?
+             "the starting values have zero prior density (outside the prior support)" :
+             "the prior density is unbounded at the starting values (improper mode)"
+    error("Objective is not finite at the starting parameter values: $(reason). " *
+          "Move the initial values into the interior of the prior support " *
+          "(or pass theta_0_untransformed=...).")
+end
+
+# A prior with unbounded density at a declared bound (e.g. Beta(0.5, 0.5) on [0, 1]) has no
+# interior posterior mode: the optimizer walks to the bound, the objective keeps improving,
+# and it reports Success at a degenerate point. Say so upfront - it cannot be fixed by
+# clamping, only by a different prior or bound (issue #165).
+function _warn_unbounded_prior_at_bounds(fe)
+    priors = get_priors(fe)
+    lower, upper = get_bounds_untransformed(fe)
+    for name in keys(priors)
+        prior = getfield(priors, name)
+        prior isa Priorless && continue
+        prior isa Distributions.UnivariateDistribution || continue
+        for (what, b) in (("lower", lower[name]), ("upper", upper[name]))
+            b isa Real && isfinite(b) || continue
+            lp = try
+                logpdf(prior, b)
+            catch
+                continue
+            end
+            lp == Inf &&
+                @warn "Parameter $(name): the prior density is unbounded at the $(what) " *
+                      "bound $(b), so the posterior has no interior mode there. MAP will " *
+                      "drive $(name) to the bound and report convergence at a degenerate " *
+                      "point. Use a prior that is bounded on the closure of the domain, or " *
+                      "tighten the bound."
+        end
+    end
+    return nothing
+end
+
 # True when at least one *free* fixed effect declares a non-`Priorless` prior (the
 # priors-present check MAP/PooledMap require). A prior on a `constants=` parameter is
 # only an additive offset, so it must not satisfy the gate.
@@ -2510,6 +2604,7 @@ function fit_model(dm::DataModel, method::FittingMethod, args...;
         fit_options_pooled_init::NamedTuple = NamedTuple(),
         kwargs...)
     _reset_numeric_warnings!()
+    _validate_fit_overrides(dm, NamedTuple(kwargs))
     _warn_degenerate_soft_trees(
         dm, get(NamedTuple(kwargs), :theta_0_untransformed, nothing))
     if pooled_init === false

--- a/src/estimation/ghquadrature.jl
+++ b/src/estimation/ghquadrature.jl
@@ -174,15 +174,33 @@ function _ghq_batch_ll(dm::DataModel,
     # build_re_measure_from_batch may throw DomainError when distribution
     # parameters hit numerical limits (e.g. Beta with α→0 due to underflow).
     # Treat these as invalid parameter regions and return -Inf.
+    adaptive = true
     re_measure = try
         m = build_re_measure_from_batch(info, θu_re, const_cache, dm, ll_cache)
         mc = _ghq_adaptive_measure(dm, info, θu_re, const_cache, ll_cache, m, b_star)
-        mc === nothing ? m : mc
+        adaptive = mc !== nothing
+        adaptive ? mc : m
     catch e
         e isa DomainError && return T(-Inf)
         rethrow(e)
     end
     ghq_ll = batch_loglik_ghq(dm, info, θu_re, re_measure, sgrid, const_cache, ll_cache)
+    # Adaptive centering is skipped for batches that are not purely Gaussian, and the
+    # prior-centered rule's signed Smolyak weights can turn the batch marginal negative at
+    # level >= 2 (issue #98), which used to surface as an `Inf` objective for the whole fit
+    # (issue #176). The level-1 rule has only positive weights, so fall back to it rather
+    # than declaring the batch impossible.
+    if !isfinite(ghq_ll) && !adaptive && get_n_b(info) > 0
+        grid1 = get_sparse_grid(get_n_b(info), 1)
+        if grid1 !== sgrid
+            @warn "GHQuadrature: the prior-centered rule was numerically unstable for a "*
+                  "non-Gaussian random-effect batch; falling back to the level-1 rule for "*
+                  "this batch. Pass a lower `level`, or use SAEM/MCEM for a more accurate "*
+                  "marginal." maxlog=1
+            ghq_ll = batch_loglik_ghq(
+                dm, info, θu_re, re_measure, grid1, const_cache, ll_cache)
+        end
+    end
     const_ll = _const_re_prior_logf(dm, info, θu_re, const_cache, ll_cache)
     (!isfinite(ghq_ll) || !isfinite(const_ll)) && return T(-Inf)
     return ghq_ll + T(const_ll)

--- a/src/estimation/kernel.jl
+++ b/src/estimation/kernel.jl
@@ -148,10 +148,10 @@ function batch_loglik_ghq(
     log_val, result_sign = signed_logsumexp(a_vals, sgrid.signs)
 
     if result_sign < 0
-        @warn "GHQuadrature: batch marginal likelihood estimate is negative " *
-              "(signed logsumexp returned negative result). " *
-              "This indicates numerical instability — consider reducing `level` " *
-              "or checking your model specification."
+        @warn "GHQuadrature: batch marginal likelihood estimate is negative "*
+              "(signed logsumexp returned negative result). "*
+              "This indicates numerical instability — consider reducing `level` "*
+              "or checking your model specification." maxlog=1
         return T(-Inf)
     end
 

--- a/src/estimation/map.jl
+++ b/src/estimation/map.jl
@@ -81,6 +81,7 @@ function _fit_model(dm::DataModel, method::MAP, args...;
     has_prior ||
         error("MAP requires priors on free fixed effects. Define priors in @fixedEffects (e.g., RealNumber(...; prior=Normal(...))), drop the prior-carrying parameters from `constants`, or use MLE instead.")
 
+    _warn_unbounded_prior_at_bounds(fe)
     add_term = _combine_add_terms(_MAPTerm(fe), extra_objective)
     fit_kwargs = (constants = constants,
         penalty = penalty,

--- a/src/estimation/mle.jl
+++ b/src/estimation/mle.jl
@@ -98,6 +98,7 @@ function _fit_no_re(dm::DataModel, method;
         error("This method requires at least one free fixed effect. Remove constants or specify a fixed effect or random effect.")
     layout = free_parameter_layout(fe; constants = constants,
         theta0_untransformed = theta_0_untransformed)
+    _check_add_term_at_start(add_term, layout.inv_transform(layout.θ_const_t))
     free_names = layout.free_names
     inv_transform = layout.inv_transform
     θ_const_t_vec = layout.θ_const_t_vec
@@ -117,7 +118,7 @@ function _fit_no_re(dm::DataModel, method;
         θt_full = _merge_free_into_full(θ_const_t_vec, free_idx, v_free, axs_full)
         θu = inv_transform(θt_full)
         add = add_term(θu)
-        add == Inf && return infT
+        isinf(add) && return infT
         ll = loglikelihood(
             dm, θu, ComponentArray(); cache = cache, serialization = serialization)
         ll == -Inf && return infT

--- a/src/estimation/pooled.jl
+++ b/src/estimation/pooled.jl
@@ -1098,6 +1098,7 @@ function _pooled_solve(dm::DataModel, method, θ_start_u::ComponentArray,
 
     θ_const_u = deepcopy(θ_start_u)
     _apply_constants!(θ_const_u, merged_constants)
+    _check_add_term_at_start(add_term, θ_const_u)
     θ_const_t = transform(θ_const_u)
     θ0_t = transform(θ_start_u)
 
@@ -1124,7 +1125,7 @@ function _pooled_solve(dm::DataModel, method, θ_start_u::ComponentArray,
         θt_full = _merge_free_into_full(θ_const_t_vec, free_idx, v_free, axs_full)
         θu = inv_transform(θt_full)
         add = add_term(θu)
-        add == Inf && return infT
+        isinf(add) && return infT
         η_loc = if recompute_eta
             try
                 _compute_pooled_etas(dm, θu, strategies)

--- a/src/model/FixedEffects.jl
+++ b/src/model/FixedEffects.jl
@@ -846,13 +846,13 @@ function _transform_bounds(bounds::Tuple{ComponentArray, ComponentArray},
             end
         elseif spec.kind == :logit
             if l isa AbstractArray
-                l2 = map(x -> (isinf(x) || x <= 0) ? -Inf : log(x / (1 - x)), l)
-                u2 = map(x -> (isinf(x) || x >= 1) ? Inf : log(x / (1 - x)), u)
+                l2 = map(x -> (isinf(x) || x <= 0) ? -Inf : logit_forward(x), l)
+                u2 = map(x -> (isinf(x) || x >= 1) ? Inf : logit_forward(x), u)
                 push!(lower_pairs, name => l2)
                 push!(upper_pairs, name => u2)
             else
-                l2 = (isinf(l) || l <= 0) ? -Inf : log(l / (1 - l))
-                u2 = (isinf(u) || u >= 1) ? Inf : log(u / (1 - u))
+                l2 = (isinf(l) || l <= 0) ? -Inf : logit_forward(l)
+                u2 = (isinf(u) || u >= 1) ? Inf : logit_forward(u)
                 push!(lower_pairs, name => l2)
                 push!(upper_pairs, name => u2)
             end
@@ -867,8 +867,8 @@ function _transform_bounds(bounds::Tuple{ComponentArray, ComponentArray},
                 elseif mask[j] === :logit
                     lj = l2[j]
                     uj = u2[j]
-                    l2[j] = (isinf(lj) || lj <= 0) ? -Inf : log(lj / (1 - lj))
-                    u2[j] = (isinf(uj) || uj >= 1) ? Inf : log(uj / (1 - uj))
+                    l2[j] = (isinf(lj) || lj <= 0) ? -Inf : logit_forward(lj)
+                    u2[j] = (isinf(uj) || uj >= 1) ? Inf : logit_forward(uj)
                 end
             end
             push!(lower_pairs, name => l2)

--- a/src/model/Parameters.jl
+++ b/src/model/Parameters.jl
@@ -14,6 +14,18 @@ export RealNumber, RealVector, RealPSDMatrix, RealLiePSDMatrix, RealDiagonalMatr
 export ProbabilityVector, DiscreteTransitionMatrix, ContinuousTransitionMatrix
 export Priorless
 
+# The logit transform clamps to ±LOGIT_CLAMP, so a value or finite bound whose log-odds
+# exceed that limit cannot be represented: the forward transform saturates and the inverse
+# maps back to a different number. Say so at declaration instead of corrupting it silently
+# (issue #167).
+function _warn_logit_unrepresentable(name, what, x)
+    (x <= 0 || x >= 1 || abs(log(x / (1 - x))) <= LOGIT_CLAMP) && return nothing
+    @warn "Parameter $(name): $(what) $(x) is outside the range representable on the " *
+          ":logit scale (|logit(x)| ≤ $(LOGIT_CLAMP)); it saturates at " *
+          "$(sign(x - 0.5) * LOGIT_CLAMP) and will not round-trip to $(x)."
+    return nothing
+end
+
 """
     Priorless()
 
@@ -82,6 +94,9 @@ function RealNumber(value::Real; name::Symbol = :unnamed, scale::Symbol = :ident
     if scale == :logit
         (value > 0 && value < 1) ||
             error("Invalid initial value for parameter $(name). Expected value ∈ (0, 1) for scale :logit; got value=$(value).")
+        _warn_logit_unrepresentable(name, "initial value", value)
+        isfinite(lower) && _warn_logit_unrepresentable(name, "lower bound", lower)
+        isfinite(upper) && _warn_logit_unrepresentable(name, "upper bound", upper)
     end
     T = value isa AbstractFloat ? typeof(value) : Float64
     v = T(value)
@@ -145,8 +160,16 @@ function RealVector(value::AbstractVector{<:Real};
         lower = map((l, sc) -> (sc == :log && l == -Inf) ? EPSILON : l, lower, s)
     end
     for (idx, (sc, vi)) in enumerate(zip(s, value))
-        if sc == :logit && !(vi > 0 && vi < 1)
-            error("Invalid initial value for parameter $(name) at index $(idx). Expected value ∈ (0, 1) for scale :logit; got value=$(vi).")
+        if sc == :logit
+            (vi > 0 && vi < 1) ||
+                error("Invalid initial value for parameter $(name) at index $(idx). Expected value ∈ (0, 1) for scale :logit; got value=$(vi).")
+            _warn_logit_unrepresentable(name, "initial value at index $(idx)", vi)
+            li = lower isa AbstractVector ? lower[idx] : lower
+            ui = upper isa AbstractVector ? upper[idx] : upper
+            isfinite(li) &&
+                _warn_logit_unrepresentable(name, "lower bound at index $(idx)", li)
+            isfinite(ui) &&
+                _warn_logit_unrepresentable(name, "upper bound at index $(idx)", ui)
         end
     end
 

--- a/src/uq/common.jl
+++ b/src/uq/common.jl
@@ -316,6 +316,14 @@ function _project_psd_covariance(cov_mat::Matrix{Float64})
     V = Matrix{Float64}(0.5 .* (V .+ V'))
     min_raw = isempty(vals_raw) ? 0.0 : minimum(vals_raw)
     min_used = isempty(vals) ? 0.0 : minimum(vals)
+    # Clipping a negative eigenvalue to zero shrinks the variance along that direction, so a
+    # weakly identified parameter can come out looking precise. Never do that silently
+    # (issue #173).
+    n_clipped > 0 &&
+        @warn "Wald covariance was projected to the nearest PSD matrix: $(n_clipped) "*
+              "negative eigenvalue(s) clipped to zero (most negative $(min_raw)). Standard "*
+              "errors along those directions are shrunk toward zero and understate the true "*
+              "uncertainty; prefer method = :profile / :mcmc for those parameters." maxlog=3
     diag = (;
         vcov_projected = n_clipped > 0,
         vcov_min_eig_raw = min_raw,

--- a/src/uq/wald.jl
+++ b/src/uq/wald.jl
@@ -1,6 +1,46 @@
 using LinearAlgebra
 using Random
 
+# Pseudo-inverse of the objective Hessian for the Wald "bread" matrix.
+#
+# `pinv`'s default rank tolerance maps a near-zero singular value to 0 rather than to a
+# large reciprocal, so a weakly identified direction came out with near-zero variance -
+# falsely precise, the exact opposite of what a standard error must convey (issue #173).
+# Keep every nonzero singular value so such a direction yields a LARGE variance, and only
+# drop the exactly singular ones (which is what makes this usable where `inv` throws).
+function _wald_pinv(H::AbstractMatrix, active_names)
+    F = svd(H)
+    n = length(F.S)
+    smax = n == 0 ? 0.0 : maximum(F.S)
+    tol = eps(Float64) * smax * maximum(size(H))
+    weak = findall(<(tol), F.S)
+    if !isempty(weak)
+        # Name the parameters loading most on the (near-)null directions - those are the
+        # ones whose reported SE is now large because they are not identified by the data.
+        loads = length(active_names) == n ?
+                [active_names[argmax(abs.(view(F.V, :, j)))] for j in weak] : active_names
+        @warn "Wald covariance: the objective Hessian is (near-)singular in "*
+              "$(length(weak)) direction(s); the standard errors for these parameters are "*
+              "large because they are only weakly identified. Consider reparameterizing or "*
+              "fixing them via `constants=`." parameters=unique(loads) smallest_singular_value=minimum(F.S)
+    end
+    Sinv = [s > 0 ? inv(s) : zero(s) for s in F.S]
+    return F.V * Diagonal(Sinv) * F.U'
+end
+
+function _wald_bread(H::AbstractMatrix, pseudo_inverse::Bool, active_names)
+    bread = try
+        pseudo_inverse ? _wald_pinv(H, active_names) : inv(H)
+    catch err
+        pseudo_inverse ||
+            error("Failed to invert Hessian for Wald covariance. Consider pseudo_inverse=true. Original error: $(sprint(showerror, err))")
+        @warn "Falling back to pseudo-inverse for Hessian inversion in UQ." error=sprint(
+            showerror, err)
+        _wald_pinv(H, active_names)
+    end
+    return Matrix{Float64}(0.5 .* (bread .+ bread'))
+end
+
 # Shared Wald finalize tail: project the raw covariance to PSD, draw from the Gaussian
 # approximation, map draws back to the natural scale, extend any stickbreak coordinates,
 # and assemble the UQResult. `extra_diag` carries method-specific diagnostics (e.g.
@@ -252,16 +292,7 @@ function _compute_uq_wald_no_re(res::FitResult;
               "is not differentiable - typically a degenerate random-effect covariance or an " *
               "unconverged fit. Check the fit converged, or use method = :profile / :mcmc.")
 
-    bread = try
-        pseudo_inverse ? pinv(H_active) : inv(H_active)
-    catch err
-        pseudo_inverse ||
-            error("Failed to invert Hessian for Wald covariance. Consider pseudo_inverse=true. Original error: $(sprint(showerror, err))")
-        @warn "Falling back to pseudo-inverse for Hessian inversion in UQ." error=sprint(
-            showerror, err)
-        pinv(H_active)
-    end
-    bread = Matrix{Float64}(0.5 .* (bread .+ bread'))
+    bread = _wald_bread(H_active, pseudo_inverse, active_names)
 
     Vt_raw = if vcov == :hessian
         copy(bread)
@@ -436,16 +467,7 @@ function _compute_uq_wald_re(res::FitResult;
         fd_max_tries = fd_max_tries)
     H_active = 0.5 .* (H_active .+ H_active')
 
-    bread = try
-        pseudo_inverse ? pinv(H_active) : inv(H_active)
-    catch err
-        pseudo_inverse ||
-            error("Failed to invert Hessian for Wald covariance. Consider pseudo_inverse=true. Original error: $(sprint(showerror, err))")
-        @warn "Falling back to pseudo-inverse for Hessian inversion in UQ." error=sprint(
-            showerror, err)
-        pinv(H_active)
-    end
-    bread = Matrix{Float64}(0.5 .* (bread .+ bread'))
+    bread = _wald_bread(H_active, pseudo_inverse, active_names)
 
     Vt_raw = if vcov == :hessian
         copy(bread)

--- a/src/utils/ParameterTranformations.jl
+++ b/src/utils/ParameterTranformations.jl
@@ -268,15 +268,15 @@ function log_inverse(x::Real)
 end
 
 function logit_forward(x::Real)
-    return clamp(log(x / (1 - x)), -20.0, 20.0)
+    return clamp(log(x / (1 - x)), -LOGIT_CLAMP, LOGIT_CLAMP)
 end
 
 function logit_inverse(x::Real)
-    return Lux.sigmoid(clamp(x, -20.0, 20.0))
+    return Lux.sigmoid(clamp(x, -LOGIT_CLAMP, LOGIT_CLAMP))
 end
 
 @inline function _logit_inv_jacobian(x::Real)
-    abs(x) >= 20.0 && return zero(x)
+    abs(x) >= LOGIT_CLAMP && return zero(x)
     s = logit_inverse(x)
     return s * (one(s) - s)
 end

--- a/test/estimation_ghquadrature_tests.jl
+++ b/test/estimation_ghquadrature_tests.jl
@@ -1799,3 +1799,35 @@ end
         @test maximum(abs.(collect(pa) .- collect(pb))) <= 1e-6
     end
 end
+
+# #176: adaptive centering is skipped when a crossed batch is not purely Gaussian, and the
+# prior-centered Smolyak rule's signed weights used to turn the batch marginal negative at
+# level >= 2 - reported as an Inf objective for the whole fit.
+@testset "mixed Gaussian/non-Gaussian crossed batch stays finite" begin
+    model = @Model begin
+        @fixedEffects begin
+            a = RealNumber(0.5)
+            σ = RealNumber(0.3, scale = :log)
+            ω_id = RealNumber(0.5, scale = :log)
+            α = RealNumber(2.0, scale = :log)
+            β = RealNumber(2.0, scale = :log)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η_id = RandomEffect(Normal(0.0, ω_id); column = :ID)
+            η_site = RandomEffect(Beta(α, β); column = :SITE)
+        end
+        @formulas begin
+            y ~ Normal(a + η_id + (η_site - 0.5), σ)
+        end
+    end
+    rng = Xoshiro(42)
+    df = DataFrame(ID = repeat(1:6, inner = 2), SITE = repeat(1:6, inner = 2),
+        t = repeat([0.0, 1.0], 6), y = rand(rng, 12) .+ 0.5)
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+    res = fit_model(dm, GHQuadrature(level = 3, optim_kwargs = (maxiters = 5,));
+        rng = Xoshiro(42))
+    @test isfinite(get_objective(res))
+end

--- a/test/estimation_mle_tests.jl
+++ b/test/estimation_mle_tests.jl
@@ -265,6 +265,17 @@ let
             @test θu.a == 0.0
         end
     end
+
+    # #169: invalid overrides report themselves at call time, not as a raw DomainError /
+    # FieldError from deep inside the objective.
+    @testset "override validation" begin
+        @test_throws ErrorException fit_model(dm, NoLimits.MLE(); constants = (σ = -1.0,))
+        @test_throws ErrorException fit_model(dm, NoLimits.MLE(); penalty = (bb = 1.0,))
+        # #165: σ = 0 has zero LogNormal prior density; the objective's Inf short-circuit
+        # would hand the optimizer a zero gradient and it would report convergence there.
+        @test_throws ErrorException fit_model(dm, NoLimits.MAP();
+            theta_0_untransformed = ComponentArray(a = 0.1, σ = 0.0))
+    end
 end
 
 @testset "MLE penalties" begin
@@ -539,14 +550,18 @@ let
 
     dm = DataModel(model, df; primary_id = :ID, time_col = :t)
 
-    for (label, method) in (
-        ("MLE", NoLimits.MLE(; optim_kwargs = (maxiters = 2,))),
-        ("MAP", NoLimits.MAP(; optim_kwargs = (maxiters = 2,))))
-        @testset "$label handles +Inf objective in AD path" begin
-            res = fit_model(dm, method)
+    @testset "MLE handles +Inf objective in AD path" begin
+        res = fit_model(dm, NoLimits.MLE(; optim_kwargs = (maxiters = 2,)))
 
-            @test res isa FitResult
-            @test !isfinite(NoLimits.get_objective(res))
-        end
+        @test res isa FitResult
+        @test !isfinite(NoLimits.get_objective(res))
+    end
+
+    # #165: a = 0 lies outside the Uniform(0.1, 1.0) prior support, so the MAP objective is
+    # +Inf with zero AD partials there - the optimizer used to read that as a converged
+    # optimum. It must be refused instead of "fitted".
+    @testset "MAP rejects a start outside the prior support" begin
+        @test_throws ErrorException fit_model(
+            dm, NoLimits.MAP(; optim_kwargs = (maxiters = 2,)))
     end
 end

--- a/test/transform_tests.jl
+++ b/test/transform_tests.jl
@@ -322,3 +322,16 @@ end
         @test isapprox(H, fd_hess(h_lie, t0); rtol = 1e-6, atol = 1e-7)
     end
 end
+
+# #167: logit_forward clamps to ±LOGIT_CLAMP, so the declared transformed bounds must not
+# describe a region the transform can never reach, and an unrepresentable value must say so.
+@testset "logit clamp is visible to bounds and declarations" begin
+    fe = @fixedEffects begin
+        p = RealNumber(0.5; scale = :logit, lower = 1e-15, upper = 1 - 1e-15)
+    end
+    lo, up = NoLimits.get_bounds_transformed(fe)
+    @test lo.p == NoLimits.logit_forward(1e-15) == -NoLimits.LOGIT_CLAMP
+    @test up.p == NoLimits.logit_forward(1 - 1e-15) == NoLimits.LOGIT_CLAMP
+
+    @test_logs (:warn,) match_mode=:any RealNumber(1e-10; name = :q, scale = :logit)
+end

--- a/test/uq_tests.jl
+++ b/test/uq_tests.jl
@@ -635,3 +635,12 @@ end
     @test all(isfinite.(x))
     @test all(y .>= 0.0)
 end
+
+# #173: pinv's default rank tolerance mapped a near-zero singular value to 0, so a weakly
+# identified direction was reported as near-zero variance - falsely precise. It must be large.
+@testset "Wald bread keeps weakly identified directions large" begin
+    H = [1.0 1.0; 1.0 1.0+1e-10]
+    B = NoLimits._wald_pinv(H, [:a, :b])
+    @test diag(B)[2] > 1e8
+    @test isapprox(B, inv(H); rtol = 1e-3)
+end


### PR DESCRIPTION
Closes #165, closes #167, closes #169, closes #173, closes #176.

Five verified bughunt issues, all silent-wrong-answer or cryptic-error failures. None overlap PR #178.

### #165 — MAP reports Success at degenerate posterior boundaries
`add == Inf && return infT` returned a bare `Inf` of the Dual's element type, i.e. a value with **zero partials**, so LBFGS saw a zero gradient and declared convergence at an infeasible start. Two changes: the start point is now checked against the objective's additive term up front (`_check_add_term_at_start`, shared with the duplicated `pooled.jl` driver), and the short-circuit tests `isinf(add)` so an unboundedly *positive* prior density (`Beta(0.5,0.5)` at a bound) is refused rather than chased. For that second manifestation the posterior genuinely has no interior mode, so MAP additionally warns up front when a prior's density diverges at a declared bound — the optimizer still stops at the closest representable point, but no longer silently.

### #167 — logit clamp invisible to bounds and round-trips
`_transform_bounds` re-implemented `log(x/(1-x))` without the `[-20, 20]` clamp `logit_forward` applies, so the optimizer was told a region was feasible that the transform can never reach (declared `-34.54` vs. achievable `-20.0`). It now routes through `logit_forward`; the clamp is a single named constant `LOGIT_CLAMP`; and declaring a value or a finite bound whose log-odds exceed it warns instead of silently corrupting the round-trip. The `±Inf` sentinels are kept as-is so `use_bounds` behaviour is unchanged.

### #169 — unvalidated `constants=` / `penalty=`
Validated once at the single `fit_model` entry point, so it covers every method: an unknown `penalty=` key now errors like `constants=` already did, and a constant violating its parameter's scale domain reports that instead of a raw `DomainError` from `log()`.

### #173 — `pseudo_inverse=true` reports tiny SEs for weak parameters
`pinv`'s default rank tolerance maps a near-zero singular value to `0` rather than to a large reciprocal, so a weakly identified direction came out with near-zero variance — falsely precise, the opposite of what a Wald SE must convey. The two duplicated bread blocks collapse into one helper that keeps every nonzero singular value (so the weak direction gets a **large** variance) and names the parameters loading on the near-null directions. The PSD projection of the sandwich covariance also no longer clips negative eigenvalues silently. On the reporter's model the `b` SE goes from `1.4e-4` to the same order as `pseudo_inverse=false`; the residual factor is genuine ill-conditioning (smallest singular value ~1.7e-12) and is now reported.

### #176 — GHQuadrature `Inf` on mixed Gaussian/non-Gaussian batches
Adaptive centering is deliberately skipped when a crossed batch is not purely Gaussian, and the prior-centered Smolyak rule's signed weights turn the batch marginal negative at `level >= 2` (the failure mode the code's own docstring names as #98), surfacing as an `Inf` objective for the whole fit. Such a batch now falls back to the level-1 rule (positive weights only) when — and only when — the higher-level rule actually goes non-finite, so currently-working non-Gaussian batches keep their accuracy. Reporter's model: `Inf` -> `1.4259`.

### Tests
Extended existing testsets (no new files, shared fixtures reused): override validation + infeasible MAP start in `estimation_mle_tests.jl`, logit bound/declaration in `transform_tests.jl`, `_wald_pinv` unit check in `uq_tests.jl`, mixed-batch GHQ fit in `estimation_ghquadrature_tests.jl`.

The pre-existing `"MAP handles +Inf objective in AD path"` testset asserted exactly the behaviour #165 reports as a bug — a `FitResult` with a non-finite objective from a start outside the prior support. It is split so MLE keeps its `+Inf` path and MAP is expected to refuse.

All 10 test groups pass locally; formatted with JuliaFormatter v1 (sciml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)