### PR TITLE
ci: arm64 runner rehearsal (timing benchmark, do not merge yet)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,8 +14,12 @@ concurrency:
 # cache saved on one VM is ~fully invalid on the next (observed: 785 of 827
 # deps recompiled, 16 min, on a freshly restored cache). This is the official
 # Julia x86_64 binary target string, so cached pkgimages load on any runner.
+# arm64 rehearsal: the suite is compile-bound, and GitHub's free arm64 runners
+# (Cobalt 100) are substantially faster single-thread than the mixed x86 fleet.
+# The target string is the official Julia aarch64-linux binary target, same
+# rationale as the x86 pin. Separate cache family: arm pkgimages are disjoint.
 env:
-  JULIA_CPU_TARGET: "generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+  JULIA_CPU_TARGET: "generic;cortex-a57;thunderx2t99;carmel,clone_all;apple-m1,base(3);neoverse-512tvb,base(3)"
 
 jobs:
   # One job per fixture-affine group in test/runtests.jl (NL_TEST_GROUP=i). The
@@ -24,7 +28,7 @@ jobs:
   # every queued PR to re-run against a moved base.
   shard:
     name: test shard ${{ matrix.group }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
@@ -41,7 +45,7 @@ jobs:
       # no-op; delete-old-caches prunes prior runs.
       - uses: julia-actions/cache@v3
         with:
-          cache-name: julia-test
+          cache-name: julia-test-arm64
           include-matrix: "false"
       - uses: julia-actions/julia-buildpkg@v1
       # --check-bounds=auto reuses buildpkg's cached precompile instead of
@@ -59,7 +63,7 @@ jobs:
   # by 0.62-0.74 relative between serial and threaded).
   threaded:
     name: test threaded (invariance oracles)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
@@ -67,7 +71,7 @@ jobs:
           version: "1.12"
       - uses: julia-actions/cache@v3
         with:
-          cache-name: julia-test
+          cache-name: julia-test-arm64
       - uses: julia-actions/julia-buildpkg@v1
       - name: Run invariance oracles with 4 threads
         env:
@@ -82,7 +86,7 @@ jobs:
   # job, and a skipped required check reads as "not run" rather than "failed".
   test:
     name: test (Julia 1.12, ubuntu)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: [shard, threaded]
     if: always()
     steps:


### PR DESCRIPTION
Rehearsal for part 2 of the sub-10-minute CI plan (stacked on #190). Runs the unchanged 10-shard matrix + threaded oracles on `ubuntu-24.04-arm` (free for public repos) with the official Julia aarch64 binary CPU target and a separate `julia-test-arm64` cache family.

The suite is compile-bound, so wall time tracks single-core speed; local arm64 runs these files at roughly half the GitHub x86 time. This PR measures what the Cobalt 100 runners actually deliver, including whether the knife-edge tests (uq PSD Wald) stay green on aarch64.

- First run: cold arm depot, expect ~20 min of dependency precompilation on every shard — ignore the timings.
- Second run (trigger commit): the real numbers that size the reshard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)