### PR TITLE
fix: Laplace admissibility test rejected well-posed ill-conditioned batches (#157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- `Laplace` (and the FOCEI/AGHQ paths sharing its marginal) stopped ~1900 nats short of
+  the optimum on badly scaled data, reporting fixed effects far from the truth while
+  `GHQuadrature` on the same data and start landed at it (#157). The admissibility test
+  guarding the Laplace expansion rejected any empirical-Bayes Hessian with condition
+  number `>= 1e8`, which a single-observation individual at a large time reaches
+  legitimately (`-H = xxᵀ/σ² + Ω⁻¹` is well posed but conditioned like `t²`). Since the
+  rejection is a hard `-Inf`, the outer optimizer climbed until the worst-conditioned
+  individual sat exactly on the threshold and its line search had nowhere left to step.
+  The test is now the un-jittered Cholesky itself - a log-det that measures data rather
+  than the rescue jitter is kept, whatever its conditioning - which is the criterion the
+  adaptive quadrature rule already used.
+
 ## v0.2.2
 
 ### Bug fixes

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -1647,28 +1647,28 @@ function _laplace_cholesky_negH(
 end
 
 """
-    negH_definite_without_jitter(H; rtol=1e-8) -> Bool
+    negH_definite_without_jitter(H) -> Bool
 
-Is `-H` positive definite with every curvature direction informative, i.e. without relying
-on the diagonal jitter `_laplace_cholesky_negH` adds to force a Cholesky? Validity
-precondition for a Laplace/AGHQ marginal: when a direction carries no curvature, the
-`-½·logdet(-H)` term measures the regularisation (posterior variance `~1/jitter`) rather
-than the data, and inflates the marginal past its exact ceiling `-n/2·log(2πσ²)`.
+Does `-H` factorize without the diagonal jitter `_laplace_cholesky_negH` adds to force a
+Cholesky? Validity precondition for a Laplace/AGHQ marginal: when a direction carries no
+curvature, the `-½·logdet(-H)` term measures the regularisation (posterior variance
+`~1/jitter`) rather than the data, and inflates the marginal past its exact ceiling
+`-n/2·log(2πσ²)`. An un-jittered Cholesky is exactly that question, and it is the same
+criterion `remeasure.jl` already applies to the AGHQ scaling.
 
-The test is *relative* (`λmin > rtol·λmax`), so it is invariant to the units the data is
-recorded in. An absolute floor is not: comparing against the bare `jitter` makes the same
-posterior admissible in one unit system and degenerate in another, and comparing against
-the adaptive jitter `max(jitter, scale_factor·mean|diag|)` additionally rejects
-well-conditioned Hessians merely for having a large diagonal — which stalls the outer
-optimizer at its starting values. Applied to primal values so the objective and its
-gradient agree on admissibility.
+It replaced a relative eigenvalue test (`λmin > 1e-8·λmax`), which rejected *well-posed*
+batches for being merely ill-conditioned: a single-observation individual at a large time
+has `-H = xxᵀ/σ² + Ω⁻¹` with condition number `~t²`, entirely legitimate. Worse, the
+rejection is a hard `-Inf`, so the outer optimizer climbed until the worst-conditioned
+individual sat exactly on the threshold and then stalled ~1800 nats short of the optimum
+(issue #157). Applied to primal values so the objective and its gradient agree on
+admissibility.
 """
-function negH_definite_without_jitter(H::AbstractMatrix; rtol::Real = 1e-8)
+function negH_definite_without_jitter(H::AbstractMatrix)
     size(H, 1) == 0 && return true
     Hneg = -_scalar_value.(H)
     all(isfinite, Hneg) || return false
-    λ = eigvals(Symmetric(Hneg))          # ascending; catches λmin <= 0 too
-    return first(λ) > rtol * last(λ)
+    return cholesky(Symmetric(Hneg), check = false).info == 0
 end
 
 function _laplace_logdet_negH(dm::DataModel,

--- a/src/estimation/remeasure.jl
+++ b/src/estimation/remeasure.jl
@@ -658,11 +658,11 @@ function build_centered_re_measure(
     H = _laplace_hessian_b(dm, batch_info, θu, b_star, const_cache, ll_cache, nothing, bi)
     # S only places the nodes — the change-of-variables correction compensates any
     # invertible scaling exactly — so the admissibility test is plain definiteness of -H,
-    # not the relative-conditioning test `negH_definite_without_jitter` applies to the
-    # Laplace *value* (where 1/jitter would masquerade as a posterior variance). Rejecting
-    # a merely ill-conditioned -H sent well-behaved batches back to the prior-centered
-    # rule of issue #98, whose signed sum turns negative, which makes the objective jump
-    # to +Inf for those θ (issue #151).
+    # which is also what `negH_definite_without_jitter` now applies to the Laplace *value*
+    # (jitter would let 1/jitter masquerade as a posterior variance there). Rejecting a
+    # merely ill-conditioned -H sent well-behaved batches back to the prior-centered rule
+    # of issue #98, whose signed sum turns negative, which makes the objective jump to
+    # +Inf for those θ (issue #151).
     chol, used_jitter = _laplace_cholesky_negH(H; jitter = jitter, max_tries = max_tries)
     (chol === nothing || chol.info != 0 || !iszero(used_jitter)) && return nothing
     L = chol.L  # lower triangular, L*L' = -H

--- a/test/api_primitives_tests.jl
+++ b/test/api_primitives_tests.jl
@@ -639,8 +639,8 @@ end
 # The Laplace/AGHQ marginal is only defined at a genuine interior mode. If a curvature
 # direction is uninformative, the `-½logdet(-H)` term is set by the jitter (~1/jitter) and
 # inflates the marginal without bound -- it can then exceed the exact ceiling
-# -n/2·log(2πσ²) that the true marginal must respect. The test is relative, so the verdict
-# tracks the conditioning of `-H` and never the units the data is recorded in.
+# -n/2·log(2πσ²) that the true marginal must respect. The verdict is the un-jittered
+# Cholesky itself, so a log-det that measures data is kept whatever its conditioning.
 @testset "negH_definite_without_jitter guards the Laplace marginal" begin
     ok = NoLimits.negH_definite_without_jitter
 
@@ -649,13 +649,16 @@ end
     # Zero-dimensional batch: nothing to check.
     @test ok(zeros(0, 0))
 
-    # A direction with no curvature relative to the rest: only the jitter would make the
-    # Cholesky succeed, so the log-det would measure the regularisation.
-    for lam in (0.0, 1e-14, 1e-10)
-        @test !ok(-Matrix(Diagonal([1.0, 1.0, lam])))
+    # A direction with no curvature at all: only the jitter would make the Cholesky
+    # succeed, so the log-det would measure the regularisation.
+    @test !ok(-Matrix(Diagonal([1.0, 1.0, 0.0])))
+    # Issue #157: ill-conditioned but definite must PASS. A 1-obs individual at t = 4e3
+    # has -H = xxᵀ/σ² + Ω⁻¹ with condition number ~t²; the old relative test
+    # (λmin > 1e-8·λmax) called that degenerate, and the resulting -Inf cliff stalled the
+    # outer optimizer ~1800 nats short of the optimum.
+    for lam in (1e-14, 1e-10, 1e-4)
+        @test ok(-Matrix(Diagonal([1.0, 1.0, lam])))
     end
-    # Small but informative curvature must pass, so the guard is not over-eager.
-    @test ok(-Matrix(Diagonal([1.0, 1.0, 1e-4])))
 
     # Indefinite (b* is a saddle, not a maximum) and non-finite entries are rejected.
     @test !ok(-Matrix(Diagonal([1.0, -2.0])))
@@ -690,10 +693,10 @@ end
         @test 2 * sum(log, diag(cw.U))≈logdet(-Hwide) rtol=1e-12
     end
 
-    # Unit-invariance: the verdict follows conditioning, not scale. A relative threshold
-    # gives this for free; both absolute floors previously tried did not.
-    Hfine = -Matrix(Diagonal([1.0, 1.0, 1e-4]))    # cond 1e4  -> informative
-    Hdeg = -Matrix(Diagonal([1.0, 1.0, 1e-12]))    # cond 1e12 -> degenerate
+    # Unit-invariance: the verdict follows definiteness, not scale. The un-jittered
+    # Cholesky gives this for free; both absolute floors previously tried did not.
+    Hfine = -Matrix(Diagonal([1.0, 1.0, 1e-4]))    # informative
+    Hdeg = -Matrix(Diagonal([1.0, 1.0, 0.0]))      # no curvature -> degenerate
     for s in (1e-6, 1.0, 1e3, 1e6)
         @test ok(s .* Hfine)
         @test !ok(s .* Hdeg)

--- a/test/estimation_ghquadrature2_tests.jl
+++ b/test/estimation_ghquadrature2_tests.jl
@@ -864,7 +864,9 @@ end
         bstars = NoLimits.empirical_bayes(dm1, θ; rng = Xoshiro(2))
         H = NoLimits._laplace_hessian_b(dm1, infos[1], θ_re,
             Vector{Float64}(bstars[1]), cc, cache, nothing, 1)
-        @test !NoLimits.negH_definite_without_jitter(H)   # what used to force the fallback
+        # Admissible since #157 too: it factorizes without jitter. The old relative test
+        # (λmin > 1e-8·λmax) rejected it, which is what forced the fallback below.
+        @test NoLimits.negH_definite_without_jitter(H)
         rm = NoLimits.build_centered_re_measure(
             bstars[1], infos[1], 1, θ_re, cc, dm1, cache)
         @test rm !== nothing


### PR DESCRIPTION
Closes #157.

## The bug

`Laplace` converged ~1900 nats short of the optimum on badly scaled data and reported
fixed effects far from the simulation truth, while `GHQuadrature` on the identical data
and starting values landed at it.

It is an **outer-optimisation failure, not an approximation gap**. On the reproducer
(M18, a linear-Gaussian random intercept+slope where the Laplace expansion is exact):

| θ | `laplace_marginal` | `ghq_marginal` | diff |
|---|---|---|---|
| θ_laplace | -2437.533393594051 | -2437.533393594051 | 0.0 |
| θ_ghq | -625.0231151946524 | -625.0231151946524 | 0.0 |
| θ_truth | -626.3775965825182 | -626.3775965825182 | 0.0 |

Same function, different search. Warm-starting `Laplace()` from θ_ghq holds 625.0231 after
2 iterations, and the FD gradient at the stall point is -558.7 in the `a` coordinate - not
remotely stationary.

## Cause

`negH_definite_without_jitter` declared any empirical-Bayes Hessian with condition number
`>= 1e8` degenerate (`λmin > 1e-8·λmax`), which makes the batch marginal `-Inf`. Every one
of the 150 batch `-H` at the stall point is positive definite and factorizes untouched -
what fired was the guard.

The worst batch is a **single-observation individual at t = 4190.8**. Its
`-H = xxᵀ/σ² + Ω⁻¹` is perfectly well posed; it is ill-conditioned only because `t²` is
1.8e7 times the intercept direction, which is exactly what data spanning `1e-3..5e3`
produces. Minimum `λmin/λmax` across batches:

| θ | min `λmin/λmax` |
|---|---|
| Laplace stall point | **1.00000000000017e-8** |
| θ_ghq | 2.944995222057963e-8 |
| θ_truth | 2.6874836042982612e-8 |

Sixteen digits of agreement with the threshold: LBFGS climbed until the worst-conditioned
individual sat exactly on the cliff and the line search had nowhere to step. The optimum
is admissible, but by a factor of only ~3 - the cliff runs through the search region.

## The fix

Admissibility is the un-jittered Cholesky itself:

```julia
function negH_definite_without_jitter(H::AbstractMatrix)
    size(H, 1) == 0 && return true
    Hneg = -_scalar_value.(H)
    all(isfinite, Hneg) || return false
    return cholesky(Symmetric(Hneg), check = false).info == 0
end
```

This is the most permissive test that still excludes the failure mode the guard exists for
(a `-½·logdet(-H)` term measuring the rescue jitter rather than the data), it is the
criterion `remeasure.jl` already applied to the AGHQ scaling, and it drops an `eigvals`
from the hot path.

Lowering `rtol` was not an option: the suite demands the guard reject a relative λ of
`1e-10` and accept `1e-4`, while this fixture needs `1e-8` accepted - two decades from a
case that must be rejected. A single relative eigenvalue cutoff cannot separate "genuinely
uninformative direction" from "well-posed but badly scaled individual".

## Result

| | before | after |
|---|---|---|
| `Laplace` serial | 2437.5334 | 625.0231151943991 |
| `Laplace` threaded | 896.4256 (per #116) | 625.0231151553966 |
| `FOCEI` serial | - | 625.0231151798534 |
| `FOCEI` threaded | - | 625.0231151900053 |
| `GHQuadrature(level = 5)` | 625.0231151946522 | 625.0231151946521 |

All five agree to ~4e-8 absolute (6e-11 relative) and θ matches GHQ's to seven digits.
The serial/threaded split #116 recorded on this same fixture goes with it - an `Inf` cliff
running through the search path is exactly what turns 1e-16 reduction-order noise into an
O(1) objective gap.

## Tests

Two tests encoded the old threshold and are updated:

- `api_primitives_tests.jl`: the must-reject loop over `(0.0, 1e-14, 1e-10)` becomes a
  must-reject of `0.0` plus a must-**pass** of `(1e-14, 1e-10, 1e-4)`, carrying the #157
  rationale. The unit-invariance block's degenerate matrix becomes a genuinely singular one.
- `estimation_ghquadrature2_tests.jl`: the ill-conditioned-but-definite `-H` from the #151
  case is now admissible to the Laplace value as well, so that assertion is flipped.

Ran locally, all green: groups 5, 9, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 26 -
every group touching the Laplace/AGHQ marginal.

## Consumers checked

`_laplace_grad_batch` early-returns on `logdet == Inf` before touching the factor; both
outer-objective paths keep the same short-circuit; `identifiability.jl` uses only `H`;
`empirical_bayes_covariance` keeps its `nothing`-iff-rejected semantics (and now returns a
covariance where it previously gave up); `remeasure.jl`'s comment is updated so the two
rules read as the same rule. No other conditioning guard exists in `src/`, and no doc
describes the old behaviour.

## Known residual

A numerically-PD-but-near-singular `-H` is now admitted, so the Laplace value can exceed
the `-n/2·log(2πσ²)` ceiling in a nearly-flat posterior direction. That is a genuine
defect of the Gaussian approximation there rather than the jitter artifact the guard was
built for, and it is the price of not rejecting well-posed fits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
