### PR TITLE
test: pin censored outcome distributions across estimators (#197)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -50,6 +50,7 @@ makedocs(;
             "@DifferentialEquation" => "model-building/differential-equation.md",
             "@initialDE" => "model-building/initial-de.md",
             "@formulas" => "model-building/formulas.md",
+            "Copula Distributions" => "model-building/copulas.md",
             "Function Approximators (NNs + SoftTrees)" => "model-building/universal-function-approximators.md"
         ],
         "Data Model Construction" => "data-model-construction.md",

--- a/docs/src/model-building/copulas.md
+++ b/docs/src/model-building/copulas.md
@@ -6,7 +6,7 @@ Both require `Copulas` to be loaded alongside NoLimits, since it is an optional 
 
 ```julia
 using Pkg; Pkg.add("Copulas")
-using NoLimits, Copulas, Distributions
+using NoLimits, Copulas, Distributions, DataFrames, Random
 ```
 
 ## Copula as a Random-Effect Distribution
@@ -27,7 +27,8 @@ model = @Model begin
 
     @randomEffects begin
         D = RandomEffect(
-            SklarDist(ClaytonCopula(2, 3.0), (Normal(mu1, 0.9), Normal(mu2, 0.6)));
+            Copulas.SklarDist(Copulas.ClaytonCopula(2, 3.0),
+                (Normal(mu1, 0.9), Normal(mu2, 0.6)));
             column=:ID)
     end
 
@@ -38,6 +39,9 @@ end
 ```
 
 `D` is a two-element random effect and is indexed as `D[1]`, `D[2]` exactly like an `MvNormal` one. The copula parameter can be estimated too: declare it as a fixed effect on the log scale and pass it in, as `thc` does in the outcome example below.
+
+!!! note "Qualify Copulas names inside `@randomEffects`"
+    The random-effect distribution builder is compiled into a generated-function module that does not see the `using Copulas` in your script, so `Copulas.SklarDist` and `Copulas.ClaytonCopula` must be written out in full. A bare `SklarDist(...)` builds the model without complaint and then fails with `UndefVarError: SklarDist not defined` when you construct the `DataModel`. `@formulas` resolves against your own scope, so the outcome example below can use the short names.
 
 Estimation works with `Laplace`, `GHQuadrature`, `Pooled`, `MCMC` and the other random-effects methods. Three internals are worth knowing about, because they are what makes the marginals matter more than the copula itself:
 
@@ -82,7 +86,7 @@ truth = SklarDist(ClaytonCopula(2, 2.0), (Normal(0.3, 0.8), Normal(1.2, 0.5)))
 df = DataFrame(vec([(ID=i, t=Float64(j), y=rand(rng, truth)) for i in 1:6, j in 1:4]))
 
 dm = DataModel(model, df; primary_id=:ID, time_col=:t)
-res = fit_model(dm, Laplace())
+res = fit_model(dm, NoLimits.Laplace())
 ```
 
 `get_loglikelihood`, `simulate_data` and `cross_validate` all work on the result, and `simulate_data` returns a `y` column of two-element vectors matching the input shape. `get_residuals` returns one row per observation as usual, but the scalar residual metrics (`pit`, `res_quantile`, `res_raw`, `res_pearson`, `logscore`) are `missing` for vector-valued observations and a warning says so; they have no scalar definition here. Judge fit through the log-likelihood, cross-validation, or dimension-wise plots built from `simulate_data` instead.

--- a/docs/src/model-building/copulas.md
+++ b/docs/src/model-building/copulas.md
@@ -1,0 +1,96 @@
+# Copula Distributions
+
+[Copulas.jl](https://github.com/lrnv/Copulas.jl) separates a multivariate distribution into its marginals and the dependence structure linking them. A `SklarDist(copula, marginals)` behaves as an ordinary `Distributions.jl` multivariate distribution, so NoLimits accepts one in either of the two places a distribution can appear: as a random-effect distribution in `@randomEffects`, and as an outcome distribution in `@formulas`.
+
+Both require `Copulas` to be loaded alongside NoLimits, since it is an optional dependency:
+
+```julia
+using Pkg; Pkg.add("Copulas")
+using NoLimits, Copulas, Distributions
+```
+
+## Copula as a Random-Effect Distribution
+
+Multivariate random effects are usually given an `MvNormal`, which forces both the marginals and the dependence to be Gaussian. A copula decouples the two: below, the two random effects keep Normal marginals whose means are estimated, while a Clayton copula imposes lower-tail dependence, so subjects low in one effect tend to be low in the other more strongly than a Gaussian correlation would allow.
+
+```julia
+model = @Model begin
+    @fixedEffects begin
+        mu1 = RealNumber(0.2; prior=Normal(0.0, 2.0))
+        mu2 = RealNumber(-0.3; prior=Normal(0.0, 2.0))
+        s = RealNumber(0.7; scale=:log, prior=LogNormal(0.0, 1.0))
+    end
+
+    @covariates begin
+        t = Covariate()
+    end
+
+    @randomEffects begin
+        D = RandomEffect(
+            SklarDist(ClaytonCopula(2, 3.0), (Normal(mu1, 0.9), Normal(mu2, 0.6)));
+            column=:ID)
+    end
+
+    @formulas begin
+        y ~ Normal(D[1] + 0.5 * D[2], s)
+    end
+end
+```
+
+`D` is a two-element random effect and is indexed as `D[1]`, `D[2]` exactly like an `MvNormal` one. The copula parameter can be estimated too: declare it as a fixed effect on the log scale and pass it in, as `thc` does in the outcome example below.
+
+Estimation works with `Laplace`, `GHQuadrature`, `Pooled`, `MCMC` and the other random-effects methods. Three internals are worth knowing about, because they are what makes the marginals matter more than the copula itself:
+
+- `GHQuadrature` transports its quadrature nodes through the marginal quantile functions, and `MCMC` samples in a product-of-marginals base space. Both read the marginals out of the `SklarDist` through the `NoLimits._re_marginals` hook that the `Copulas` extension provides.
+- `Pooled` plugs the random effect in at its mean. A copula never shifts its marginals, so the marginal means are the exact plug-in value; `get_notes(res).plugin.D` reports `:mean` rather than a Monte Carlo fallback.
+- `get_random_effects` returns one column per dimension, here `D_1` and `D_2`.
+
+## Copula as an Outcome Distribution
+
+When each observation is a vector of jointly measured quantities, a copula outcome models their dependence without forcing joint normality. The observation column holds vector-valued cells, one vector per row, matching the copula's dimension.
+
+```julia
+model = @Model begin
+    @fixedEffects begin
+        nu1 = RealNumber(0.0)
+        nu2 = RealNumber(1.0)
+        w1 = RealNumber(1.0; scale=:log)
+        w2 = RealNumber(1.0; scale=:log)
+        thc = RealNumber(1.5; scale=:log)
+    end
+
+    @covariates begin
+        t = Covariate()
+    end
+
+    @randomEffects begin
+        eta = RandomEffect(Normal(0.0, 0.3); column=:ID)
+    end
+
+    @formulas begin
+        y ~ SklarDist(ClaytonCopula(2, thc), (Normal(nu1 + eta, w1), Normal(nu2, w2)))
+    end
+end
+```
+
+Here `thc` is the Clayton dependence parameter, estimated on the log scale alongside the marginal locations and scales, and the subject-level `eta` shifts the first marginal only. Building the `DataModel` needs a `y` column whose cells are two-element vectors:
+
+```julia
+using Random
+rng = Xoshiro(7)
+truth = SklarDist(ClaytonCopula(2, 2.0), (Normal(0.3, 0.8), Normal(1.2, 0.5)))
+df = DataFrame(vec([(ID=i, t=Float64(j), y=rand(rng, truth)) for i in 1:6, j in 1:4]))
+
+dm = DataModel(model, df; primary_id=:ID, time_col=:t)
+res = fit_model(dm, Laplace())
+```
+
+`get_loglikelihood`, `simulate_data` and `cross_validate` all work on the result, and `simulate_data` returns a `y` column of two-element vectors matching the input shape. `get_residuals` returns one row per observation as usual, but the scalar residual metrics (`pit`, `res_quantile`, `res_raw`, `res_pearson`, `logscore`) are `missing` for vector-valued observations and a warning says so; they have no scalar definition here. Judge fit through the log-likelihood, cross-validation, or dimension-wise plots built from `simulate_data` instead.
+
+Note that `FOCEI` builds its Fisher-information surrogate from a fixed list of outcome families and rejects a `SklarDist` outcome. Use `Laplace`, which makes no distributional assumption beyond a twice-differentiable log-density. This restriction applies to the outcome distribution only; a copula random effect is fine under `FOCEI`.
+
+## Related Pages
+
+- [`@randomEffects`](random-effects.md) for the general random-effect declaration syntax.
+- [`@formulas`](formulas.md) for outcome distributions, including third-party distributions in general.
+- [Installation](../installation.md) for the full list of optional dependencies.

--- a/docs/src/model-building/formulas.md
+++ b/docs/src/model-building/formulas.md
@@ -333,6 +333,43 @@ end
 
 Here `delta_t` is a time-varying covariate holding the elapsed time since the previous observation for each row. The `outcome` column must hold two-element vectors matching the dimension of the `MvNormal` emissions. Partially-missing vectors (e.g. `[1.2, missing]`) are handled by marginalizing the `MvNormal` over the observed index.
 
+## Example: Outcome Distributions from Other Packages
+
+The right-hand side of a `~` statement is ordinary Julia code, and the likelihood only ever calls the generic `Distributions.jl` interface on the result. Any `Distribution` from any package therefore works as an outcome without registration or glue code. [CensoredDistributions.jl](https://github.com/EpiAware/CensoredDistributions.jl), which supplies the interval- and primary-event-censored distributions common in epidemiological delay modelling, is a typical case:
+
+```julia
+using CensoredDistributions
+
+model = @Model begin
+    @fixedEffects begin
+        a = RealNumber(1.0)
+        sigma = RealNumber(0.6; scale=:log)
+        omega = RealNumber(0.4; scale=:log)
+    end
+
+    @covariates begin
+        t = Covariate()
+    end
+
+    @randomEffects begin
+        eta = RandomEffect(Normal(0.0, omega); column=:ID)
+    end
+
+    @formulas begin
+        mu = a + eta + 0.1 * t
+        y ~ interval_censored(Normal(mu, sigma), 1.0)
+    end
+end
+```
+
+This fits with `MLE`, `MAP`, `MCMC`, `Laplace`, `GHQuadrature`, `SAEM`, `MCEM`, `Pooled` and `PooledMap`, and `get_loglikelihood`, `get_random_effects`, `simulate_data` and `get_residuals` all behave as usual. Three caveats apply to any outcome distribution outside the standard families, not just censored ones:
+
+- `FOCEI` builds its Fisher-information surrogate from a fixed list of families and rejects anything outside it with an error naming the supported ones. Use `Laplace` instead, which makes no such assumption.
+- Distributions whose log-density is `-Inf` over part of the parameter space, including censored and truncated ones, can make `VI` diverge, because the ADVI sampler visits those regions during adaptation. The optimization-based methods are unaffected.
+- `get_residuals` fills `res_raw` and `res_pearson`, and `plot_fits` draws its prediction line, from `mean` and `var`. A distribution that defines neither leaves those columns `missing`; `pit`, `res_quantile` and `logscore` need only `cdf` and `logpdf` and remain available.
+
+For the simpler case of censoring at a detection limit, `censored(...)` from `Distributions.jl` needs no extra package. See the [left-censored viral load tutorial](../tutorials/mixed-effects-left-censored-virload50-laplace.md).
+
 ## Related APIs
 
 Programmatic access to the internal representation and evaluation of formulas is provided by `get_formulas_meta`, `get_formulas_ir`, `get_formulas_builders`, and `get_formulas_time_offsets`. Full signatures are in the [API reference](../api.md).

--- a/test/estimation_common_tests.jl
+++ b/test/estimation_common_tests.jl
@@ -757,3 +757,45 @@ end
         end
     end
 end
+
+@testset "censored outcome distributions" begin
+    # Issue #197: any third-party `Distribution` with a `logpdf` works as an outcome
+    # without integration code -- `Distributions.censored` stands in here for
+    # CensoredDistributions.jl, which exercises the same generic dispatch.
+    model = @Model begin
+        @fixedEffects begin
+            a = RealNumber(1.0)
+            σ = RealNumber(0.6; scale = :log)
+            ω = RealNumber(0.4; scale = :log)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η = RandomEffect(Normal(0.0, ω); column = :ID)
+        end
+        @formulas begin
+            μ = a + η + 0.1 * t
+            y ~ censored(Normal(μ, σ); upper = 2.0)
+        end
+    end
+    df = DataFrame(ID = repeat(1:6, inner = 3), t = repeat([0.0, 1.0, 2.0], 6),
+        y = [1.0, 1.4, 2.0, 0.7, 1.2, 1.9, 1.3, 2.0, 2.0, 0.9, 1.1, 1.6,
+            1.5, 1.8, 2.0, 0.6, 1.0, 1.7])
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+
+    for (name, method) in (
+        ("Laplace", NoLimits.Laplace(; optim_kwargs = (maxiters = 3,))),
+        ("GHQuadrature",
+            NoLimits.GHQuadrature(; level = 2,
+                optim_kwargs = (maxiters = 3,))),
+        ("Pooled", NoLimits.Pooled(; optim_kwargs = (maxiters = 3,))))
+        @testset "$name" begin
+            @test isfinite(get_objective(fit_model(dm, method)))
+        end
+    end
+
+    # FOCEI dispatches on a fixed family whitelist for its Fisher-information
+    # surrogate, so it rejects censored outcomes by design rather than silently.
+    @test_throws ErrorException fit_model(dm, NoLimits.FOCEI())
+end


### PR DESCRIPTION
Closes the investigation part of #197.

Censored outcome distributions (`CensoredDistributions.jl`, `Distributions.censored`) already work as `@formulas` outcomes with MLE, MAP, MCMC, Laplace, GHQuadrature, SAEM, MCEM, Pooled and PooledMap - NoLimits only calls the generic `Distributions` API on outcome distributions, and the `mean`/`std` sites in plotting are already try/catch-guarded. No extension or weak dependency is needed; see the [issue comment](https://github.com/manuhuth/NoLimits.jl/issues/197#issuecomment-5297237368) for the full matrix and the two genuine gaps (FOCEI rejects by design, VI diverges on the `-Inf` tails).

This adds one testset in `test/estimation_common_tests.jl` using `Distributions.censored`, so the compile-bound suite gains no new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)