### PR TITLE
release: v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,23 @@
 
 ## Unreleased
 
+## v0.2.3
+
+### Features
+
+- Turing.jl is now a weak dependency (#36). `using NoLimits` no longer loads it, cutting
+  load time and dependency count; `MCMC`, `VI`, the chain-based UQ refit and the Turing
+  E-step samplers require an explicit `using Turing`. `MCEM`'s default E-step is now the
+  Turing-free `MCEM_MCMC(sampler = SaemixMH(), sample_schedule = 100)` - pass
+  `NUTS(0.75)` / `250` to restore the previous default.
+- Random effects can be given a copula distribution from Copulas.jl (#177), loaded via
+  the `NoLimitsCopulasExt` extension, with adaptive Gauss-Hermite quadrature support.
+
 ### Bug fixes
 
+- `get_marginal_likelihood` omitted the prior density of random-effect levels pinned via
+  `constants_re`, so likelihoods were not comparable across models pinning different
+  levels (#171).
 - `Laplace` (and the FOCEI/AGHQ paths sharing its marginal) stopped ~1900 nats short of
   the optimum on badly scaled data, reporting fixed effects far from the truth while
   `GHQuadrature` on the same data and start landed at it (#157). The admissibility test

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NoLimits"
 uuid = "1d491b74-35a5-408f-ae19-cf8524c3769d"
 license = "MIT"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Manuel Huth", "Jonas Arruda", "Clemens Peiter", "Roy Gusinow", "Nina Schmid", "Jan Hasenauer"]
 
 [deps]


### PR DESCRIPTION
Bumps `Project.toml` to 0.2.3 and cuts the CHANGELOG section for it.

Since v0.2.2:
- Turing.jl is a weak dependency (#36); `MCEM`'s default E-step is the Turing-free `SaemixMH()`.
- Copulas.jl random effects via `NoLimitsCopulasExt` (#177).
- `get_marginal_likelihood` includes the prior density of `constants_re`-pinned levels (#171).
- Laplace admissibility guard no longer rejects well-posed ill-conditioned batches (#157).

🤖 Generated with [Claude Code](https://claude.com/claude-code)