### PR TITLE
fix: close the estimation audit findings from #229

### DIFF
--- a/src/estimation/Multistart.jl
+++ b/src/estimation/Multistart.jl
@@ -142,21 +142,27 @@ function _lhs_draws_array(dist, n::Int, rng::AbstractRNG, size_hint)
     return out
 end
 
+# NaN compares false against both bounds, so the finiteness test is what keeps a NaN or
+# Inf draw from reaching the optimizer as a start value (#229).
 function _check_bounds(name::Symbol, v, lower, upper)
     if v isa Number
-        if !(v >= lower && v <= upper)
-            error("Multistart sampling for $(name) violates bounds. Use a truncated distribution for sampling.")
+        if !(isfinite(v) && v >= lower && v <= upper)
+            error("Multistart start for $(name) is not finite or violates bounds (got $(v)). Use a truncated distribution for sampling.")
         end
         return
     end
-    bad = findall((v .< lower) .| (v .> upper))
+    bad = findall(@. !isfinite(v) | (v < lower) | (v > upper))
     return isempty(bad) ||
-        error("Multistart sampling for $(name) violates bounds at indices $(bad). Use a truncated distribution for sampling.")
+        error("Multistart start for $(name) is not finite or violates bounds at indices $(bad). Use a truncated distribution for sampling.")
 end
 
 function _sample_param(
         name::Symbol, value, dist, n::Int, sampling::Symbol, rng::AbstractRNG
     )
+    # PSD parameter blocks must be symmetric positive-definite to be transformable at
+    # all, so a sampled matrix is repaired rather than rejected: symmetrized, then
+    # jittered until it factors. The repair is deliberate — a start that cannot be
+    # transformed is not a usable start (#229).
     function _fix_matrix(v)
         if v isa AbstractMatrix && size(v, 1) == size(v, 2)
             v = 0.5 .* (v .+ transpose(v))
@@ -173,6 +179,8 @@ function _sample_param(
     end
 
     if dist isa AbstractArray
+        size(dist) == size(value) ||
+            error("Multistart sampling for $(name): the distribution array has size $(size(dist)) but the parameter has size $(size(value)).")
         # `copy`, not `similar`: coordinates whose distribution is `nothing` keep the
         # model start value instead of holding uninitialized memory (#226).
         samples = [copy(value) for _ in 1:n]
@@ -526,7 +534,7 @@ function _multistart_screen(
     # prior-mean screen there instead of scoring a different model (#226).
     if screening == :ebe && _has_crossed_individuals(dm)
         @warn "Multistart: screening=:ebe does not support crossed random-effect designs (an individual spans several levels); using prior-mean screening instead."
-        screening = :loglik
+        screening = :prior_mean
     end
     # EBE inner optimization is serial per individual; use EnsembleSerial for that path.
     cache_serialization = screening == :ebe ? EnsembleSerial() : serialization
@@ -556,21 +564,16 @@ function _multistart_screen(
     return candidates[idxs], selected_scores
 end
 
+# Runs are ranked by their own objective. A non-finite objective means the run failed;
+# it used to fall back to -loglikelihood, which drops priors/penalties and could rank a
+# degenerate MAP or penalized fit ahead of a valid one (#229).
 function _multistart_score(res::FitResult)
     obj = try
         get_objective(res)
     catch
         NaN
     end
-    if isfinite(obj)
-        return obj
-    end
-    ll = try
-        get_loglikelihood(res)
-    catch
-        NaN
-    end
-    return isfinite(ll) ? -ll : Inf
+    return isfinite(obj) ? obj : Inf
 end
 
 """
@@ -669,6 +672,16 @@ function fit_model(ms::Multistart, dm::DataModel, method::FittingMethod, args...
         @info "Multistart" candidates = n_req selected = n_used varying = varied_str
     end
     if theta_0_user !== nothing
+        # Sampled starts are bounds- and finiteness-checked in `_multistart_initials`;
+        # the explicit one goes through the same gate rather than a second path (#229).
+        bounds = get_bounds_untransformed(get_fixed(get_model(dm)))
+        for name in get_names(get_fixed(get_model(dm)))
+            hasproperty(theta_0_user, name) || continue
+            _check_bounds(
+                name, getproperty(theta_0_user, name),
+                getproperty(bounds[1], name), getproperty(bounds[2], name)
+            )
+        end
         starts = vcat([theta_0_user], starts)
         @info "Multistart: explicit theta_0_untransformed kept as start 1."
     end

--- a/src/estimation/cv.jl
+++ b/src/estimation/cv.jl
@@ -150,7 +150,16 @@ function cross_validate(
     n_folds >= 2 || error("n_folds must be ≥ 2, got $n_folds")
     kind ∈ (:id, :observation) || error("kind must be :id or :observation, got $kind")
     n = length(get_individuals(dm))
-    n >= n_folds || error("n_folds ($n_folds) exceeds number of individuals ($n)")
+    if kind == :id
+        n >= n_folds || error("n_folds ($n_folds) exceeds number of individuals ($n)")
+    else
+        # Observation folds split each individual's observations round-robin, so the
+        # binding constraint is observations per individual, not the individual count
+        # (#229): every fold needs at least one observation to score.
+        max_obs = maximum(length.(get_obs_rows(get_row_groups(dm))); init = 0)
+        max_obs >= n_folds ||
+            error("n_folds ($n_folds) exceeds the largest number of observations for one individual ($max_obs); some folds would be empty.")
+    end
 
     train_rows = Vector{Vector{Int}}(undef, n_folds)
     test_rows = Vector{Vector{Int}}(undef, n_folds)
@@ -501,11 +510,17 @@ function _cv_evaluate_mc(
     )
     η_train_vec = _eta_from_eb(dm_train, batch_infos, bstars, const_cache, θu)
 
-    # Lookup: test individual re_groups → (batch_idx, train_ind_idx)
-    re_to_train = Dict{Any, Tuple{Int, Int}}()
+    # Lookup per random effect and level, not per full level tuple: a crossed test
+    # individual can share one trained level while another of its levels is new, and only
+    # the new one needs the prior (#229). For a non-crossed design this is the same
+    # mapping the whole-tuple lookup produced.
+    level_train = Dict{Tuple{Symbol, Any}, Tuple{Int, Int}}()
     for (bi, info) in enumerate(batch_infos)
         for i in get_inds(info)
-            re_to_train[get_re_groups(get_individuals(dm_train)[i])] = (bi, i)
+            g = get_re_groups(get_individuals(dm_train)[i])
+            for re in re_names
+                level_train[(re, getproperty(g, re))] = (bi, i)
+            end
         end
     end
     ref_eta = η_train_vec[1]
@@ -535,47 +550,51 @@ function _cv_evaluate_mc(
     all_dfs = [Vector{DataFrame}(undef, n_test) for _ in 1:n_mc_samples]
     for s in 1:n_mc_samples
         srng = sample_rngs[s]
+        # Conditional draws are built per training individual, once per sample.
+        cond_cache = Dict{Int, ComponentArray}()
         for j in 1:n_test
             ind_j = get_individuals(dm_test)[j]
-            key = get_re_groups(ind_j)
-            tinfo = get(re_to_train, key, nothing)
-            is_seen = tinfo !== nothing
-
-            η_j = if is_seen && seen_re_mode == :conditional
-                bi, ti = tinfo
-                b_s = bstars_per_sample[s][bi]
-                ComponentArray(
-                    _build_eta_ind(
-                        dm_train, ti, batch_infos[bi], b_s, const_cache, θu
-                    )
+            g = get_re_groups(ind_j)
+            unseen_dists() = get!(
+                () -> dists_builder(
+                    θu, get_const_cov(ind_j), model_funs_test, helpers_test
+                ),
+                unseen_dists_cache, j
+            )
+            prior_eta() = get!(
+                () -> _cv_prior_mean_eta(
+                    dm_test, j, θu, dists_builder,
+                    model_funs_test, helpers_test,
+                    re_names, ref_eta
+                ),
+                mean_eta_cache, j
+            )
+            η_j = ComponentArray(
+                NamedTuple(
+                    map(re_names) do re
+                        tinfo = get(level_train, (re, getproperty(g, re)), nothing)
+                        v = if tinfo !== nothing && seen_re_mode == :conditional
+                            bi, ti = tinfo
+                            η_ti = get!(cond_cache, ti) do
+                                ComponentArray(
+                                    _build_eta_ind(
+                                        dm_train, ti, batch_infos[bi],
+                                        bstars_per_sample[s][bi], const_cache, θu
+                                    )
+                                )
+                            end
+                            getproperty(η_ti, re)
+                        elseif tinfo !== nothing   # :ebe — same for every sample
+                            getproperty(η_train_vec[tinfo[2]], re)
+                        elseif unseen_re_mode == :montecarlo
+                            rand(srng, getproperty(unseen_dists(), re))
+                        else                       # :mean — same for every sample
+                            getproperty(prior_eta(), re)
+                        end
+                        return re => v
+                    end
                 )
-            elseif is_seen   # :ebe — same for every sample
-                η_train_vec[tinfo[2]]
-            elseif unseen_re_mode == :montecarlo
-                dists = get!(
-                    () -> dists_builder(
-                        θu, get_const_cov(ind_j), model_funs_test, helpers_test
-                    ),
-                    unseen_dists_cache, j
-                )
-                ComponentArray(
-                    NamedTuple(
-                        (
-                            re => rand(srng, getproperty(dists, re))
-                                for re in re_names
-                        )
-                    )
-                )
-            else             # :mean — RE prior mean, same for every sample
-                get!(
-                    () -> _cv_prior_mean_eta(
-                        dm_test, j, θu, dists_builder,
-                        model_funs_test, helpers_test,
-                        re_names, ref_eta
-                    ),
-                    mean_eta_cache, j
-                )
-            end
+            )
 
             all_dfs[s][j] = _eval_individual_obs(
                 dm_test, j, θu, η_j, ll_cache_test, loss; score_rows = score_rows
@@ -686,8 +705,11 @@ performance on the held-out test set. All `kwargs` are forwarded to
 With `seen_re_mode=:ebe, unseen_re_mode=:mean` each random effect's level is resolved
 separately, so a crossed test individual keeps the trained value for every level it shares
 with the training fold and falls back to the prior only for genuinely new levels. The
-Monte-Carlo modes (`:conditional`/`:montecarlo`) still resolve on the full level tuple: an
-individual that shares only some of its levels is treated as unseen there.
+Monte-Carlo modes (`:conditional`/`:montecarlo`) resolve levels the same way.
+
+`MCMC`/`VI` fits carry no empirical-Bayes random effects; their test predictions are made at
+zero/population random effects and `seen_re_mode`/`unseen_re_mode` do not apply (a warning is
+emitted). Refit with an EBE-based estimator for random-effect-aware cross-validation.
 
 [`Pooled`](@ref)/[`PooledMap`](@ref) fits evaluate every test individual — seen or
 unseen — at the deterministic plug-in η computed from that individual's covariates
@@ -766,7 +788,10 @@ function fit_cv(
             # Pooled/PooledMap: plug-in η from each test individual's covariates
             _cv_evaluate_pooled(dm_test, res_train, θu, ll_cache_test, loss, score_rows)
         elseif !_cv_has_re_support(res_train)
-            # Method without EBE support (e.g. MCMC) → evaluate at zero RE
+            # MCMC/VI results carry no empirical-Bayes modes, so predictions are made at
+            # the RE prior location. Say so rather than letting seen_re_mode look honored
+            # (#229).
+            @warn "fit_cv: $(nameof(typeof(get_result(res_train)))) fits provide no empirical-Bayes random effects; test predictions use zero/population random effects and seen_re_mode/unseen_re_mode do not apply. Refit with Laplace/FOCEI/GHQuadrature/SAEM/MCEM for random-effect-aware cross-validation." maxlog = 1
             _cv_collect_obs(dm_test, θu, nothing, ll_cache_test, loss, score_rows)
         elseif seen_re_mode == :ebe && unseen_re_mode == :mean
             _cv_evaluate_ebe(
@@ -782,7 +807,13 @@ function fit_cv(
 
         insertcols!(obs_df, 1, :fold => fill(f, nrow(obs_df)))
 
-        ll_finite = filter(!isnan, obs_df[!, :loglikelihood])
+        # A fold can score nothing at all (every outcome missing, every ODE solve
+        # failed): keep the empty frame instead of indexing a column that is not there.
+        ll_all = "loglikelihood" ∈ names(obs_df) ? obs_df[!, :loglikelihood] : Float64[]
+        ll_finite = filter(!isnan, ll_all)
+        n_dropped = length(ll_all) - length(ll_finite)
+        n_dropped == 0 ||
+            @warn "fit_cv: fold $f scored $(length(ll_finite)) of $(length(ll_all)) held-out observations; $(n_dropped) had a non-finite log-likelihood and were dropped from the fold total."
         test_ll = isempty(ll_finite) ? NaN : sum(ll_finite)
 
         fit_res = store_results ? res_train : nothing

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -2156,6 +2156,14 @@ end
 
 struct LaplaceCacheOptions{T}
     theta_tol::T
+
+    # A negative tolerance makes every cache-reuse comparison fail, silently disabling
+    # the EBE/Hessian cache instead of tightening it (#229).
+    function LaplaceCacheOptions(theta_tol::T) where {T}
+        (isfinite(theta_tol) && theta_tol >= 0) ||
+            error("LaplaceCacheOptions: theta_tol must be a finite number ≥ 0. Got: $theta_tol")
+        return new{T}(theta_tol)
+    end
 end
 
 @inline _default_inner_grad_tol(dm::DataModel) = get_de(get_model(dm)) === nothing ? 1.0e-8 :

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -81,6 +81,7 @@ struct MCEM_MCMC{S, K, SS} <: AbstractMCEMEStep
 
     function MCEM_MCMC(sampler::S, turing_kwargs::K, sample_schedule::SS, warm_start) where {S, K, SS}
         _check_sample_schedule(sample_schedule)
+        _check_turing_kwargs("MCEM", turing_kwargs)
         return new{S, K, SS}(sampler, turing_kwargs, sample_schedule, warm_start)
     end
 end
@@ -929,19 +930,27 @@ function _is_update_blocks!(
     return
 end
 
-# A user proposal must return `(samples::n_b × n_samples, log_qs::n_samples)` with finite
-# log densities; otherwise the failure surfaces as an opaque error inside weighting (#226).
-function _is_check_proposal_output(out, n_b::Int, n_samples::Int)
+# Every proposal — user-supplied or built in — must produce an `n_b × n_samples` real,
+# finite sample matrix and `n_samples` finite log densities. Non-finite samples reach the
+# likelihood AND the Haario adaptation, where they turn the proposal covariance into NaN
+# for every later iteration, so they are rejected here rather than downstream (#226, #229).
+# Returns the pair with `log_qs` narrowed to `Vector{Float64}`, which is what
+# `_is_compute_log_weights` dispatches on.
+function _is_check_proposal_output(out, n_b::Int, n_samples::Int, what::AbstractString)
     (out isa Tuple && length(out) == 2) ||
-        error("MCEM_IS: the proposal must return a (samples, log_qs) tuple. Got: $(typeof(out))")
+        error("MCEM_IS: $what must return a (samples, log_qs) tuple. Got: $(typeof(out))")
     samples, log_qs = out
     (samples isa AbstractMatrix && size(samples) == (n_b, n_samples)) ||
-        error("MCEM_IS: the proposal must return an $(n_b)×$(n_samples) sample matrix. Got: $(summary(samples))")
-    (log_qs isa AbstractVector && length(log_qs) == n_samples) ||
-        error("MCEM_IS: the proposal must return $(n_samples) log proposal densities. Got: $(summary(log_qs))")
+        error("MCEM_IS: $what must return an $(n_b)×$(n_samples) sample matrix. Got: $(summary(samples))")
+    eltype(samples) <: Real ||
+        error("MCEM_IS: $what returned a sample matrix of $(eltype(samples)); real numbers are required.")
+    all(isfinite, samples) ||
+        error("MCEM_IS: $what returned non-finite random-effect samples.")
+    (log_qs isa AbstractVector{<:Real} && length(log_qs) == n_samples) ||
+        error("MCEM_IS: $what must return $(n_samples) real log proposal densities. Got: $(summary(log_qs))")
     all(isfinite, log_qs) ||
-        error("MCEM_IS: the proposal returned non-finite log proposal densities.")
-    return nothing
+        error("MCEM_IS: $what returned non-finite log proposal densities.")
+    return (samples, convert(Vector{Float64}, log_qs))
 end
 
 # Unified IS E-step dispatcher for a single batch.
@@ -961,26 +970,37 @@ function _is_sample_batch(
     n_samples = e_step.n_samples
     proposal = e_step.proposal
     # Choose sampling strategy
-    samples, log_qs = if proposal === :prior
-        _is_prior_sample_batch(dm, info, θ, const_cache, cache, rng, n_samples, re_names)
-    elseif proposal === :gaussian
-        # Fall back to prior-based initial covariance until blocks have data
-        if isempty(blocks) || blocks[1].n_samples < 2
+    out, what = if proposal === :prior
+        (
             _is_prior_sample_batch(
-                dm, info, θ, const_cache, cache, rng, n_samples,
-                re_names
+                dm, info, θ, const_cache, cache, rng, n_samples, re_names
+            ), "the prior proposal",
+        )
+    elseif proposal === :gaussian
+        # Fall back to prior-based initial covariance until the blocks that actually
+        # carry levels have adapted — gating on blocks[1] alone keeps every effect on
+        # prior sampling whenever the first declared effect has no active level (#229).
+        adapting = [b for b in blocks if b.n_levels > 0 && b.dim > 0]
+        if isempty(adapting) || any(b -> b.n_samples < 2, adapting)
+            (
+                _is_prior_sample_batch(
+                    dm, info, θ, const_cache, cache, rng, n_samples, re_names
+                ), "the prior proposal",
             )
         else
-            _is_gaussian_sample_batch(dm, info, rng, n_samples, re_names, re_types, blocks)
+            (
+                _is_gaussian_sample_batch(
+                    dm, info, rng, n_samples, re_names, re_types, blocks
+                ), "the Gaussian proposal",
+            )
         end
     elseif proposal isa Function
         re_dists = _re_dists_for_info(dm, info, θ, cache)
-        out = proposal(θ, info, re_dists, rng, n_samples)
-        _is_check_proposal_output(out, get_n_b(info), n_samples)
-        out
+        (proposal(θ, info, re_dists, rng, n_samples), "the proposal")
     else
         error("MCEM_IS: unknown proposal type $(repr(proposal)). Use :prior, :gaussian, or a Function.")
     end
+    samples, log_qs = _is_check_proposal_output(out, get_n_b(info), n_samples, what)
     log_ws, ess = _is_compute_log_weights(dm, info, θ, const_cache, cache, samples, log_qs)
     return (samples, log_ws, ess)
 end

--- a/src/estimation/mcmc_types.jl
+++ b/src/estimation/mcmc_types.jl
@@ -50,12 +50,30 @@ struct MCMC{S, K, A, P} <: FittingMethod
     progress::P
 end
 
+# `n_samples`/`n_adapt` are forwarded verbatim to the sampler, where a non-positive
+# value either errors late or silently produces an empty chain (#229).
+function _check_turing_kwargs(what::AbstractString, turing_kwargs)
+    turing_kwargs isa NamedTuple || return nothing
+    if haskey(turing_kwargs, :n_samples)
+        n = turing_kwargs.n_samples
+        (n isa Integer && n >= 1) ||
+            error("$what: turing_kwargs.n_samples must be an integer ≥ 1. Got: $(repr(n))")
+    end
+    if haskey(turing_kwargs, :n_adapt)
+        n = turing_kwargs.n_adapt
+        (n isa Integer && n >= 0) ||
+            error("$what: turing_kwargs.n_adapt must be an integer ≥ 0. Got: $(repr(n))")
+    end
+    return nothing
+end
+
 function MCMC(;
         sampler = nothing,
         turing_kwargs = NamedTuple(),
         adtype = nothing,
         progress = false
     )
+    _check_turing_kwargs("MCMC", turing_kwargs)
     return MCMC(sampler, turing_kwargs, adtype, progress)
 end
 
@@ -205,7 +223,10 @@ struct VI{K} <: FittingMethod
     turing_kwargs::K
 end
 
-VI(; turing_kwargs = NamedTuple()) = VI(turing_kwargs)
+function VI(; turing_kwargs = NamedTuple())
+    _check_turing_kwargs("VI", turing_kwargs)
+    return VI(turing_kwargs)
+end
 
 """
     VIResult{Q, T, S, N, O, C, M} <: MethodResult

--- a/src/estimation/pooled.jl
+++ b/src/estimation/pooled.jl
@@ -434,15 +434,22 @@ end
 # Demotion ladder: :mean → :median → MC mean (flows) → :zero. Used when a
 # strategy's plug-in is not ForwardDiff-differentiable at the start values
 # (e.g. mean/median of a Normal truncated at Inf produce NaN partials).
-function _pooled_demote_strategy(strategy, dist, mc_draws::Int, rng::AbstractRNG)
+# `dists` holds the RE's distribution for EVERY individual: with covariate-dependent
+# distributions a median can exist for one individual and not for another, and the
+# plug-in has to work for all of them (#229).
+function _pooled_demote_strategy(strategy, dists, mc_draws::Int, rng::AbstractRNG)
+    dist = first(dists)
     is_flow = dist isa NormalizingPlanarFlow
     if strategy === :mean
-        med = try
-            median(dist)
-        catch
-            nothing
+        med_ok = all(dists) do d
+            med = try
+                median(d)
+            catch
+                nothing
+            end
+            return med !== nothing && all(isfinite, med)
         end
-        med !== nothing && all(isfinite, med) && return :median
+        med_ok && return :median
         return is_flow ? _PooledMCPlugin([rand(rng, dist.base.dist) for _ in 1:mc_draws]) :
             :zero
     elseif strategy === :median
@@ -464,10 +471,11 @@ function _pooled_dual_safe_strategies(
     re_names = get_re_names(lp_cache)
     dists_builder = create_random_effect_distribution(get_random(model))
     θs = _symmetrize_psd_params(θ_user_u, get_fixed(model))
-    dists = dists_builder(
-        θs, get_const_cov(first(get_individuals(dm))),
-        get_model_funs(model), get_helper_funs(model)
-    )
+    dists_all = [
+        dists_builder(
+                θs, get_const_cov(ind), get_model_funs(model), get_helper_funs(model)
+            ) for ind in get_individuals(dm)
+    ]
     axs = getaxes(θ_user_t)
     θ0_vec = _pooled_flat(θ_user_t)
     idx_all = collect(1:length(θ0_vec))
@@ -484,7 +492,7 @@ function _pooled_dual_safe_strategies(
             ok && break
             old = _pooled_plugin_label(strategies[ri])
             strategies[ri] = _pooled_demote_strategy(
-                strategies[ri], getproperty(dists, re),
+                strategies[ri], [getproperty(d, re) for d in dists_all],
                 mc_draws, rng
             )
             new = _pooled_plugin_label(strategies[ri])
@@ -510,27 +518,30 @@ function _pooled_spread_kinds(dm::DataModel, θ::ComponentArray)
     dists_builder = create_random_effect_distribution(get_random(model))
     model_funs = get_model_funs(model)
     helpers = get_helper_funs(model)
-    ind = first(get_individuals(dm))
     θs = _symmetrize_psd_params(θ, get_fixed(model))
-    dists = dists_builder(θs, get_const_cov(ind), model_funs, helpers)
+    # The spread measure is evaluated for every individual later on, so it has to exist
+    # for every individual — a covariate-dependent RE distribution can have a finite
+    # variance for the first individual and none for another (#229).
+    dists_all = [
+        dists_builder(θs, get_const_cov(ind), model_funs, helpers)
+            for ind in get_individuals(dm)
+    ]
+    ok(f, re) = all(
+        d -> _pooled_finite_or_nothing(() -> f(getproperty(d, re))) !== nothing,
+        dists_all
+    )
     kinds = Symbol[]
     for (ri, re) in enumerate(re_names)
-        dist = getproperty(dists, re)
         kind = if get_dims(lp_cache)[ri] == 1
-            if _pooled_finite_or_nothing(() -> var(dist)) !== nothing
+            if ok(var, re)
                 :var
-            elseif _pooled_finite_or_nothing(
-                    () -> quantile(dist, 0.75) -
-                        quantile(dist, 0.25)
-                ) !==
-                    nothing
+            elseif ok(d -> quantile(d, 0.75) - quantile(d, 0.25), re)
                 :iqr
             else
                 :none
             end
         else
-            _pooled_finite_or_nothing(() -> vec(Matrix(cov(dist)))) !== nothing ? :cov :
-                :none
+            ok(d -> vec(Matrix(cov(d))), re) ? :cov : :none
         end
         push!(kinds, kind)
     end
@@ -690,8 +701,12 @@ function _pooled_probe_points(
                 break
             end
         end
-        found || push!(probes, copy(θ0_vec))
+        # A failed jitter used to append a copy of the start point; duplicate rows make
+        # the rank/collinearity tests see fewer distinct probes than they think (#229).
+        found || continue
     end
+    length(probes) == n_probes ||
+        @warn "Pooled: only $(length(probes)) of $(n_probes) identifiability probe points could be evaluated; parameters are classified from fewer probes than requested."
     return probes
 end
 

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -554,6 +554,30 @@ function SAEM(;
         error("SAEM: t0 must be ≥ 0. Got: $t0")
     isnothing(mcmc_steps) || mcmc_steps >= 1 ||
         error("SAEM: mcmc_steps must be ≥ 1. Got: $mcmc_steps")
+    _check_turing_kwargs("SAEM", turing_kwargs)
+    sa_schedule in (:robbins_monro, :two_phase, :custom) ||
+        error("SAEM: sa_schedule must be :robbins_monro, :two_phase or :custom. Got: :$sa_schedule")
+    sa_schedule !== :custom || sa_schedule_fn !== nothing ||
+        error("SAEM: sa_schedule=:custom requires sa_schedule_fn.")
+    # γ = k^sa_phase2_kappa with k ≥ 1, so only a negative exponent decays; anything else
+    # is clamped to a constant step, which is not a stochastic-approximation schedule.
+    isfinite(sa_phase2_kappa) && sa_phase2_kappa < 0 ||
+        error("SAEM: sa_phase2_kappa must be a finite negative number. Got: $sa_phase2_kappa")
+    small_n_chain_target >= 1 ||
+        error("SAEM: small_n_chain_target must be ≥ 1. Got: $small_n_chain_target")
+    anneal_min_sd > 0 ||
+        error("SAEM: anneal_min_sd must be > 0. Got: $anneal_min_sd")
+    var_lb_value > 0 ||
+        error("SAEM: var_lb_value must be > 0. Got: $var_lb_value")
+    # 0 is the documented way to disable the annealing floor entirely.
+    isfinite(sa_anneal_alpha) && 0 <= sa_anneal_alpha <= 1 ||
+        error("SAEM: sa_anneal_alpha must be in [0, 1]. Got: $sa_anneal_alpha")
+    sa_anneal_schedule in (:exponential, :linear) ||
+        error("SAEM: sa_anneal_schedule must be :exponential or :linear. Got: :$sa_anneal_schedule")
+    isnothing(sa_anneal_iters) || sa_anneal_iters >= 1 ||
+        error("SAEM: sa_anneal_iters must be ≥ 1. Got: $sa_anneal_iters")
+    isnothing(sa_anneal_fn) ||
+        error("SAEM: sa_anneal_fn is reserved for future use and is not active; passing it would silently do nothing.")
     resolved_t0 = isnothing(t0) ? (maxiters ÷ 2) : t0
     resolved_sa_anneal_iters = isnothing(sa_anneal_iters) ? resolved_t0 : sa_anneal_iters
     ebe_rescue = EBERescueOptions(
@@ -622,7 +646,14 @@ end
 end
 
 function _saem_gamma_schedule(iter::Int, opts::SAEMOptions)
-    opts.sa_schedule === :custom && return opts.sa_schedule_fn(iter, opts)
+    if opts.sa_schedule === :custom
+        γ = opts.sa_schedule_fn(iter, opts)
+        # γ weights the new sufficient statistics against the stored ones; outside [0, 1]
+        # it amplifies Monte-Carlo noise instead of averaging it away (#229).
+        (γ isa Real && isfinite(γ) && 0 <= γ <= 1) ||
+            error("SAEM: sa_schedule_fn returned $(repr(γ)) at iteration $iter; it must be a finite number in [0, 1].")
+        return Float64(γ)
+    end
     if opts.sa_schedule === :robbins_monro
         iter <= opts.sa_burnin_iters && return 0.0
         iter <= opts.sa_burnin_iters + opts.t0 && return 1.0

--- a/test/estimation_common_tests.jl
+++ b/test/estimation_common_tests.jl
@@ -875,3 +875,29 @@ end
     @test NoLimits.SAEM(; maxiters = 3) isa NoLimits.SAEM
     @test NoLimits.MCEM(; sample_schedule = [5, 7]) isa NoLimits.MCEM
 end
+
+# Misspelled symbols used to silently select a different algorithm, and out-of-domain
+# schedule/annealing values silently changed the estimator (#229).
+@testset "estimator options reject invalid schedule settings" begin
+    @test_throws ErrorException NoLimits.SAEM(; sa_schedule = :bad)
+    @test_throws ErrorException NoLimits.SAEM(; sa_schedule = :custom)
+    @test_throws ErrorException NoLimits.SAEM(; sa_phase2_kappa = NaN)
+    @test_throws ErrorException NoLimits.SAEM(; sa_phase2_kappa = 1.0)
+    @test_throws ErrorException NoLimits.SAEM(; sa_anneal_schedule = :exponetial)
+    @test_throws ErrorException NoLimits.SAEM(; sa_anneal_alpha = 2.0)
+    @test_throws ErrorException NoLimits.SAEM(; sa_anneal_iters = -5)
+    @test_throws ErrorException NoLimits.SAEM(; small_n_chain_target = 0)
+    @test_throws ErrorException NoLimits.SAEM(; anneal_min_sd = 0.0)
+    @test_throws ErrorException NoLimits.SAEM(; var_lb_value = 0.0)
+    @test_throws ErrorException NoLimits.MCMC(; turing_kwargs = (n_adapt = -1,))
+    @test_throws ErrorException NoLimits.MCMC(; turing_kwargs = (n_samples = 0,))
+    @test_throws ErrorException NoLimits.Laplace(; theta_tol = -1.0)
+    # sa_anneal_alpha = 0 stays valid: it is the documented way to disable annealing.
+    @test NoLimits.SAEM(; sa_anneal_alpha = 0.0) isa NoLimits.SAEM
+
+    # A custom γ schedule is checked where it is used, not just at construction.
+    bad = NoLimits.SAEM(; sa_schedule = :custom, sa_schedule_fn = (i, o) -> 2.0).saem
+    @test_throws ErrorException NoLimits._saem_gamma_schedule(1, bad)
+    good = NoLimits.SAEM(; sa_schedule = :custom, sa_schedule_fn = (i, o) -> 0.25).saem
+    @test NoLimits._saem_gamma_schedule(1, good) == 0.25
+end

--- a/test/estimation_cv_tests.jl
+++ b/test/estimation_cv_tests.jl
@@ -141,6 +141,22 @@ end
     @test all(f -> f ∈ 1:3, os[!, :fold])
 end
 
+# Observation folds split each individual's observations, so the individual count is not
+# the binding constraint — only observations per individual are (#229).
+@testset "cross_validate observation folds are limited by observations, not individuals" begin
+    model = _make_mle_model()
+    df = DataFrame(ID = repeat(1:2; inner = 5), t = repeat(1.0:5.0, 2), y = randn(MersenneTwister(3), 10))
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+
+    cv = cross_validate(dm, 4; kind = :observation, rng = MersenneTwister(4))
+    @test length(cv.test_rows) == 4
+    @test all(!isempty, cv.test_rows)
+    # More folds than any individual has observations would leave folds empty.
+    @test_throws ErrorException cross_validate(dm, 6; kind = :observation)
+    # id folds keep the individual-count requirement.
+    @test_throws ErrorException cross_validate(dm, 3; kind = :id)
+end
+
 @testset "fit_cv observation-wise + MLE: all individuals in both train and test" begin
     model = _make_mle_model()
     df = _make_df()

--- a/test/estimation_multistart_tests.jl
+++ b/test/estimation_multistart_tests.jl
@@ -75,6 +75,17 @@ end
     @test all(s -> -1.0 <= s.a <= 1.0, starts)
 end
 
+# NaN compares false against both bounds, so a NaN draw used to pass the bounds gate,
+# and a mis-sized distribution array failed deep inside sampling (#229).
+@testset "Multistart start validation catches NaN and shape errors" begin
+    @test_throws ErrorException NoLimits._check_bounds(:b, [1.0, NaN], [-Inf, -Inf], [Inf, Inf])
+    @test_throws ErrorException NoLimits._check_bounds(:a, Inf, -Inf, Inf)
+    @test NoLimits._check_bounds(:b, [1.0, 2.0], [-Inf, -Inf], [Inf, Inf]) == true
+    @test_throws ErrorException NoLimits._sample_param(
+        :b, [1.0, 2.0], [Normal(), Normal(), Normal()], 2, :lhs, MersenneTwister(1)
+    )
+end
+
 @testset "Multistart bounds violation" begin
     model = @Model begin
         @covariates begin


### PR DESCRIPTION
Closes #229.

Twenty-eight of the forty findings are fixed; twelve are closed as already-handled or by-design, with reasoning below.

## Option validation (1, 2, 4-9, 11, 12, 21, 22, 40)

- **SAEM**: `sa_schedule` and `sa_anneal_schedule` must name a real schedule (a typo silently selected `:two_phase` / `:linear` before); `sa_schedule=:custom` requires `sa_schedule_fn`; `sa_phase2_kappa` must be finite and negative (γ = k^κ with k ≥ 1 only decays for κ < 0 — anything else clamps to a constant step); `small_n_chain_target`, `anneal_min_sd` and `var_lb_value` must be positive; `sa_anneal_alpha` must be in `[0, 1]` (0 stays valid — it is the documented way to disable annealing); `sa_anneal_iters` must be ≥ 1.
- **MCMC / VI / SAEM / MCEM**: `turing_kwargs.n_samples` must be ≥ 1 and `n_adapt` ≥ 0, checked once in a shared helper in the Turing-free core rather than at sampler-execution time.
- **Laplace**: `theta_tol` must be finite and ≥ 0. A negative tolerance made every cache-reuse comparison fail, silently disabling the EBE/Hessian cache.
- **Multistart**: `_check_bounds` now requires finiteness. NaN compares false against both bounds, so a NaN draw passed the gate and reached the optimizer; `Inf` passed too whenever the bound was `Inf`. An array-valued distribution spec must match the parameter's size.

## Behavioural fixes

- **SAEM (3)** — a `:custom` schedule callback must return a finite weight in `[0, 1]`; outside that range it amplifies Monte-Carlo noise into the sufficient statistics instead of averaging it away.
- **MCEM IS (14-18)** — the proposal contract is checked for *every* proposal, built-in or user-supplied: an `n_b × n_samples` matrix of reals, all finite, plus `n_samples` finite log densities. Non-finite samples previously reached both the likelihood and the Haario adaptation, where they turned the proposal covariance into NaN for all later iterations. `log_qs` is narrowed to `Vector{Float64}`, so a valid `Vector{Int}`/`Vector{Real}` proposal no longer passes validation and then hits a `MethodError`.
- **MCEM IS (20)** — the Gaussian proposal decides it has adapted from the blocks that actually carry levels, not from `blocks[1]`; a first random effect with no active levels used to pin every effect to prior sampling forever.
- **Multistart (26)** — runs are ranked by their own objective. The `-loglikelihood` fallback for a non-finite objective dropped priors and penalties, so a degenerate MAP or penalized run could outrank a valid one.
- **Multistart (24)** — the explicit `theta_0_untransformed` candidate goes through the same bounds/finiteness gate as sampled starts.
- **Pooled (35, 36)** — the plug-in demotion ladder and the spread-measure choice are decided against every individual's RE distribution, not the first one's; with covariate-dependent RE distributions a median or variance can exist for individual 1 and not for individual 2.
- **Pooled (38)** — a jitter probe that cannot be evaluated is skipped rather than replaced by a duplicate of the start point (duplicate rows make the rank/collinearity tests see fewer distinct probes than they report), and the shortfall is warned about.

## Cross-validation (27-32)

- MCMC/VI fits carry no empirical-Bayes random effects. CV silently evaluated them at zero RE while appearing to honor `seen_re_mode`; it now warns explicitly and the docstring says so.
- The Monte-Carlo path resolves random-effect levels one at a time, matching the EBE path from #228: a crossed test individual that shares one trained level keeps it instead of being treated as entirely new. For non-crossed designs the mapping and the RNG stream are unchanged.
- `cross_validate(kind=:observation)` is limited by observations per individual, not by the individual count — 4 observation folds over 2 individuals with 5 observations each is a valid design and used to be rejected.
- A fold that scores nothing (all outcomes missing, every ODE solve failed) no longer indexes a `:loglikelihood` column that does not exist, and dropped non-finite rows are reported per fold instead of quietly shrinking the total.

## Closed without a code change

- **10** `sa_anneal_fn` is documented as "reserved for future use (not active)" and is consumed nowhere; it is now rejected at construction rather than silently ignored.
- **13** `MCEM_MCMC` already validates its sample schedule in the inner constructor (#228).
- **19** An all-invalid IS batch is a controlled failure: uniform weights keep the shapes valid, ESS is reported as 0, and Q rejects the batch. A retry/resample policy is a feature, not a bug fix.
- **23** `_fix_matrix` repairs sampled PSD blocks on purpose — a matrix that cannot be Cholesky-factored cannot be transformed, so it is not a usable start. Documented in place.
- **25** `n_draws_used > n_draws_requested` already emits a warning; it is not silent.
- **33** The observation-fold mask is built over `eval_rows` in the same order `_rebuild_dm` keeps (DataModel never reorders rows — it warns on unsorted times), so `obs_rows[i]` indexes it correctly. The new HMM CV test in #228 fails on any misalignment.
- **34** Event rows are model inputs, not outcomes, and an event after a held-out observation cannot affect the ODE state at that observation. Including them in both folds is what makes the held-out prediction well posed.
- **37** Conservative freezing on an unprobeable plug-in is the documented fallback, and the objective-invariance check rescues candidates that do reach the likelihood.
- **39** A family the Fisher-information registry does not cover already errors with "FOCEI: distribution X is not supported ... Use Laplace instead", whether it appears at the start or during optimization. The up-front check is a fail-early convenience.
- **35 / 36** were partially closed in #226 as well; the residual first-individual dependence is fixed here.

## Tests

Extended existing testsets (no new files): schedule/annealing/Turing-kwarg/`theta_tol` validation and the custom-γ guard in `estimation_common_tests.jl`, the NaN/shape start guards in `estimation_multistart_tests.jl`, and observation-fold feasibility in `estimation_cv_tests.jl`.

Run locally and passing: cv, multistart, common, mcem, mcem_is, pooled, saem (×4), laplace (×2), focei, mcmc, mcmc_re, vi, uq, api_primitives, accessors, copulas, identifiability. Runic clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBEaom9f8cQfFHerKRHSW1