### PR TITLE
fix: per-component missingness in MV residuals; qualify README Laplace (closes #241)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ df = DataFrame(
 )
 
 dm  = DataModel(model, df; primary_id=:ID, time_col=:time)
-res = fit_model(dm, Laplace())
+res = fit_model(dm, NoLimits.Laplace())
 
 get_params(res; scale=:untransformed)   # population estimates
 get_random_effects(res)                 # per-subject effects

--- a/src/plotting/plotting_residuals.jl
+++ b/src/plotting/plotting_residuals.jl
@@ -89,14 +89,24 @@ end
 
 # Residual cells are scalar for univariate outcomes and per-component vectors for
 # multivariate ones; joint scores (`logscore`) stay scalar in either case.
-const _ResidualCell = Union{Missing, Float64, Vector{Float64}}
+const _ResidualCell = Union{
+    Missing, Float64, Vector{Float64}, Vector{Union{Missing, Float64}},
+}
+
+# Component vectors stay narrowly typed unless a component is actually missing.
+@inline _narrow_components(v) =
+    any(ismissing, v) ? convert(Vector{Union{Missing, Float64}}, v) :
+    Float64[Float64(x) for x in v]
 
 # Observation / fitted values keep their multivariate shape until after metric dispatch.
+# Partially observed vectors keep their observed components rather than collapsing.
 @inline function _obs_value(v)
     ismissing(v) && return missing
     if v isa AbstractVector
-        any(ismissing, v) && return missing
-        return Float64[Float64(x) for x in v]
+        all(ismissing, v) && return missing
+        return _narrow_components(
+            Union{Missing, Float64}[ismissing(x) ? missing : Float64(x) for x in v]
+        )
     end
     return _to_float_or_missing(v)
 end
@@ -123,10 +133,17 @@ function _metric_summary(vals::AbstractVector, qlo::Float64, qhi::Float64)
         all(v -> length(v) == n, vals_use) ||
             _residual_error("component count differs across posterior draws.")
         m = reduce(hcat, vals_use)
+        # Components can be missing independently across draws.
+        comp = [collect(skipmissing(view(m, k, :))) for k in 1:n]
+        summ(f) = _narrow_components(
+            Union{Missing, Float64}[
+                isempty(c) ? missing : Float64(f(c)) for c in comp
+            ]
+        )
         return (
-            Float64[mean(view(m, k, :)) for k in 1:n],
-            Float64[quantile(view(m, k, :), qlo) for k in 1:n],
-            Float64[quantile(view(m, k, :), qhi) for k in 1:n],
+            summ(mean),
+            summ(c -> quantile(c, qlo)),
+            summ(c -> quantile(c, qhi)),
         )
     end
     m = mean(vals_use)
@@ -205,7 +222,7 @@ end
 
 function _compute_mv_residual_metrics(
         dist,
-        y::Vector{Float64},
+        y::AbstractVector,
         residual_list::Vector{Symbol},
         fitted_stat,
         randomize_discrete::Bool,
@@ -229,21 +246,21 @@ function _compute_mv_residual_metrics(
             "the outcome has $(length(y)) components but its distribution reports " *
                 "$(length(marg)) marginals."
         )
-        pit_vec = Vector{Float64}(undef, length(y))
-        ok = true
-        for k in eachindex(y)
-            p = _pit_from_dist(
-                marg[k], y[k]; randomize_discrete = randomize_discrete,
-                cdf_fallback_mc = cdf_fallback_mc, rng = rng
-            )
-            ismissing(p) ? (ok = false) : (pit_vec[k] = p)
-        end
-        ok && (pit = pit_vec)
+        pit_vec = Union{Missing, Float64}[
+            _pit_from_dist(
+                    marg[k], y[k]; randomize_discrete = randomize_discrete,
+                    cdf_fallback_mc = cdf_fallback_mc, rng = rng
+                ) for k in eachindex(y)
+        ]
+        all(ismissing, pit_vec) || (pit = _narrow_components(pit_vec))
         if (:quantile in req) && !ismissing(pit)
-            res_quantile = Float64[
-                quantile(Normal(), clamp(p, eps(Float64), 1.0 - eps(Float64)))
-                    for p in pit
-            ]
+            res_quantile = _narrow_components(
+                Union{Missing, Float64}[
+                    ismissing(p) ? missing :
+                        quantile(Normal(), clamp(p, eps(Float64), 1.0 - eps(Float64)))
+                        for p in pit
+                ]
+            )
         end
         (:pit in req) || (pit = missing)
     end
@@ -265,9 +282,10 @@ function _compute_mv_residual_metrics(
     end
 
     logscore = missing
-    if :logscore in req
+    # The joint score needs every component; a partial vector has no joint density.
+    if (:logscore in req) && !any(ismissing, y)
         ls = try
-            -Float64(logpdf(dist, y))
+            -Float64(logpdf(dist, Float64[y...]))
         catch
             missing
         end
@@ -289,7 +307,7 @@ function _compute_residual_metrics(
         cdf_fallback_mc::Int,
         rng::AbstractRNG
     )
-    if y isa Vector{Float64}
+    if y isa AbstractVector
         return _compute_mv_residual_metrics(
             dist, y, residual_list, fitted_stat, randomize_discrete, cdf_fallback_mc, rng
         )
@@ -482,6 +500,11 @@ Vector-valued observations keep one row per observation; the `y`, `fitted`, `res
 `Vector{Float64}` with one entry per outcome component, in the order of the observation.
 `logscore` stays scalar: it is the joint score `-logpdf(dist, y)`. `time` and `x` remain
 scalar. Scalar outcomes are unaffected and keep scalar cells throughout.
+
+A partially observed vector keeps its observed components: the cell type widens to
+`Vector{Union{Missing, Float64}}` and only the missing components are `missing`. Such a
+row has no `logscore`, since the joint density needs every component. A row is only
+wholly `missing` when every component is.
 
 Component `pit` / `res_quantile` need the component marginals of the outcome
 distribution (known for `MvNormal` and for distributions with an `_re_marginals`

--- a/test/copulas_tests.jl
+++ b/test/copulas_tests.jl
@@ -168,6 +168,19 @@ import Turing   # MCMC/VI need the Turing extension loaded (#36)
         @test_throws ErrorException NoLimits._compute_mv_residual_metrics(
             Dirichlet([1.0, 1.0]), [0.5, 0.5], [:pit], mean, true, 0, Xoshiro(8)
         )
+        # Partially observed vectors keep their observed components (#240 group 4).
+        @test NoLimits._obs_value([1.0, 2.0]) isa Vector{Float64}
+        @test NoLimits._obs_value([1.0, missing]) isa Vector{Union{Missing, Float64}}
+        @test ismissing(NoLimits._obs_value([missing, missing]))
+        part = NoLimits._compute_mv_residual_metrics(
+            mvn, Union{Missing, Float64}[0.5, missing],
+            [:raw, :pearson, :pit, :logscore], mean, true, 0, Xoshiro(9)
+        )
+        @test !ismissing(part.res_raw[1]) && ismissing(part.res_raw[2])
+        @test !ismissing(part.res_pearson[1]) && ismissing(part.res_pearson[2])
+        @test !ismissing(part.pit[1]) && ismissing(part.pit[2])
+        # The joint score needs every component.
+        @test ismissing(part.logscore)
 
         for mode in (:population, :ebe, :reestimate, :marginal)
             pdf_out = NoLimits.predict(


### PR DESCRIPTION
Follow-up to #242. Two independent fixes.

## Per-component missingness in multivariate residuals

#242 shipped the multivariate residual schema with a documented limitation: cells were missing-or-whole-vector, so a partially observed vector (component 1 present, component 2 absent) collapsed to a fully missing row. Raw-observation plots (profiles, VPC, DV/PRED/IPRED/WRES) kept partial components, but residual and GOF plots dropped those rows entirely. That was a knowing deviation from #240 Group 4's acceptance criterion, recorded in #242 for a decision; the decision is to fix it.

Root cause was one line in `_obs_value`:

```julia
any(ismissing, v) && return missing
```

One absent component discarded the whole observation before metric dispatch ever saw it. It now collapses only when *every* component is missing, and the rest is propagation:

- `_narrow_components` keeps fully observed vectors as plain `Vector{Float64}`, widening to `Vector{Union{Missing, Float64}}` only when a component is genuinely absent. The schema merged in #242 is therefore unchanged for both scalar and fully observed multivariate outcomes.
- The component PIT loop no longer collapses the whole vector when one component's PIT is unavailable; `res_quantile` follows it component-wise.
- `res_raw` and `res_pearson` propagate `missing` elementwise through the existing arithmetic.
- `_metric_summary` summarizes each component over the posterior draws that actually have it, so a component missing in some draws no longer poisons the whole band.
- The joint `logscore` is `missing` for a partial row. This is deliberate: `-logpdf(dist, y)` needs every component, and there is no defensible joint density for a partial observation.

`_expand_residual_components` on the plotting side needed no change - it already indexes per component and the downstream mask drops missing points, so partial vectors now flow through to the plots correctly.

The docstring records the widened contract: a row is wholly `missing` only when every component is.

## README quickstart: unqualified `Laplace()` (#241)

The quickstart imported `Distributions` and then called `fit_model(dm, Laplace())`. Verified against the documented imports on 1.12:

```
julia> using NoLimits, DataFrames, Distributions
julia> Laplace()
ERROR: UndefVarError: `Laplace` not defined in `Main`
Hint: It looks like two or more modules export different bindings with this name...
```

Now `NoLimits.Laplace()`, matching the docs, which already qualified it everywhere - which is why docs CI stayed green while the README was broken.

Checked the neighbouring names rather than qualifying on suspicion: `Laplace` is the only real collision. `Normal` resolves fine because `NoLimits.Normal === Distributions.Normal` (same re-exported binding), and `SAEM` / `MCEM` / `MCMC` in the surrounding prose do not collide at all. Those are left alone.

## Testing

Seven assertions added to the existing `"SklarDist outcome with vector-valued cells"` testset in `test/copulas_tests.jl` - no new test file, no new `@Model`, no new fit. They cover `_obs_value` narrowing (`[1.0, 2.0]` stays `Vector{Float64}`, `[1.0, missing]` widens, `[missing, missing]` collapses) and a partially observed row producing component-wise `res_raw` / `res_pearson` / `pit` with `missing` only in the absent slot and a `missing` joint `logscore`.

| Files | Result |
| --- | --- |
| `copulas_tests.jl` | 38/38 (was 31 before the new assertions) |
| `plotting_functions_tests.jl` | 82/82 |

Runic clean over `src` and `test`.

Closes #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
