### PR TITLE
fix: honor constants_re in predict re_mode=:ebe (#251)

### DIFF
--- a/src/plotting/plotting_residuals.jl
+++ b/src/plotting/plotting_residuals.jl
@@ -987,8 +987,9 @@ function predict(
         )
     end
     θ = get_params(res; scale = :untransformed)
+    # Inherit and normalize once, so every re_mode sees the same fixed levels (#251).
+    constants_re = _res_constants_re(res, constants_re, dm_new)
     if re_mode == :population
-        constants_re = _res_constants_re(res, constants_re, dm_new)
         df = get_residuals(
             dm_new; params = NamedTuple(θ), residuals = [:raw],
             fitted_stat = fitted_stat, constants_re = constants_re,
@@ -1105,19 +1106,49 @@ function _predict_eta_ebe(
             "refit with store_data_model = true."
     )
     η_vec = _default_random_effects_from_dm(dm_new, constants_re, θ)
+    # Pass no override here: the stored EB modes were computed under the fit's own
+    # constants_re, and a different batch layout would misalign with them.
     bstars, batch_infos, θu, const_cache, _, _ = _resolve_bstars_for_re(
-        dm_old, res, constants_re
+        dm_old, res, NamedTuple()
     )
     η_train = _eta_from_eb(dm_old, batch_infos, bstars, const_cache, θu)
     re_to_eta = Dict{Any, ComponentArray}(
         get_re_groups(get_individuals(dm_old)[i]) => η_train[i]
             for i in 1:length(get_individuals(dm_old))
     )
+    fixed_maps = _normalize_constants_re(dm_new, constants_re)
+    re_names = get_re_names(get_random(get_model(dm_new)))
     for j in 1:length(get_individuals(dm_new))
-        key = get_re_groups(get_individuals(dm_new)[j])
-        haskey(re_to_eta, key) && (η_vec[j] = re_to_eta[key])
+        ind = get_individuals(dm_new)[j]
+        key = get_re_groups(ind)
+        haskey(re_to_eta, key) || continue
+        η_vec[j] = isempty(fixed_maps) ? re_to_eta[key] :
+            _eta_with_fixed_levels(ind, re_to_eta[key], re_names, fixed_maps)
     end
     return η_vec
+end
+
+# Rebuild an individual's η so fixed random-effect levels win over the stored EBE,
+# which supplies every free level (#251).
+function _eta_with_fixed_levels(ind, η_ebe, re_names, fixed_maps::NamedTuple)
+    lookup = Dict{Tuple{Symbol, Any}, Any}()
+    dims = Dict{Symbol, Int}()
+    for re in re_names
+        g = getfield(get_re_groups(ind), re)
+        v = getproperty(η_ebe, re)
+        if g isa AbstractVector && length(g) > 1
+            for (gi, lvl) in pairs(g)
+                lookup[(re, lvl)] = v[gi]
+            end
+            dims[re] = v[1] isa AbstractVector ? length(v[1]) : 1
+        else
+            lookup[(re, g isa AbstractVector ? g[1] : g)] = v
+            dims[re] = v isa AbstractVector ? length(v) : 1
+        end
+    end
+    return _assemble_individual_eta(
+        ind, re_names, dims, fixed_maps, (re, lvl, dim) -> lookup[(re, lvl)]
+    )
 end
 
 # Monte-Carlo marginal prediction: integrate the random effects over their prior,

--- a/test/residual_plots_tests.jl
+++ b/test/residual_plots_tests.jl
@@ -101,6 +101,20 @@ end
         pop_df.prediction[pop_df.id .== "id_001"],
         ebe_df.prediction[ebe_df.id .== "id_001"]; atol = 1.0e-8
     )
+
+    # Regression for #251: an explicit constants_re must beat the stored EBE in :ebe,
+    # matching :population on the pinned level and leaving free levels on their EBE.
+    ov = (; η = (; id_002 = 1.5))
+    ebe_ov = NoLimits.predict(res, df; re_mode = :ebe, constants_re = ov)
+    pop_ov = NoLimits.predict(res, df; re_mode = :population, constants_re = ov)
+    @test isapprox(
+        ebe_ov.prediction[ebe_ov.id .== "id_002"],
+        pop_ov.prediction[pop_ov.id .== "id_002"]; atol = 1.0e-8
+    )
+    @test isapprox(
+        ebe_ov.prediction[ebe_ov.id .== "id_003"],
+        ebe_df.prediction[ebe_df.id .== "id_003"]; atol = 1.0e-8
+    )
 end
 
 @testset "residuals MCMC summary and draw-level outputs" begin


### PR DESCRIPTION
Closes #251.

- `predict` now inherits and normalizes `constants_re` once, before the `re_mode` branch, so `:ebe`/`:reestimate`/`:marginal` see the same fixed levels `:population` did.
- `_predict_eta_ebe` resolves the stored EB modes with the fit's own constants: a caller override changed the RE batch layout and misaligned with the stored modes (it raised a `BoundsError` in the new test before this change).
- Fixed levels are then re-pinned on top of the EBE via `_assemble_individual_eta`, so `constants_re` wins for seen groups too, not just the unseen fallback.

Test: extended the existing #106/#147 testset in `test/residual_plots_tests.jl` with an explicit `constants_re` override in `:ebe` (matches `:population` on the pinned level, leaves free levels on their EBE). `NL_TEST_FILES=residual_plots_tests.jl` passes (102/102); the new assertions error on the pre-fix source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwRzKThCAt8NmwAv9XSNbg