### PR TITLE
fix: accept a bare filename as save_path in plotting

### DIFF
--- a/src/plotting/plotting.jl
+++ b/src/plotting/plotting.jl
@@ -208,7 +208,8 @@ function _ensure_save_path(save_path::Union{Nothing, String})
         ext = ".png"
     end
     dir = dirname(save_path)
-    isdir(dir) || error("save_path directory does not exist: $(dir)")
+    # An empty dirname means a bare filename in the current directory.
+    isempty(dir) || isdir(dir) || error("save_path directory does not exist: $(dir)")
     return save_path
 end
 

--- a/test/integration_plotting.jl
+++ b/test/integration_plotting.jl
@@ -167,6 +167,15 @@ const _OBS_RES_MLE = fit_model(_OBS_DM, NoLimits.MLE())
             _PLOT_RES_MLE;
             save_path = joinpath(tmp, "a.png"), plot_path = joinpath(tmp, "b.png")
         )
+        @test_throws ErrorException plot_data(
+            _PLOT_RES_MLE; save_path = joinpath(tmp, "missing_dir", "c.png")
+        )
+    end
+
+    # A bare filename is valid and resolves against the current directory.
+    cd(mktempdir()) do
+        plot_data(_PLOT_RES_MLE; save_path = "bare.png")
+        @test isfile("bare.png")
     end
 
     @test_throws ErrorException plot_fits(_PLOT_RES_MLE; x_axis_feature = :missing_feature)


### PR DESCRIPTION
## Bug

Every `plot_*` function validates `save_path` through `_ensure_save_path` (`src/plotting/plotting.jl`). A bare relative filename such as `save_path = "fits.png"` failed with `save_path directory does not exist: ` because `dirname("fits.png")` is `""` and `isdir("")` is `false`. A bare filename is valid and means the current directory; users hit this from the REPL and from both language wrappers.

## Fix

One line in `_ensure_save_path`: an empty dirname is accepted as the current directory, a non-empty non-existing directory still errors with the same message.

```julia
isempty(dir) || isdir(dir) || error("save_path directory does not exist: $(dir)")
```

## Test

Extended the existing `plot_data and plot_fits basic` testset in `test/integration_plotting.jl` (reusing the existing fixture fit): saving with `save_path = "bare.png"` inside a temporary cwd now works, and a filename inside a genuinely missing directory still throws.

`NL_TEST_FILES="integration_plotting.jl"`: `integration_plotting.jl | 63 pass | 63 total`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)