### PR TITLE
feat: accept any Tables.jl table where a DataFrame is expected (#259)

### DIFF
--- a/src/data_model/DataModel.jl
+++ b/src/data_model/DataModel.jl
@@ -1513,7 +1513,9 @@ observation counts, and saveat-mode resolution.
 
 # Arguments
 - `model::Model`: the compiled model (from `@Model`).
-- `df`: a `DataFrame` containing all required columns.
+- `df`: a `DataFrame`, or any Tables.jl-compatible table (a column `NamedTuple`, a
+  `CSV.File`, an R `data.frame` passed through JuliaConnectoR, ...), containing all
+  required columns. Non-`DataFrame` tables are materialized into a `DataFrame`.
 
 # Keyword Arguments
 - `primary_id::Union{Nothing, Symbol} = nothing`: primary individual-grouping column.
@@ -1545,6 +1547,7 @@ function DataModel(
         t0::Union{Nothing, Real} = 0.0,
         serialization::SciMLBase.EnsembleAlgorithm = EnsembleSerial()
     )
+    df = _as_dataframe(df)
     primary_id = _as_symbol(primary_id)
     time_col = _as_symbol(time_col)
     evid_col = _as_symbol(evid_col)

--- a/src/plotting/plotting_residuals.jl
+++ b/src/plotting/plotting_residuals.jl
@@ -946,7 +946,8 @@ a known upper level. `:ebe`/`:reestimate`/`:marginal` need a random-effects meth
 are not available for MCMC/VI posterior-draw fits (whose `:population` path already
 integrates the posterior).
 
-Pass `newdata` as a `DataFrame`, rebuilt into a `DataModel` using the fitted model and
+Pass `newdata` as a `DataFrame` or any Tables.jl-compatible table, rebuilt into a
+`DataModel` using the fitted model and
 the grouping, time and event columns of the original fit, or as a ready-made
 `DataModel`. Returns a `DataFrame` with the individual identifier, the time, the
 observable, and the predicted response in the `prediction` column. For a multivariate

--- a/src/utils/GeneralUtils.jl
+++ b/src/utils/GeneralUtils.jl
@@ -5,6 +5,7 @@ export rowsoftmax
 using ForwardDiff
 import DiffEqBase
 import Roots
+import DataFrames
 
 # Public symbol-valued options also accept the string spelling, so the Python/R
 # bindings (and serialized federated options) can pass them through unchanged.
@@ -12,6 +13,12 @@ import Roots
 @inline _as_symbol(x::AbstractString) = Symbol(x)
 @inline _as_symbol(x::Symbol) = x
 @inline _as_symbol(x) = x   # nothing, NamedTuples, functions, ... pass through
+
+# Public tabular inputs accept any Tables.jl table (CSV.File, column NamedTuple, an R
+# data.frame through JuliaConnectoR, ...). Non-tables pass through so the existing
+# schema validation still reports them.
+_as_dataframe(df::DataFrames.DataFrame) = df
+_as_dataframe(x) = DataFrames.Tables.istable(x) ? DataFrames.DataFrame(x) : x
 
 """
     rowsoftmax(L::AbstractMatrix) -> AbstractMatrix

--- a/test/data_model_tests.jl
+++ b/test/data_model_tests.jl
@@ -247,6 +247,16 @@ end
     @test ind1.series.obs.y == [1.0, 1.1]
     @test ind1.const_cov.x.Age == 30.0
     @test ind1.series.vary.z == [1.0, 1.2]
+
+    # Any Tables.jl table is materialized at the boundary (#259).
+    dm_tbl = DataModel(
+        model, DataFrames.Tables.columntable(df_ok);
+        primary_id = :ID,
+        time_col = :t
+    )
+    @test get_df(dm_tbl) == get_df(dm)
+    @test length(get_individuals(dm_tbl)) == length(get_individuals(dm))
+    @test get_individual(dm_tbl, 1).series.obs.y == ind1.series.obs.y
 end
 
 # Shared across the events and validation-errors testsets below.
@@ -377,6 +387,12 @@ end
     # Column keywords also accept strings (#255), including on the error paths.
     @test_throws ErrorException DataModel(
         model, df_missing_time; primary_id = "ID", time_col = "t"
+    )
+
+    # A non-table input passes through the normalization (#259) and still fails in the
+    # schema validation, not with a conversion error.
+    @test_throws ErrorException DataModel(
+        model, 42; primary_id = :ID, time_col = :t
     )
 end
 

--- a/test/residual_plots_tests.jl
+++ b/test/residual_plots_tests.jl
@@ -97,6 +97,10 @@ end
     # of the pinned 0.6, diverging from :ebe by exactly that offset.
     pop_df = NoLimits.predict(res, df; re_mode = :population)
     ebe_df = NoLimits.predict(res, df; re_mode = :ebe)
+    # newdata also accepts any Tables.jl table (#259).
+    @test NoLimits.predict(
+        res, DataFrames.Tables.columntable(df); re_mode = :ebe
+    ) == ebe_df
     @test isapprox(
         pop_df.prediction[pop_df.id .== "id_001"],
         ebe_df.prediction[ebe_df.id .== "id_001"]; atol = 1.0e-8


### PR DESCRIPTION
## What changed

Public tabular inputs now accept any Tables.jl-compatible table (column `NamedTuple`, `CSV.File`, an R `data.frame` through JuliaConnectoR, ...) and are materialized into a `DataFrame` at the boundary. Non-tables pass through unchanged, so the existing schema validation still produces the same errors.

New shared helper next to `_as_symbol` in `src/utils/GeneralUtils.jl`:

```julia
_as_dataframe(df::DataFrames.DataFrame) = df
_as_dataframe(x) = DataFrames.Tables.istable(x) ? DataFrames.DataFrame(x) : x
```

Dependency decision: no new direct dependency. `Tables` is reached through DataFrames (`DataFrames.Tables.istable`), which is already a hard dependency, so no manifest re-seeding was needed.

## Entry points

- `DataModel(model, df; ...)` — the only public entry point that takes user tabular data. Normalized first thing in the body.
- `predict(res, newdata)`, `cross_validate`/`fit_cv` and `simulate_data_model` all rebuild through that constructor, so they inherit the acceptance with no change of their own.

Audited with a grep for `::DataFrame` / `::AbstractDataFrame` in signatures. Excluded, with reasons: `get_residuals` and the plotting/VPC entry points take a `DataModel` or a residual frame that NoLimits itself produced, not user data; the annotated internals (`_prepare_warfarin_df`, `_attach_random_effects!`, `_expand_residual_components`, `CVResult.obs_scores`) are private or return types. Return types stay `DataFrames.DataFrame` everywhere.

## Tests

Extended existing testsets, no new models or files:

- `test/data_model_tests.jl` ("DataModel without events"): builds `Tables.columntable(df_ok)` from the existing fixture frame and asserts `get_df`, individual count and observation series match the DataFrame path.
- `test/data_model_tests.jl` ("DataModel validation errors"): error-parity case, a non-table input still fails with `ErrorException` from schema validation.
- `test/residual_plots_tests.jl`: `predict(res, Tables.columntable(df); re_mode = :ebe)` is identical to the DataFrame result.

Ran through the sandbox: `NL_TEST_FILES="data_model_tests.jl,residual_plots_tests.jl,aqua_tests.jl,aqua_ambiguities_tests.jl"` — all four batches pass (data_model 131, residual_plots 105, aqua 9, aqua_ambiguities 1).

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)