### PR TITLE
fix: three FFNN follow-ups from the bug hunt (#261)

### DIFF
--- a/docs/src/model-building/universal-function-approximators.md
+++ b/docs/src/model-building/universal-function-approximators.md
@@ -34,7 +34,7 @@ For the common case - a plain multilayer perceptron - `FFNNParameters` takes the
 z_nn = FFNNParameters((2, 8, 8, 1); activation=:tanh, function_name=:NN1, calculate_se=false)
 ```
 
-The block it returns is an `NNParameters` block, so call sites (`NN1([x.Age, x.BMI], z_nn)[1]`), priors, `calculate_se`, random effects on the weights and every estimator behave exactly as with a Lux or SimpleChains network. `activation` and `output_activation` accept a `Symbol`, a `String`, or any callable; the registry is `:tanh`, `:relu`, `:sigmoid` (alias `:logistic`), `:softplus`, `:identity`, `:gelu`, `:swish`, plus the output-only `:softmax` and `:logit`. Weights start from a Glorot-uniform draw (deterministic given `seed`) and biases from zero.
+The block it returns is an `NNParameters` block, so call sites (`NN1([x.Age, x.BMI], z_nn)[1]`), priors, `calculate_se`, random effects on the weights and every estimator behave exactly as with a Lux or SimpleChains network. `activation` and `output_activation` accept a `Symbol`, a `String`, or any callable; the registry is `:tanh`, `:relu`, `:sigmoid` (alias `:logistic`), `:softplus`, `:identity`, `:gelu`, `:swish`, plus the output-only `:softmax`. Weights start from a Glorot-uniform draw (deterministic given `seed`) and biases from zero.
 
 Reach for `NNParameters` with a Lux `Chain` or a SimpleChains `SimpleChain` when the architecture goes beyond a plain MLP.
 

--- a/src/model/FFNN.jl
+++ b/src/model/FFNN.jl
@@ -1,5 +1,5 @@
 using Random
-using StatsFuns: logistic, logit, log1pexp, softmax
+using StatsFuns: logistic, log1pexp, softmax
 
 export FFNNParameters
 
@@ -27,21 +27,24 @@ const _FFNN_ACTIVATIONS = (
     softplus = log1pexp, identity = identity, gelu = _ffnn_gelu, swish = _ffnn_swish,
 )
 
-# Output-only: `softmax` is a vector transform and `logit` maps (0,1) to ℝ, so neither
-# belongs between hidden layers.
-const _FFNN_OUTPUT_ACTIVATIONS = (softmax = _FFNNSoftmax(), logit = logit)
+# Output-only: `softmax` is a vector transform, so it does not belong between hidden
+# layers. `logit` is deliberately absent: it needs inputs in (0, 1), while the output
+# layer emits an unbounded affine value, so it would just throw a DomainError.
+const _FFNN_OUTPUT_ACTIVATIONS = (softmax = _FFNNSoftmax(),)
+
+const _FFNN_ACTIVATION_HINT = "For a (0, 1)-bounded output use :logistic, for probabilities use :softmax."
 
 function _ffnn_activation(a; output::Bool)
     a isa Union{Symbol, AbstractString} || return a   # any callable passes through
     s = _as_symbol(a)
     haskey(_FFNN_ACTIVATIONS, s) && return getfield(_FFNN_ACTIVATIONS, s)
     if haskey(_FFNN_OUTPUT_ACTIVATIONS, s)
-        output || error("Invalid FFNN activation :$(s). It is only available as an `output_activation` (:softmax is a vector transform and :logit expects inputs in (0, 1)).")
+        output || error("Invalid FFNN activation :$(s). It is only available as an `output_activation` (:softmax is a vector transform). $(_FFNN_ACTIVATION_HINT)")
         return getfield(_FFNN_OUTPUT_ACTIVATIONS, s)
     end
     valid = join(string.(keys(_FFNN_ACTIVATIONS)), ", ")
     out_only = join(string.(keys(_FFNN_OUTPUT_ACTIVATIONS)), ", ")
-    return error("Unknown FFNN activation :$(s). Valid names are $(valid) (hidden or output) and $(out_only) (output only); alternatively pass any callable.")
+    return error("Unknown FFNN activation :$(s). Valid names are $(valid) (hidden or output) and $(out_only) (output only); alternatively pass any callable. $(_FFNN_ACTIVATION_HINT)")
 end
 
 """
@@ -90,6 +93,8 @@ function (net::FFNN)(x::AbstractVector, θ::AbstractVector)
     s = net.sizes
     length(x) == s[1] ||
         error("FFNN input has length $(length(x)); the network expects $(s[1]).")
+    length(θ) == _ffnn_nparams(net) ||
+        error("FFNN parameter vector has length $(length(θ)); the network expects $(_ffnn_nparams(net)).")
     T = promote_type(eltype(θ), eltype(x))
     y = _ffnn_promote(T, x)
     offset = 0
@@ -169,7 +174,7 @@ Use [`NNParameters`](@ref) for architectures beyond a plain MLP.
   Registry: `:tanh`, `:relu`, `:sigmoid` (alias `:logistic`), `:softplus`, `:identity`,
   `:gelu` (tanh approximation), `:swish`.
 - `output_activation = :identity`: transform of the output layer. Same registry, plus the
-  output-only `:softmax` (numerically stable, sums to 1) and `:logit`.
+  output-only `:softmax` (numerically stable, sums to 1).
 - `name::Symbol = :unnamed`: parameter name (injected automatically by `@fixedEffects`).
 - `function_name::Symbol`: name the network is called under inside model blocks.
 - `seed::Integer = 0`: seed for the Glorot-uniform weight initialization (biases start at

--- a/src/model/Validation.jl
+++ b/src/model/Validation.jl
@@ -127,6 +127,7 @@ _nl_fun_in_dim(p) = nothing
 _nl_fun_in_dim(p::SoftTreeParameters) = p.input_dim
 _nl_fun_in_dim(p::SplineParameters) = 1
 function _nl_fun_in_dim(p::NNParameters)
+    p.chain isa FFNN && return p.chain.sizes[1]
     hasproperty(p.chain, :layers) || return nothing
     layers = p.chain.layers
     isempty(layers) && return nothing

--- a/test/simplechains_nn_tests.jl
+++ b/test/simplechains_nn_tests.jl
@@ -333,12 +333,40 @@ end
     end
     @test err !== nothing && occursin("tanh", err) && occursin("swish", err)
     @test_throws ErrorException NoLimits.FFNN((1, 2, 1), :softmax, :identity)
-    @test_throws ErrorException NoLimits.FFNN((1, 2, 1), :logit, :identity)
     @test_throws ErrorException NoLimits.FFNN((3,), :tanh, :identity)
     @test_throws ErrorException NoLimits.FFNN((3, 0), :tanh, :identity)
     @test_throws ErrorException NoLimits.FFNN((3, 1.5), :tanh, :identity)
     # A mismatched input length is reported instead of reading past the parameters.
     @test_throws ErrorException NoLimits.FFNN((1, 2, 1), :tanh, :identity)([0.1, 0.2], θ)
+
+    # `:logit` is no longer registered anywhere: applied to the unbounded affine output it
+    # only ever threw a DomainError. Both positions report it with the same hint.
+    for (a, oa) in ((:logit, :identity), (:tanh, :logit))
+        err = try
+            NoLimits.FFNN((1, 2, 1), a, oa)
+            nothing
+        catch e
+            sprint(showerror, e)
+        end
+        @test err !== nothing
+        @test occursin("Unknown FFNN activation :logit", err)
+        @test occursin(":logistic", err) && occursin(":softmax", err)
+    end
+
+    # A wrong parameter-vector length is reported instead of being truncated (too long) or
+    # raising a raw BoundsError (too short).
+    net = NoLimits.FFNN((1, 2, 1), :tanh, :identity)
+    for bad in (vcat(θ, 0.0), θ[1:(end - 1)])
+        err = try
+            net([0.1], bad)
+            nothing
+        catch e
+            sprint(showerror, e)
+        end
+        @test err !== nothing
+        @test occursin("FFNN parameter vector has length $(length(bad))", err)
+        @test occursin("expects 7", err)
+    end
 end
 
 @testset "FFNNParameters block, plumbing and AD" begin
@@ -383,6 +411,30 @@ end
     for k in 1:5
         @test isfinite(nest(z -> mf.NN1(x .+ z, p)[1], k)(0.0))
     end
+
+    # A wrong call shape is caught at model-build time, as for the Lux/SimpleChains
+    # backends, instead of only at fit time from inside the AD-typed objective.
+    @test NoLimits._nl_fun_in_dim(nn) == 2
+    err = try
+        @Model begin
+            @fixedEffects begin
+                σ = RealNumber(0.5, scale = :log)
+                ζ = FFNNParameters((2, 5, 1); function_name = :NN1, seed = 2)
+            end
+            @covariates begin
+                t = Covariate()
+            end
+            @formulas begin
+                μ = NN1([t], ζ)[1]
+                y ~ Normal(μ, σ)
+            end
+        end
+        nothing
+    catch e
+        sprint(showerror, e)
+    end
+    @test err !== nothing
+    @test occursin("expects a length-2 input vector; got length 1", err)
 end
 
 @testset "FFNN and SimpleChains agree on identical copied weights" begin


### PR DESCRIPTION
Three verified follow-ups on the `FFNNParameters` block added in #263 (feature request #261). Each was reproduced before fixing.

## 1. `:logit` removed from the output-activation registry

`_ffnn_apply_out(f, z) = f.(z)` applied the output activation element-wise to the raw affine output `z = W*y .+ b` of the last layer, which is unbounded. `logit` needs its argument in `(0, 1)`, so `output_activation = :logit` threw `DomainError` for essentially any input (`FFNN((1,1), :identity, :logit)([1.5], [1.0, 0.0])` -> `DomainError with -3.0`) and no test ever exercised a forward call with it.

`:logit` is now unknown in both positions and raises the registry's clear error, extended with a hint: use `:logistic` for a `(0, 1)`-bounded output or `:softmax` for probabilities. Removed from the docstring and the docs registry list as well.

## 2. Flat parameter length validated in the forward call

`(net::FFNN)(x, θ)` already checked `length(x) == sizes[1]` with a clear message, but said nothing about `θ`: a too-long vector was silently truncated and a too-short one raised a raw `BoundsError: attempt to access 8-element Vector{Float64} at index [9:9]`. Added the symmetric `length(θ) == _ffnn_nparams(net)` check with an actionable message (got N, expected M).

## 3. Build-time call-shape validation no longer bypassed for FFNN

`_nl_fun_in_dim(p::NNParameters)` duck-typed on `hasproperty(p.chain, :layers)`, so it returned `nothing` for an FFNN chain (fields `sizes`/`activation`/`output_activation`). The model-build-time input-length check that Validation.jl documents as existing for #206/#209/#214/#215 therefore never fired for FFNN, and a length mismatch only surfaced later at fit time. Added the FFNN case (`p.chain.sizes[1]`), so an `@Model` calling a 2-input FFNN with a length-1 vector now errors at build with the same message the other backends produce.

## Tests

Extended the existing FFNN testsets in `test/simplechains_nn_tests.jl` (no new files, no new fixtures): `:logit` in either position errors with the hint, `θ` too long and too short both raise the clear message, and the build-time in-dim mismatch errors for FFNN.

```
NL_TEST_FILES="simplechains_nn_tests.jl,aqua_tests.jl,aqua_ambiguities_tests.jl"
  aqua_ambiguities_tests.jl | 1 pass
  aqua_tests.jl             | 9 pass
  simplechains_nn_tests.jl  | 111 pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)