### PR TITLE
release: v0.2.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NoLimits"
 uuid = "1d491b74-35a5-408f-ae19-cf8524c3769d"
 license = "MIT"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Manuel Huth", "Jonas Arruda", "Clemens Peiter", "Roy Gusinow", "Nina Schmid", "Jan Hasenauer"]
 
 [deps]


### PR DESCRIPTION
Version bump to v0.2.5.

## Release content

- Strings are accepted wherever public APIs expect a Symbol (#255, #256)
- Dicts (AbstractDict) are accepted wherever public APIs expect a NamedTuple (#257, #260)
- Any Tables.jl-compatible table is accepted where a DataFrame is expected (#259, #262)
- Plot save_path accepts bare filenames (#258)
- New FFNNParameters: dependency-free feed-forward networks from layer sizes and activation names (#261, #263, #264)
- New documentation and tutorial for the R (NoLimitsR) and Python (NoLimitsPy) interfaces (#265)

🤖 Generated with [Claude Code](https://claude.com/claude-code)