### PR TITLE
docs: mention FFNNParameters where the NN tutorials introduce a chain

### DIFF
--- a/docs/src/estimation/saem.md
+++ b/docs/src/estimation/saem.md
@@ -641,6 +641,17 @@ For HMM outcomes (`DiscreteTimeDiscreteStatesHMM`, `ContinuousTimeDiscreteStates
 
 The following example illustrates a mixed-effects ODE model in which neural network parameter vectors serve as random-effect distribution means. Despite the highly nonlinear dynamics, the random-effect mean parameters and observation scale parameter admit closed-form SAEM updates.
 
+!!! tip "The same networks without Lux"
+    Each `Chain(Dense(1, 4, tanh), Dense(4, 1))` below can be replaced by a dependency-free
+    `FFNNParameters` block with identical call sites:
+
+    ```julia
+    zA1 = FFNNParameters((1, 4, 1); activation=:tanh, output_activation=:identity,
+        function_name=:NNA1, calculate_se=false)
+    ```
+
+    See [function approximators](../model-building/universal-function-approximators.md).
+
 ```julia
 using NoLimits
 using LinearAlgebra

--- a/docs/src/model-building/universal-function-approximators.md
+++ b/docs/src/model-building/universal-function-approximators.md
@@ -36,7 +36,7 @@ z_nn = FFNNParameters((2, 8, 8, 1); activation=:tanh, function_name=:NN1, calcul
 
 The block it returns is an `NNParameters` block, so call sites (`NN1([x.Age, x.BMI], z_nn)[1]`), priors, `calculate_se`, random effects on the weights and every estimator behave exactly as with a Lux or SimpleChains network. `activation` and `output_activation` accept a `Symbol`, a `String`, or any callable; the registry is `:tanh`, `:relu`, `:sigmoid` (alias `:logistic`), `:softplus`, `:identity`, `:gelu`, `:swish`, plus the output-only `:softmax`. Weights start from a Glorot-uniform draw (deterministic given `seed`) and biases from zero.
 
-Reach for `NNParameters` with a Lux `Chain` or a SimpleChains `SimpleChain` when the architecture goes beyond a plain MLP.
+Reach for `NNParameters` with a Lux `Chain` or a SimpleChains `SimpleChain` when the architecture goes beyond a plain MLP. The tutorials that build networks with a backend, [Neural Differential-Equation Components](../tutorials/mixed-effects-nn-saem.md) and [Building Custom Estimators](../tutorials/building-custom-estimators.md), note the equivalent `FFNNParameters` call where the chain is introduced.
 
 !!! tip "Lux vs. SimpleChains backend for `NNParameters`"
     `NNParameters` accepts either a Lux `Chain` or a SimpleChains `SimpleChain`. The call

--- a/docs/src/tutorials/building-custom-estimators.md
+++ b/docs/src/tutorials/building-custom-estimators.md
@@ -281,6 +281,17 @@ also closed-form - the mode value plus a trace correction - giving a fully deter
 
 ### Model and Data
 
+!!! tip "The same network without Lux"
+    `FFNNParameters` builds a plain multilayer perceptron with no optional dependency:
+
+    ```julia
+    ζ = FFNNParameters((1, 6, 1); activation=:tanh, output_activation=:identity,
+        function_name=:NN1, calculate_se=false)
+    ```
+
+    It returns an `NNParameters` block, so the estimator code below is unaffected. See
+    [function approximators](../model-building/universal-function-approximators.md).
+
 ```julia
 using Lux, LinearAlgebra
 

--- a/docs/src/tutorials/mixed-effects-nn-saem.md
+++ b/docs/src/tutorials/mixed-effects-nn-saem.md
@@ -73,6 +73,19 @@ first(df, 10)
 
 Instead of closed-form rate laws, neural networks learn the rate functions from data. Each `NNParameters` block declares a small feedforward network whose flattened weights join the fixed-effects vector and expose a callable (e.g. `NNA1`) usable inside `@DifferentialEquation` (see [function approximators](../model-building/universal-function-approximators.md)). Four networks drive the two-compartment system: `fA1`/`fA2` for the depot, `fC1`/`fC2` for the central compartment.
 
+!!! tip "The same architecture without SimpleChains"
+    A plain multilayer perceptron needs no neural-network backend at all: `FFNNParameters`
+    takes the layer sizes directly and its forward pass lives in NoLimits.
+
+    ```julia
+    zA1 = FFNNParameters((1, width_nn, 1); activation=:tanh, output_activation=:identity,
+        function_name=:NNA1, calculate_se=false)
+    ```
+
+    It returns an `NNParameters` block, so call sites, priors and random effects on the
+    weights are unchanged. See
+    [function approximators](../model-building/universal-function-approximators.md).
+
 Each network's weights are paired with a subject-level random-effect vector (`etaA1`, `etaA2`, `etaC1`, `etaC2`) drawn from an `MvNormal` centered on the population weights, so every individual gets a personalized network around shared population structure.
 
 ```julia

--- a/docs/src/tutorials/r-and-python.md
+++ b/docs/src/tutorials/r-and-python.md
@@ -341,6 +341,17 @@ model. Install the optional Julia package once (`install_nolimits(extras = "Simp
 in R, `nl.install_julia_packages("SimpleChains")` in Python), then write the prelude into
 the model string:
 
+!!! tip "No install needed for a plain network"
+    `FFNNParameters` builds the same architecture from its layer sizes without any optional
+    dependency, so the prelude reduces to the `@Model` block:
+
+    ```julia
+    z = FFNNParameters((1, 2, 1); activation=:tanh, output_activation=:identity,
+        function_name=:NN1, calculate_se=false)
+    ```
+
+    See [function approximators](../model-building/universal-function-approximators.md).
+
 ```r
 model <- nl_model('
 using SimpleChains


### PR DESCRIPTION
FFNNParameters shipped in v0.2.5 but was only documented on the universal-function-approximators page. Readers following the neural-network tutorials installed SimpleChains or Lux without learning that a plain MLP needs neither.

Adds a short `!!! tip` at the point where the chain is first constructed on each affected page, with the equivalent `FFNNParameters` call using that page's own layer sizes, plus a back-reference from the approximators page. All added code fences are plain `julia`, not `@example`, so the docs build cost is unchanged.

Pages: `docs/src/tutorials/mixed-effects-nn-saem.md`, `docs/src/tutorials/building-custom-estimators.md`, `docs/src/tutorials/r-and-python.md`, `docs/src/estimation/saem.md`, `docs/src/model-building/universal-function-approximators.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)