### PR TITLE
feat: expose the analytic Laplace marginal theta-gradient as a dev_api primitive

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -271,6 +271,7 @@ complete_data_loglikelihood_hessian
 empirical_bayes
 empirical_bayes_covariance
 laplace_marginal
+laplace_marginal_gradient
 ghq_marginal
 sample_random_effect_draws
 RandomEffectPosteriorSample

--- a/docs/src/method-developer-api.md
+++ b/docs/src/method-developer-api.md
@@ -37,7 +37,7 @@ Every function here obeys two conventions:
 | Forward map | `solve_individual`, `obs_distributions`, `hmm_filter_step!` |
 | Densities | `conditional_loglikelihood`, `complete_data_loglikelihood`, `re_logprior`, `complete_data_loglikelihood_gradient`, `complete_data_loglikelihood_hessian` |
 | Posterior / empirical Bayes | `empirical_bayes`, `empirical_bayes_covariance`, `sample_random_effect_draws` |
-| Marginals | `laplace_marginal`, `ghq_marginal` |
+| Marginals | `laplace_marginal`, `laplace_marginal_gradient`, `ghq_marginal` |
 | Curvature seam | `AbstractCurvature`, `ExactHessianCurvature`, `FisherInformationCurvature`, `inner_curvature` |
 | Fitting drivers | `fit_method`, `fit_fixed_effects`, `fit_laplace_family` |
 | Transforms | `ForwardTransform`, `InverseTransform`, `apply_inv_jacobian_T`, `logabsdetjac` |

--- a/src/estimation/dev_api.jl
+++ b/src/estimation/dev_api.jl
@@ -449,7 +449,7 @@ Scale contract: `θ` is natural-scale (as everywhere in this API) and `scale` se
 scale of the RETURNED gradient. `:untransformed` (default) is `∂/∂θ` on the natural scale;
 `:transformed` applies the fixed-effects transform Jacobian and returns `∂/∂θ_t` on the
 optimizer's transformed scale (`:log`, `:logit`, Cholesky, ... - see
-[`get_transform`](@ref)). The gradient is a `ComponentArray` on `θ`'s axes for
+`get_transform`). The gradient is a `ComponentArray` on `θ`'s axes for
 `:untransformed` and on the transformed-θ axes for `:transformed`.
 """
 function laplace_marginal_gradient(

--- a/src/estimation/dev_api.jl
+++ b/src/estimation/dev_api.jl
@@ -28,7 +28,8 @@ export solve_individual, obs_distributions, hmm_filter_step!, conditional_loglik
     complete_data_loglikelihood, re_logprior, complete_data_loglikelihood_gradient,
     complete_data_loglikelihood_hessian
 # Posterior / empirical Bayes / marginal / sampling
-export empirical_bayes, empirical_bayes_covariance, laplace_marginal, ghq_marginal,
+export empirical_bayes, empirical_bayes_covariance, laplace_marginal,
+    laplace_marginal_gradient, ghq_marginal,
     sample_random_effect_draws,
     RandomEffectPosteriorSample, get_draws, get_log_weights, get_ess, EBEOptions
 # Fisher-information registry
@@ -373,8 +374,8 @@ end
 Laplace-approximate marginal log-likelihood
 `log p(y | θ) ≈ log f(b*) + ½·n_b·log(2π) − ½·log det(−H)`. The batch form uses a supplied mode
 `b_star`; the population form finds the modes and sums over batches. For a θ-gradient of the
-marginal use the Laplace fit's analytic (envelope + trace-estimator) gradient; naive AD through
-the recomputed mode is not supported.
+marginal use [`laplace_marginal_gradient`](@ref) (the Laplace fit's analytic envelope +
+trace-estimator gradient); naive AD through the recomputed mode is not supported.
 """
 function laplace_marginal(
         dm::DataModel, θ::ComponentArray, batch::REBatchInfo, b_star;
@@ -419,6 +420,90 @@ function laplace_marginal(
             )
             for bi in eachindex(infos)
     )
+end
+
+# Move a natural-scale θ-gradient onto the transformed scale with the same Jacobian
+# the Laplace fit applies to its analytic gradient (laplace.jl `obj_grad`).
+function _dev_gradient_scale(dm::DataModel, θ::ComponentArray, grad::ComponentArray, scale::Symbol)
+    scale === :untransformed && return grad
+    scale === :transformed ||
+        error("laplace_marginal_gradient: scale must be :untransformed or :transformed, got :$scale.")
+    fe = get_fixed(get_model(dm))
+    θ_re = symmetrize_psd_parameters(θ, fe)
+    return apply_inv_jacobian_T(get_inverse_transform(fe), get_transform(fe)(θ_re), grad)
+end
+
+"""
+    laplace_marginal_gradient(dm, θ, batch, b_star; const_cache, cache=nothing, scale=:untransformed, curvature=ExactHessianCurvature(), jitter=1e-6, max_tries=6, growth=10.0, adaptive=false, scale_factor=0.0, use_trace_logdet_grad=true, use_hutchinson=false, hutchinson_n=8, rng=Random.default_rng()) -> (value, gradient)
+    laplace_marginal_gradient(dm, θ; constants_re=NamedTuple(), scale=:untransformed, kwargs...) -> (value, gradient)
+
+Value AND analytic θ-gradient of the Laplace-approximate marginal log-likelihood
+[`laplace_marginal`](@ref) - the exact gradient the `Laplace` fit optimizes, including the
+implicit `db*/dθ` envelope correction, so naive AD through the re-optimized mode is not
+needed. `value` is identical to `laplace_marginal` at the same arguments. The batch form
+takes one supplied mode `b_star`; the population form finds the modes and sums both value and
+gradient over batches (subjects are independent, so per-site sums are exact - this is the
+federation property).
+
+Scale contract: `θ` is natural-scale (as everywhere in this API) and `scale` selects the
+scale of the RETURNED gradient. `:untransformed` (default) is `∂/∂θ` on the natural scale;
+`:transformed` applies the fixed-effects transform Jacobian and returns `∂/∂θ_t` on the
+optimizer's transformed scale (`:log`, `:logit`, Cholesky, ... - see
+[`get_transform`](@ref)). The gradient is a `ComponentArray` on `θ`'s axes for
+`:untransformed` and on the transformed-θ axes for `:transformed`.
+"""
+function laplace_marginal_gradient(
+        dm::DataModel, θ::ComponentArray, batch::REBatchInfo, b_star;
+        const_cache::REConstantsCache, cache = nothing, scale::Symbol = :untransformed,
+        curvature::AbstractCurvature = ExactHessianCurvature(), jitter = 1.0e-6,
+        max_tries::Int = 6, growth = 10.0, adaptive::Bool = false, scale_factor = 0.0,
+        use_trace_logdet_grad::Bool = true, use_hutchinson::Bool = false,
+        hutchinson_n::Int = 8, rng::AbstractRNG = Random.default_rng()
+    )
+    c = _dev_ll_cache(dm, cache)
+    res = _laplace_grad_batch(
+        dm, batch, θ, b_star, const_cache, c, nothing, 1;
+        jitter = jitter, max_tries = max_tries, growth = growth, adaptive = adaptive,
+        scale_factor = scale_factor, use_trace_logdet_grad = use_trace_logdet_grad,
+        use_hutchinson = use_hutchinson, hutchinson_n = hutchinson_n, rng = rng,
+        hmode = curvature
+    )
+    if isinf(res.logdet)
+        @warn "laplace_marginal_gradient: the Laplace expansion is invalid at b* (-H " *
+            "degenerate or not factorizable; b* may not be a true mode). Returning -Inf."
+    end
+    n_b = get_batch_re_dim(batch)
+    value = res.logf + (n_b / 2) * log(2 * pi) - res.logdet / 2
+    return (value, _dev_gradient_scale(dm, θ, res.grad, scale))
+end
+
+function laplace_marginal_gradient(
+        dm::DataModel, θ::ComponentArray;
+        constants_re::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        scale::Symbol = :untransformed,
+        curvature::AbstractCurvature = ExactHessianCurvature(), jitter = 1.0e-6,
+        max_tries::Int = 6, growth = 10.0, adaptive::Bool = false, scale_factor = 0.0,
+        use_trace_logdet_grad::Bool = true, use_hutchinson::Bool = false,
+        hutchinson_n::Int = 8, rng::AbstractRNG = Random.default_rng(), kwargs...
+    )
+    constants_re = _as_namedtuple(constants_re)
+    bstars, infos, cc, θ_re, cache = _empirical_bayes_batches(
+        dm, θ; constants_re = constants_re, rng = rng, kwargs...
+    )
+    value = zero(eltype(θ_re))
+    grad = ComponentArray(zeros(eltype(θ_re), length(θ_re)), getaxes(θ_re))
+    for bi in eachindex(infos)
+        v, g = laplace_marginal_gradient(
+            dm, θ_re, infos[bi], bstars[bi]; const_cache = cc, cache = cache,
+            scale = :untransformed, curvature = curvature, jitter = jitter,
+            max_tries = max_tries, growth = growth, adaptive = adaptive,
+            scale_factor = scale_factor, use_trace_logdet_grad = use_trace_logdet_grad,
+            use_hutchinson = use_hutchinson, hutchinson_n = hutchinson_n, rng = rng
+        )
+        value += v
+        grad .+= g
+    end
+    return (value, _dev_gradient_scale(dm, θ_re, grad, scale))
 end
 
 """

--- a/test/api_primitives_tests.jl
+++ b/test/api_primitives_tests.jl
@@ -342,6 +342,83 @@ end
         ) isa ComponentArray
     end
 
+    @testset "laplace_marginal_gradient" begin
+        dm = fx_re_dm()
+        ser = NoLimits.EnsembleSerial()
+        fe = NoLimits.get_fixed(NoLimits.get_model(dm))
+        ft = NoLimits.get_transform(fe)
+        it = NoLimits.get_inverse_transform(fe)
+        θ0 = NoLimits.get_θ0_untransformed(fe)
+        lm(θ) = NoLimits.laplace_marginal(dm, θ; serialization = ser)
+        lmg(θ; kw...) = NoLimits.laplace_marginal_gradient(dm, θ; serialization = ser, kw...)
+
+        for s in (1.0, 0.75, 1.4)
+            θ = ComponentArray(collect(θ0) .* s, getaxes(θ0))
+            v, g = lmg(θ)
+            @test v ≈ lm(θ) rtol = 1.0e-12
+            # gradient entries correspond to θ's names/axes
+            @test g isa ComponentArray
+            @test getaxes(g) == getaxes(θ)
+            @test propertynames(g) == propertynames(θ)
+
+            # (1) natural-scale gradient vs central FD of laplace_marginal
+            θt = ft(θ)
+            _, gt = lmg(θ; scale = :transformed)
+            @test getaxes(gt) == getaxes(θt)
+            for k in propertynames(θ)
+                h = 1.0e-5 * max(1.0, abs(getproperty(θ, k)))
+                θp = copy(θ)
+                θm = copy(θ)
+                setproperty!(θp, k, getproperty(θ, k) + h)
+                setproperty!(θm, k, getproperty(θ, k) - h)
+                @test getproperty(g, k) ≈ (lm(θp) - lm(θm)) / (2h) rtol = 1.0e-5
+
+                # transformed-scale gradient vs central FD in transformed coordinates
+                ht = 1.0e-5 * max(1.0, abs(getproperty(θt, k)))
+                θtp = copy(θt)
+                θtm = copy(θt)
+                setproperty!(θtp, k, getproperty(θt, k) + ht)
+                setproperty!(θtm, k, getproperty(θt, k) - ht)
+                @test getproperty(gt, k) ≈ (lm(it(θtp)) - lm(it(θtm))) / (2ht) rtol = 1.0e-5
+            end
+
+            # batch form: per-batch (value, gradient) pairs sum to the population pair
+            bstars = NoLimits.empirical_bayes(dm, θ; serialization = ser)
+            _, infos_g, cc_g = NoLimits.build_re_batch_infos(dm, NamedTuple())
+            cache_g = NoLimits.build_likelihood_cache(dm; force_saveat = true)
+            vs = 0.0
+            gs = zero(g)
+            for bi in eachindex(infos_g)
+                vb, gb = NoLimits.laplace_marginal_gradient(
+                    dm, θ, infos_g[bi], bstars[bi]; const_cache = cc_g, cache = cache_g
+                )
+                vs += vb
+                gs .+= gb
+            end
+            @test vs ≈ v rtol = 1.0e-12
+            @test gs ≈ g rtol = 1.0e-12
+        end
+
+        # (2) additivity over disjoint-subject data models (the federation property)
+        df = fx_re_df()
+        model = fx_re_model()
+        dm_a = DataModel(model, df[df.ID .<= 3, :]; primary_id = :ID, time_col = :t)
+        dm_b = DataModel(model, df[df.ID .> 3, :]; primary_id = :ID, time_col = :t)
+        va, ga = NoLimits.laplace_marginal_gradient(dm_a, θ0; serialization = ser)
+        vb, gb = NoLimits.laplace_marginal_gradient(dm_b, θ0; serialization = ser)
+        vp, gp = lmg(θ0)
+        @test va + vb ≈ vp rtol = 1.0e-10
+        @test ga .+ gb ≈ gp rtol = 1.0e-10
+
+        # (3) at a converged Laplace optimum the gradient of the marginal vanishes
+        res_c = fit_model(dm, NoLimits.Laplace(); serialization = ser)
+        θc = NoLimits.get_params(res_c; scale = :untransformed)
+        _, gc = lmg(θc; scale = :transformed)
+        @test maximum(abs, gc) < 1.0e-4
+
+        @test_throws ErrorException lmg(θ0; scale = :nonsense)
+    end
+
     # Issue #116: per-individual quantities must key off identity, not row position, so
     # permuting/relabelling individuals may only change the order of the outer sum.
     @testset "per-individual terms are position-independent" begin


### PR DESCRIPTION
## What is exposed

`laplace_marginal_gradient` (exported, next to `laplace_marginal` in `src/estimation/dev_api.jl`) returns `(value, gradient)`:

```julia
laplace_marginal_gradient(dm, θ; constants_re, scale, <laplace hessian/jitter options>, kwargs...)
laplace_marginal_gradient(dm, θ, batch, b_star; const_cache, cache, scale, curvature, jitter, ...)
```

No re-derivation: the population form finds the EB modes exactly as `laplace_marginal` does and both forms call the existing `_laplace_grad_batch` kernel that the `Laplace` fit objective uses (envelope term, `use_trace_logdet_grad`/Hutchinson logdet gradient, implicit `db*/dθ` correction with the exact inner Hessian). Nothing in the fit path was touched, so `fit_model(dm, Laplace())` is unchanged; the value returned equals `laplace_marginal` at the same arguments. Per-batch values and gradients sum to the population pair, which makes per-site aggregation exact.

## Scale contract

`θ` is natural-scale, like every dev_api cover. `scale` selects the scale of the RETURNED gradient:

- `:untransformed` (default): `∂/∂θ` on the natural scale, a `ComponentArray` on `θ`'s axes. This is what the internal kernel produces natively.
- `:transformed`: the fixed-effects transform Jacobian is applied via `apply_inv_jacobian_T` - the same step the Laplace fit's `obj_grad` performs - giving `∂/∂θ_t` on the optimizer scale, on the transformed-θ axes.

Documented in the docstring and pinned by the tests.

## Tests

Extended `test/api_primitives_tests.jl` with existing fixtures only (no new `@Model`):

- gradient vs central finite differences of `laplace_marginal` at three θ points, on BOTH scales (`rtol = 1e-5`);
- value equals `laplace_marginal`; gradient entries correspond to θ's names/axes;
- per-batch `(value, gradient)` pairs sum to the population pair;
- additivity: a fixture split into two disjoint-subject `DataModel`s sums to the pooled value and gradient;
- gradient ~0 (max abs < 1e-4, transformed scale) at a converged `fit_model(dm, Laplace())` optimum;
- invalid `scale` errors.

Run green: `api_primitives_tests.jl` (223 pass), `estimation_common_tests.jl` (234), `estimation_laplace_tests.jl` (34), `estimation_laplace2_tests.jl` (60), `aqua_tests.jl` (9), `aqua_ambiguities_tests.jl` (1).

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)