### PR TITLE
feat: method-dispatched objective_and_gradient protocol (#271)

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -294,6 +294,7 @@ CurvatureWorkspace
 fit_method
 fit_fixed_effects
 fit_laplace_family
+objective_and_gradient
 free_parameter_layout
 NLFreeLayout
 resolve_fitted_parameters

--- a/docs/src/method-developer-api.md
+++ b/docs/src/method-developer-api.md
@@ -40,6 +40,7 @@ Every function here obeys two conventions:
 | Marginals | `laplace_marginal`, `laplace_marginal_gradient`, `ghq_marginal` |
 | Curvature seam | `AbstractCurvature`, `ExactHessianCurvature`, `FisherInformationCurvature`, `inner_curvature` |
 | Fitting drivers | `fit_method`, `fit_fixed_effects`, `fit_laplace_family` |
+| Value + gradient | `objective_and_gradient` |
 | Transforms | `ForwardTransform`, `InverseTransform`, `apply_inv_jacobian_T`, `logabsdetjac` |
 
 Full signatures are in the [API reference](api.md). The identity `complete_data_loglikelihood ==
@@ -47,6 +48,39 @@ conditional_loglikelihood + re_logprior` holds at batch scale. `empirical_bayes`
 posterior modes alone (no Hessian is computed), and `empirical_bayes_covariance` adds the
 curvature covariance `Σ = (−H)⁻¹` at those modes - together the Laplace approximation
 `N(b*, Σ)` to the random-effect posterior.
+
+## Objective value and gradient together
+
+`objective_and_gradient(method, dm, θ)` returns `(value, gradient)` for an estimator's
+log-objective in one pass, dispatching on the fitting method:
+
+```julia
+value, grad = objective_and_gradient(Laplace(), dm, θ)                       # natural scale
+value, grad = objective_and_gradient(Laplace(), dm, θ; scale = :transformed) # optimizer scale
+value, grad, H = objective_and_gradient(GHQuadrature(; level = 3), dm, θ; hessian = true)
+```
+
+`value` is the method's core log-objective, higher is better, matching the scalar covers
+(`laplace_marginal`, `ghq_marginal`, `loglikelihood`); the optimizer-side negation,
+preconditioning and free/constant merging stay in the fit. The gradient is a `ComponentArray`
+on θ's axes (or the transformed axes), and each dispatch reuses the route its own fit
+differentiates, so the gradient vanishes at that method's own optimum. `Laplace` and `FOCEI`
+forward to the analytic `laplace_marginal_gradient` kernel with their own curvature;
+`GHQuadrature` sweeps the quadrature sum with the adaptive centers held fixed at θ, exactly as
+its fit does; `Pooled` differentiates through the plug-in `η(θ)`; `MLE` and `MAP` sweep the
+log-likelihood, with MAP's log-priors included. Penalties are opt-in
+(`include_penalty = true`, `penalty = (; a = 100.0)`).
+
+`hessian = true` adds the symmetric Hessian as a `Matrix` in the gradient's flat coordinate
+order: central finite differences over the analytic gradient for `Laplace`/`FOCEI` (2p gradient
+evaluations, roughly five to six digits), a second-order ForwardDiff sweep elsewhere. Marginal
+methods also have per-batch forms (`objective_and_gradient(method, dm, θ, batch, b_star; …)`)
+and `MLE` a per-individual form, whose value and gradient pairs sum to the population pair -
+the property federated aggregation and per-subject clipping rely on.
+
+A user-defined `FittingMethod` joins this protocol by adding its own `objective_and_gradient`
+method; sampling-based methods (SAEM, MCEM, MCMC, VI) have no deterministic θ-objective and
+deliberately have none.
 
 ## Building a new fitting method
 

--- a/src/estimation/dev_api.jl
+++ b/src/estimation/dev_api.jl
@@ -710,10 +710,12 @@ const fit_laplace_family = _fit_laplace_family
 
 const _DiffResults = ForwardDiff.DiffResults
 
-@inline function _dev_check_scale(scale::Symbol)
-    scale in (:untransformed, :transformed) ||
-        error("gradient scale must be :untransformed or :transformed, got :$scale.")
-    return nothing
+# Normalizes `scale` (Symbol or string, per the #256 convention) and validates it.
+@inline function _dev_check_scale(scale::Union{Symbol, AbstractString})
+    s = _as_symbol(scale)
+    s in (:untransformed, :transformed) ||
+        error("gradient scale must be :untransformed or :transformed, got :$s.")
+    return s
 end
 
 # The penalty enters the log-objective negatively (the fits minimize `-ll + penalty`).
@@ -832,7 +834,8 @@ Shipped dispatches, and the finer-grained forms:
     `eta = …` freezes η instead. Population form only: the plug-in strategies are calibrated on
     the whole data set.
   - `MLE`, `MAP`: sweeps `loglikelihood` (plus `logprior` for `MAP`). `MLE` also has the
-    per-individual form `objective_and_gradient(MLE(), dm, θ, idx)`.
+    per-individual form `objective_and_gradient(MLE(), dm, θ, idx)`. Like `fit_model`, these
+    require a model WITHOUT random effects; use `Laplace`, `SAEM` or `MCMC` otherwise.
 
 A user-defined `FittingMethod` plugs into downstream tooling (federated aggregation,
 uncertainty workflows) by adding its own `objective_and_gradient` method.
@@ -869,12 +872,12 @@ end
 
 function objective_and_gradient(
         method::Union{Laplace, FOCEI}, dm::DataModel, θ::ComponentArray;
-        scale::Symbol = :untransformed, hessian::Bool = false,
+        scale::Union{Symbol, AbstractString} = :untransformed, hessian::Bool = false,
         include_penalty::Bool = false,
         penalty::Union{NamedTuple, AbstractDict} = NamedTuple(),
         fd_step::Real = 1.0e-5, kwargs...
     )
-    _dev_check_scale(scale)
+    scale = _dev_check_scale(scale)
     penalty = _as_namedtuple(penalty)
     call_kwargs = _dev_laplace_kwargs(method, kwargs)
     fe = get_fixed(get_model(dm))
@@ -907,8 +910,9 @@ end
 
 function objective_and_gradient(
         method::Union{Laplace, FOCEI}, dm::DataModel, θ::ComponentArray,
-        batch::REBatchInfo, b_star; scale::Symbol = :untransformed, kwargs...
+        batch::REBatchInfo, b_star; scale::Union{Symbol, AbstractString} = :untransformed, kwargs...
     )
+    scale = _dev_check_scale(scale)
     return laplace_marginal_gradient(
         dm, θ, batch, b_star; scale = scale, _dev_laplace_kwargs(method, kwargs)...
     )
@@ -939,13 +943,14 @@ end
 
 function objective_and_gradient(
         method::GHQuadrature, dm::DataModel, θ::ComponentArray;
-        scale::Symbol = :untransformed, hessian::Bool = false,
+        scale::Union{Symbol, AbstractString} = :untransformed, hessian::Bool = false,
         include_penalty::Bool = false,
         penalty::Union{NamedTuple, AbstractDict} = NamedTuple(),
         level = method.level, constants_re::Union{NamedTuple, AbstractDict} = NamedTuple(),
         ode_args::Tuple = (), ode_kwargs::Union{NamedTuple, AbstractDict} = NamedTuple(),
         cache = nothing
     )
+    scale = _dev_check_scale(scale)
     _, infos, cc = build_re_batch_infos(dm, _as_namedtuple(constants_re))
     c = cache === nothing ?
         build_likelihood_cache(
@@ -960,9 +965,10 @@ end
 
 function objective_and_gradient(
         method::GHQuadrature, dm::DataModel, θ::ComponentArray, batch::REBatchInfo;
-        const_cache::REConstantsCache, cache = nothing, scale::Symbol = :untransformed,
+        const_cache::REConstantsCache, cache = nothing, scale::Union{Symbol, AbstractString} = :untransformed,
         hessian::Bool = false, level = method.level
     )
+    scale = _dev_check_scale(scale)
     f = _DevGHQObjective(
         dm, [batch], const_cache, _dev_ll_cache(dm, cache), level, NamedTuple(), false
     )
@@ -1001,7 +1007,7 @@ end
 
 function objective_and_gradient(
         method::Pooled, dm::DataModel, θ::ComponentArray;
-        scale::Symbol = :untransformed, hessian::Bool = false,
+        scale::Union{Symbol, AbstractString} = :untransformed, hessian::Bool = false,
         include_penalty::Bool = false,
         penalty::Union{NamedTuple, AbstractDict} = NamedTuple(),
         strategies = nothing, eta = nothing,
@@ -1009,6 +1015,7 @@ function objective_and_gradient(
         serialization::SciMLBase.EnsembleAlgorithm = EnsembleSerial(), cache = nothing,
         rng::AbstractRNG = Random.default_rng()
     )
+    scale = _dev_check_scale(scale)
     θ_re = symmetrize_psd_parameters(θ, get_fixed(get_model(dm)))
     strat = strategies === nothing ?
         _dev_pooled_strategies(dm, θ_re, method, rng) : strategies
@@ -1044,12 +1051,14 @@ end
 
 function objective_and_gradient(
         method::Union{MLE, MAP}, dm::DataModel, θ::ComponentArray;
-        scale::Symbol = :untransformed, hessian::Bool = false,
+        scale::Union{Symbol, AbstractString} = :untransformed, hessian::Bool = false,
         include_penalty::Bool = false,
         penalty::Union{NamedTuple, AbstractDict} = NamedTuple(),
         ode_args::Tuple = (), ode_kwargs::Union{NamedTuple, AbstractDict} = NamedTuple(),
         serialization::SciMLBase.EnsembleAlgorithm = EnsembleSerial(), cache = nothing
     )
+    scale = _dev_check_scale(scale)
+    _require_no_random_effects(dm)
     fe = get_fixed(get_model(dm))
     c = cache === nothing ?
         build_likelihood_cache(
@@ -1075,8 +1084,10 @@ end
 
 function objective_and_gradient(
         ::MLE, dm::DataModel, θ::ComponentArray, idx::Integer;
-        scale::Symbol = :untransformed, hessian::Bool = false, cache = nothing
+        scale::Union{Symbol, AbstractString} = :untransformed, hessian::Bool = false, cache = nothing
     )
+    scale = _dev_check_scale(scale)
+    _require_no_random_effects(dm)
     f = _DevIndividualObjective(dm, Int(idx), _dev_ll_cache(dm, cache))
     return _dev_sweep(f, dm, θ, scale, hessian)
 end

--- a/src/estimation/dev_api.jl
+++ b/src/estimation/dev_api.jl
@@ -45,7 +45,7 @@ export AbstractCurvature, ExactHessianCurvature, FisherInformationCurvature,
     inner_curvature,
     CurvatureWorkspace
 # Fitting-method protocol drivers
-export fit_method, fit_fixed_effects, fit_laplace_family
+export fit_method, fit_fixed_effects, fit_laplace_family, objective_and_gradient
 
 # Resolve a single-thread evaluation cache for the per-item primitives.
 @inline _dev_ll_cache(::DataModel, cache::LikelihoodCache) = cache
@@ -427,7 +427,7 @@ end
 function _dev_gradient_scale(dm::DataModel, θ::ComponentArray, grad::ComponentArray, scale::Symbol)
     scale === :untransformed && return grad
     scale === :transformed ||
-        error("laplace_marginal_gradient: scale must be :untransformed or :transformed, got :$scale.")
+        error("gradient scale must be :untransformed or :transformed, got :$scale.")
     fe = get_fixed(get_model(dm))
     θ_re = symmetrize_psd_parameters(θ, fe)
     return apply_inv_jacobian_T(get_inverse_transform(fe), get_transform(fe)(θ_re), grad)
@@ -703,6 +703,383 @@ it with the analytic (envelope + trace-estimator) θ-gradient. Swap only the `cu
 ([`AbstractCurvature`](@ref)/[`inner_curvature`](@ref)) to define a new marginal method.
 """
 const fit_laplace_family = _fit_laplace_family
+
+# ── Joint objective value + θ-gradient (method-dispatched) ────────────────────
+# One entry point per estimator family, each reusing the exact route its own fit
+# differentiates, so the gradient a caller gets is the gradient the optimizer consumed.
+
+const _DiffResults = ForwardDiff.DiffResults
+
+@inline function _dev_check_scale(scale::Symbol)
+    scale in (:untransformed, :transformed) ||
+        error("gradient scale must be :untransformed or :transformed, got :$scale.")
+    return nothing
+end
+
+# The penalty enters the log-objective negatively (the fits minimize `-ll + penalty`).
+@inline function _dev_penalty_term(θ::ComponentArray, include_penalty::Bool, penalty::NamedTuple)
+    (!include_penalty || isempty(keys(penalty))) && return zero(eltype(θ))
+    return -penalty_value(θ, penalty)
+end
+
+# ∂/∂θ of `-penalty_value(θ, penalty)`, added to an analytic gradient in place.
+function _dev_penalty_gradient!(g::ComponentArray, θ::ComponentArray, penalty::NamedTuple)
+    for name in keys(penalty)
+        w = getfield(penalty, name)
+        setproperty!(g, name, getproperty(g, name) .- 2 .* w .* getproperty(θ, name))
+    end
+    return g
+end
+
+# Objective wrappers for the AD sweep: the differentiated argument is the flat coordinate
+# vector of the requested scale; `:transformed` differentiates through the inverse
+# transform, which is what every fit's optimizer-scale objective does.
+struct _DevObjNatural{F, A}
+    f::F
+    axs::A
+end
+@inline (o::_DevObjNatural)(x) = o.f(ComponentArray(x, o.axs))
+
+struct _DevObjTransformed{F, I, E, A}
+    f::F
+    inv_transform::I
+    fe::E
+    axs::A
+end
+@inline function (o::_DevObjTransformed)(x)
+    return o.f(symmetrize_psd_parameters(o.inv_transform(ComponentArray(x, o.axs)), o.fe))
+end
+
+# Single ForwardDiff/DiffResults sweep of a natural-scale objective `f(θ::ComponentArray)`:
+# value and gradient (and the Hessian when asked) come out of the one sweep.
+function _dev_sweep(f, dm::DataModel, θ::ComponentArray, scale::Symbol, hessian::Bool)
+    _dev_check_scale(scale)
+    fe = get_fixed(get_model(dm))
+    θ_re = symmetrize_psd_parameters(θ, fe)
+    if scale === :untransformed
+        axs = getaxes(θ_re)
+        x0 = collect(ComponentArrays.getdata(θ_re))
+        g = _DevObjNatural(f, axs)
+    else
+        θt = get_transform(fe)(θ_re)
+        axs = getaxes(θt)
+        x0 = collect(ComponentArrays.getdata(θt))
+        g = _DevObjTransformed(f, get_inverse_transform(fe), fe, axs)
+    end
+    if hessian
+        res = ForwardDiff.hessian!(_DiffResults.HessianResult(x0), g, x0)
+        H = _DiffResults.hessian(res)
+        return (
+            _DiffResults.value(res),
+            ComponentArray(_DiffResults.gradient(res), axs),
+            (H .+ H') ./ 2,
+        )
+    end
+    res = ForwardDiff.gradient!(_DiffResults.GradientResult(x0), g, x0)
+    return (_DiffResults.value(res), ComponentArray(_DiffResults.gradient(res), axs))
+end
+
+# Central FD Jacobian of an analytic gradient, symmetrized: the Laplace/FOCEI Hessian.
+function _dev_fd_hessian(g_of_x, x0::Vector{Float64}, step::Real)
+    p = length(x0)
+    H = Matrix{Float64}(undef, p, p)
+    for j in 1:p
+        h = step * max(1.0, abs(x0[j]))
+        xp = copy(x0)
+        xm = copy(x0)
+        xp[j] += h
+        xm[j] -= h
+        H[:, j] .= (g_of_x(xp) .- g_of_x(xm)) ./ (2h)
+    end
+    return (H .+ H') ./ 2
+end
+
+"""
+    objective_and_gradient(method, dm, θ; scale=:untransformed, hessian=false, include_penalty=false, penalty=NamedTuple(), kwargs...)
+        -> (value, gradient) | (value, gradient, hessian)
+
+Value AND θ-gradient of `method`'s log-objective at natural-scale `θ`, computed together the
+way the corresponding `fit_model` computes them - the shared analytic kernel for
+`Laplace`/`FOCEI`, a single ForwardDiff/DiffResults sweep elsewhere. `value` is the method's
+core LOG-objective (higher is better, matching the scalar covers `laplace_marginal`,
+`ghq_marginal`, `loglikelihood`); the optimizer-side negation, preconditioning and
+free/constant merging are not part of the primitive. The gradient is a `ComponentArray` on
+`θ`'s axes (`scale = :untransformed`) or on the transformed axes (`:transformed`).
+
+`hessian = true` additionally returns the symmetric Hessian as a plain `Matrix` in the flat
+coordinate order of the returned gradient. Per family: `Laplace`/`FOCEI` use central finite
+differences over the ANALYTIC gradient (2p gradient evaluations - second-order AD through the
+implicit empirical-Bayes modes is not available), everything else a second-order ForwardDiff
+sweep. Expect ~5-6 digits from the FD-based Hessian and full precision from the AD one.
+
+`penalty` is excluded by default; pass `include_penalty = true` together with the fit's
+`penalty` named tuple to reproduce a penalized fit's objective. `MAP`'s log-priors are not a
+penalty and are always part of the `MAP` objective.
+
+Shipped dispatches, and the finer-grained forms:
+
+  - `Laplace`, `FOCEI`: forwards to [`laplace_marginal_gradient`](@ref) with the method's own
+    curvature (exact inner Hessian / Fisher information) and Hessian options. Per-batch form
+    `objective_and_gradient(method, dm, θ, batch, b_star; const_cache, …)`; batch pairs sum to
+    the population pair (the federation property).
+  - `GHQuadrature`: sweeps [`ghq_marginal`](@ref), whose adaptive centers are built from the
+    Dual-stripped `θ` and are therefore CONSTANT with respect to the gradient - the fit's own
+    convention, so the returned gradient is the one `fit_model(dm, GHQuadrature())` optimizes.
+    Per-batch form `objective_and_gradient(method, dm, θ, batch; const_cache, …)`.
+  - `Pooled`: sweeps the plug-in objective `loglikelihood(dm, θ, η(θ))` with AD flowing through
+    `η(θ)`, as the pooled fit does. The plug-in `strategies` are derived from the method and `θ`
+    unless supplied (`strategies = get_result(res).strategies` reproduces a fit exactly), and
+    `eta = …` freezes η instead. Population form only: the plug-in strategies are calibrated on
+    the whole data set.
+  - `MLE`, `MAP`: sweeps `loglikelihood` (plus `logprior` for `MAP`). `MLE` also has the
+    per-individual form `objective_and_gradient(MLE(), dm, θ, idx)`.
+
+A user-defined `FittingMethod` plugs into downstream tooling (federated aggregation,
+uncertainty workflows) by adding its own `objective_and_gradient` method.
+"""
+function objective_and_gradient(method::FittingMethod, dm::DataModel, θ::ComponentArray; kwargs...)
+    return error(
+        "objective_and_gradient is not defined for $(typeof(method)). It ships for Laplace, " *
+            "FOCEI, GHQuadrature, Pooled, MLE and MAP; sampling-based methods (SAEM/MCEM/MCMC/VI) " *
+            "have no deterministic θ-objective. Add a method for your own FittingMethod."
+    )
+end
+
+# ── Laplace / FOCEI: the shared analytic kernel ───────────────────────────────
+
+_dev_curvature(::Laplace) = ExactHessianCurvature()
+_dev_curvature(method::FOCEI) = FisherInformationCurvature(method.interaction)
+
+# The method's own Laplace-Hessian block (jitter, trace estimator, ...), so the primitive is
+# configured like the fit; explicit kwargs win.
+function _dev_laplace_kwargs(method, kwargs)
+    h = method.hessian
+    opts = NamedTuple(n => getfield(h, n) for n in fieldnames(typeof(h)))
+    return merge((; curvature = _dev_curvature(method)), opts, NamedTuple(kwargs))
+end
+
+function _dev_laplace_pair(dm::DataModel, θ::ComponentArray, call_kwargs, include_penalty, penalty)
+    v, g = laplace_marginal_gradient(dm, θ; scale = :untransformed, call_kwargs...)
+    if include_penalty && !isempty(keys(penalty))
+        v += _dev_penalty_term(θ, true, penalty)
+        g = _dev_penalty_gradient!(g, θ, penalty)
+    end
+    return (v, g)
+end
+
+function objective_and_gradient(
+        method::Union{Laplace, FOCEI}, dm::DataModel, θ::ComponentArray;
+        scale::Symbol = :untransformed, hessian::Bool = false,
+        include_penalty::Bool = false,
+        penalty::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        fd_step::Real = 1.0e-5, kwargs...
+    )
+    _dev_check_scale(scale)
+    penalty = _as_namedtuple(penalty)
+    call_kwargs = _dev_laplace_kwargs(method, kwargs)
+    fe = get_fixed(get_model(dm))
+    θ_re = symmetrize_psd_parameters(θ, fe)
+    value, grad = _dev_laplace_pair(dm, θ_re, call_kwargs, include_penalty, penalty)
+    scaled = _dev_gradient_scale(dm, θ_re, grad, scale)
+    hessian || return (value, scaled)
+    # FD over the analytic gradient, in the coordinates of the requested scale.
+    if scale === :untransformed
+        axs = getaxes(θ_re)
+        x0 = collect(ComponentArrays.getdata(θ_re))
+        g_of_x = function (xv)
+            θx = ComponentArray(xv, axs)
+            _, gx = _dev_laplace_pair(dm, θx, call_kwargs, include_penalty, penalty)
+            return collect(gx)
+        end
+    else
+        θt = get_transform(fe)(θ_re)
+        axs = getaxes(θt)
+        x0 = collect(ComponentArrays.getdata(θt))
+        it = get_inverse_transform(fe)
+        g_of_x = function (xv)
+            θx = symmetrize_psd_parameters(it(ComponentArray(xv, axs)), fe)
+            _, gx = _dev_laplace_pair(dm, θx, call_kwargs, include_penalty, penalty)
+            return collect(_dev_gradient_scale(dm, θx, gx, :transformed))
+        end
+    end
+    return (value, scaled, _dev_fd_hessian(g_of_x, x0, fd_step))
+end
+
+function objective_and_gradient(
+        method::Union{Laplace, FOCEI}, dm::DataModel, θ::ComponentArray,
+        batch::REBatchInfo, b_star; scale::Symbol = :untransformed, kwargs...
+    )
+    return laplace_marginal_gradient(
+        dm, θ, batch, b_star; scale = scale, _dev_laplace_kwargs(method, kwargs)...
+    )
+end
+
+# ── GHQuadrature: the fit's fixed-center quadrature sum ───────────────────────
+
+struct _DevGHQObjective{D, B, C, K, L, P}
+    dm::D
+    infos::B
+    const_cache::C
+    cache::K
+    level::L
+    penalty::P
+    include_penalty::Bool
+end
+
+@inline function (o::_DevGHQObjective)(θ::ComponentArray)
+    total = _dev_penalty_term(θ, o.include_penalty, o.penalty)
+    for bi in eachindex(o.infos)
+        total += ghq_marginal(
+            o.dm, θ, o.infos[bi]; level = o.level,
+            const_cache = o.const_cache, cache = o.cache
+        )
+    end
+    return total
+end
+
+function objective_and_gradient(
+        method::GHQuadrature, dm::DataModel, θ::ComponentArray;
+        scale::Symbol = :untransformed, hessian::Bool = false,
+        include_penalty::Bool = false,
+        penalty::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        level = method.level, constants_re::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        ode_args::Tuple = (), ode_kwargs::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        cache = nothing
+    )
+    _, infos, cc = build_re_batch_infos(dm, _as_namedtuple(constants_re))
+    c = cache === nothing ?
+        build_likelihood_cache(
+            dm; ode_args = ode_args, ode_kwargs = _as_namedtuple(ode_kwargs),
+            serialization = EnsembleSerial(), force_saveat = true
+        ) : cache
+    f = _DevGHQObjective(
+        dm, infos, cc, c, level, _as_namedtuple(penalty), include_penalty
+    )
+    return _dev_sweep(f, dm, θ, scale, hessian)
+end
+
+function objective_and_gradient(
+        method::GHQuadrature, dm::DataModel, θ::ComponentArray, batch::REBatchInfo;
+        const_cache::REConstantsCache, cache = nothing, scale::Symbol = :untransformed,
+        hessian::Bool = false, level = method.level
+    )
+    f = _DevGHQObjective(
+        dm, [batch], const_cache, _dev_ll_cache(dm, cache), level, NamedTuple(), false
+    )
+    return _dev_sweep(f, dm, θ, scale, hessian)
+end
+
+# ── Pooled: AD through the plug-in η(θ) ──────────────────────────────────────
+
+struct _DevPooledObjective{D, K, S, T, E, P}
+    dm::D
+    cache::K
+    serialization::S
+    strategies::T
+    eta::E
+    penalty::P
+    include_penalty::Bool
+end
+
+@inline function (o::_DevPooledObjective)(θ::ComponentArray)
+    η = o.eta === nothing ? _compute_pooled_etas(o.dm, θ, o.strategies) : o.eta
+    ll = loglikelihood(
+        o.dm, θ, η; cache = o.cache, serialization = o.serialization
+    )
+    return ll + _dev_penalty_term(θ, o.include_penalty, o.penalty)
+end
+
+# The plug-in strategies the pooled fit derives before optimizing (`_fit_pooled`).
+function _dev_pooled_strategies(dm::DataModel, θ::ComponentArray, method, rng::AbstractRNG)
+    fe = get_fixed(get_model(dm))
+    strategies = _pooled_plugin_strategies(dm, θ; mc_draws = method.mc_draws, rng = rng)
+    return _pooled_dual_safe_strategies(
+        dm, θ, get_transform(fe)(θ), get_inverse_transform(fe),
+        strategies, method.mc_draws, rng
+    )
+end
+
+function objective_and_gradient(
+        method::Pooled, dm::DataModel, θ::ComponentArray;
+        scale::Symbol = :untransformed, hessian::Bool = false,
+        include_penalty::Bool = false,
+        penalty::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        strategies = nothing, eta = nothing,
+        ode_args::Tuple = (), ode_kwargs::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        serialization::SciMLBase.EnsembleAlgorithm = EnsembleSerial(), cache = nothing,
+        rng::AbstractRNG = Random.default_rng()
+    )
+    θ_re = symmetrize_psd_parameters(θ, get_fixed(get_model(dm)))
+    strat = strategies === nothing ?
+        _dev_pooled_strategies(dm, θ_re, method, rng) : strategies
+    c = cache === nothing ?
+        build_likelihood_cache(
+            dm; ode_args = ode_args, ode_kwargs = _as_namedtuple(ode_kwargs),
+            serialization = serialization, force_saveat = true
+        ) : cache
+    f = _DevPooledObjective(
+        dm, c, serialization, strat, eta, _as_namedtuple(penalty), include_penalty
+    )
+    return _dev_sweep(f, dm, θ, scale, hessian)
+end
+
+# ── MLE / MAP: the fixed-effects log-likelihood (plus MAP's log-priors) ───────
+
+struct _DevNoREObjective{D, K, S, P, F}
+    dm::D
+    cache::K
+    serialization::S
+    penalty::P
+    include_penalty::Bool
+    fe::F     # `nothing` for MLE; the fixed-effects block (log-priors) for MAP
+end
+
+@inline function (o::_DevNoREObjective)(θ::ComponentArray)
+    ll = loglikelihood(
+        o.dm, θ, ComponentArray(); cache = o.cache, serialization = o.serialization
+    )
+    lp = o.fe === nothing ? zero(ll) : logprior(o.fe, θ)
+    return ll + lp + _dev_penalty_term(θ, o.include_penalty, o.penalty)
+end
+
+function objective_and_gradient(
+        method::Union{MLE, MAP}, dm::DataModel, θ::ComponentArray;
+        scale::Symbol = :untransformed, hessian::Bool = false,
+        include_penalty::Bool = false,
+        penalty::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        ode_args::Tuple = (), ode_kwargs::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        serialization::SciMLBase.EnsembleAlgorithm = EnsembleSerial(), cache = nothing
+    )
+    fe = get_fixed(get_model(dm))
+    c = cache === nothing ?
+        build_likelihood_cache(
+            dm; ode_args = ode_args, ode_kwargs = _as_namedtuple(ode_kwargs),
+            serialization = serialization, force_saveat = true
+        ) : cache
+    f = _DevNoREObjective(
+        dm, c, serialization, _as_namedtuple(penalty), include_penalty,
+        method isa MAP ? fe : nothing
+    )
+    return _dev_sweep(f, dm, θ, scale, hessian)
+end
+
+struct _DevIndividualObjective{D, K}
+    dm::D
+    idx::Int
+    cache::K
+end
+
+@inline function (o::_DevIndividualObjective)(θ::ComponentArray)
+    return conditional_loglikelihood(o.dm, o.idx, θ, ComponentArray(); cache = o.cache)
+end
+
+function objective_and_gradient(
+        ::MLE, dm::DataModel, θ::ComponentArray, idx::Integer;
+        scale::Symbol = :untransformed, hessian::Bool = false, cache = nothing
+    )
+    f = _DevIndividualObjective(dm, Int(idx), _dev_ll_cache(dm, cache))
+    return _dev_sweep(f, dm, θ, scale, hessian)
+end
 
 # ── Objective factory: shared fit setup/teardown ─────────────────────────────
 

--- a/src/estimation/mle.jl
+++ b/src/estimation/mle.jl
@@ -77,6 +77,13 @@ end
 _combine_add_terms(base, ::Nothing) = base
 _combine_add_terms(base, extra) = _SumTerms(base, extra)
 
+# Precondition shared by every fixed-effects-only route (MLE/MAP fits and their primitives).
+function _require_no_random_effects(dm::DataModel)
+    isempty(get_re_names(get_random(get_model(dm)))) ||
+        error("This method is only valid for models without random effects. Use Laplace, SAEM, or MCMC for random-effects models.")
+    return nothing
+end
+
 function _fit_no_re(
         dm::DataModel, method;
         constants::NamedTuple,
@@ -90,9 +97,7 @@ function _fit_no_re(
         fit_args::Tuple = (),
         fit_kwargs::NamedTuple = NamedTuple()
     )
-    re_names = get_re_names(get_random(get_model(dm)))
-    isempty(re_names) ||
-        error("This method is only valid for models without random effects. Use Laplace, SAEM, or MCMC for random-effects models.")
+    _require_no_random_effects(dm)
 
     fe = get_fixed(get_model(dm))
     fixed_names = get_names(fe)

--- a/test/api_primitives_tests.jl
+++ b/test/api_primitives_tests.jl
@@ -419,6 +419,258 @@ end
         @test_throws ErrorException lmg(θ0; scale = :nonsense)
     end
 
+    # Issue #271: the method-dispatched joint value+gradient protocol. Each dispatch must
+    # reproduce its own fit's gradient (near-zero at that fit's optimum) and its own scalar
+    # cover's value.
+    @testset "objective_and_gradient" begin
+        og = NoLimits.objective_and_gradient
+        ser = NoLimits.EnsembleSerial()
+        dm = fx_re_dm()
+        fe = NoLimits.get_fixed(NoLimits.get_model(dm))
+        ft = NoLimits.get_transform(fe)
+        it = NoLimits.get_inverse_transform(fe)
+        θ0 = NoLimits.get_θ0_untransformed(fe)
+
+        # Central FD of a scalar θ-function, per named component, on the given scale.
+        function fd_check(f, θ, g; rtol = 1.0e-5)
+            for k in propertynames(θ)
+                h = 1.0e-5 * max(1.0, abs(getproperty(θ, k)))
+                θp = copy(θ)
+                θm = copy(θ)
+                setproperty!(θp, k, getproperty(θ, k) + h)
+                setproperty!(θm, k, getproperty(θ, k) - h)
+                @test getproperty(g, k) ≈ (f(θp) - f(θm)) / (2h) rtol = rtol
+            end
+        end
+
+        @testset "Laplace / FOCEI forward to the analytic kernel" begin
+            for m in (NoLimits.Laplace(), NoLimits.FOCEI())
+                cur = m isa NoLimits.FOCEI ?
+                    NoLimits.FisherInformationCurvature(m.interaction) :
+                    NoLimits.ExactHessianCurvature()
+                lm(θx) = NoLimits.laplace_marginal(
+                    dm, θx; curvature = cur, serialization = ser
+                )
+                for s in (1.0, 0.85)
+                    θ = ComponentArray(collect(θ0) .* s, getaxes(θ0))
+                    v, g = og(m, dm, θ; serialization = ser)
+                    vk, gk = NoLimits.laplace_marginal_gradient(
+                        dm, θ; curvature = cur, serialization = ser
+                    )
+                    @test v == vk                       # thin cover over the #270 kernel
+                    @test collect(g) == collect(gk)
+                    @test v ≈ lm(θ) rtol = 1.0e-12      # value == the scalar cover
+                    @test getaxes(g) == getaxes(θ)
+                    fd_check(lm, θ, g)
+
+                    θt = ft(θ)
+                    _, gt = og(m, dm, θ; serialization = ser, scale = :transformed)
+                    @test getaxes(gt) == getaxes(θt)
+                    fd_check(θtx -> lm(it(θtx)), θt, gt)
+                end
+            end
+
+            θ = θ0
+            m = NoLimits.Laplace()
+            v, g = og(m, dm, θ; serialization = ser)
+
+            # batch pairs sum to the population pair (the federation property)
+            bstars = NoLimits.empirical_bayes(dm, θ; serialization = ser)
+            _, infos, cc = NoLimits.build_re_batch_infos(dm, NamedTuple())
+            cache = NoLimits.build_likelihood_cache(dm; force_saveat = true)
+            vs = 0.0
+            gs = zero(g)
+            for bi in eachindex(infos)
+                vb, gb = og(
+                    m, dm, θ, infos[bi], bstars[bi]; const_cache = cc, cache = cache
+                )
+                vs += vb
+                gs .+= gb
+            end
+            @test vs ≈ v rtol = 1.0e-12
+            @test gs ≈ g rtol = 1.0e-12
+
+            # Hessian: FD over the analytic gradient. Symmetric by construction, and it must
+            # agree with a higher-order independent FD rule to ~4 digits (the documented
+            # tolerance for the FD-based Laplace/FOCEI Hessian).
+            v3, g3, H = og(m, dm, θ; serialization = ser, hessian = true)
+            @test v3 == v
+            @test H ≈ H'
+            grad_of_x = function (xv)
+                _, gx = og(
+                    m, dm, ComponentArray(xv, getaxes(θ)); serialization = ser
+                )
+                return collect(gx)
+            end
+            H_ref = FiniteDifferences.jacobian(
+                FiniteDifferences.central_fdm(5, 1), grad_of_x, collect(θ)
+            )[1]
+            @test H ≈ (H_ref .+ H_ref') ./ 2 rtol = 1.0e-4
+
+            # transformed-scale Hessian is the FD of the transformed-scale gradient
+            _, _, Ht = og(
+                m, dm, θ; serialization = ser, scale = :transformed, hessian = true
+            )
+            @test Ht ≈ Ht'
+            @test size(Ht) == (length(θ), length(θ))
+
+            # penalty is opt-in, and its analytic gradient matches the quadratic form
+            vpen, gpen = og(
+                m, dm, θ; serialization = ser, include_penalty = true,
+                penalty = (; a = 10.0)
+            )
+            @test vpen ≈ v - 10.0 * θ.a^2 rtol = 1.0e-10
+            @test gpen.a ≈ g.a - 20.0 * θ.a rtol = 1.0e-10
+            @test gpen.σ == g.σ
+
+            # gradient vanishes at the method's own optimum
+            for mm in (NoLimits.Laplace(), NoLimits.FOCEI())
+                res = fit_model(dm, mm; serialization = ser)
+                _, gc = og(
+                    mm, dm, NoLimits.get_params(res; scale = :untransformed);
+                    serialization = ser, scale = :transformed
+                )
+                @test maximum(abs, gc) < 1.0e-4
+            end
+        end
+
+        @testset "GHQuadrature keeps the fit's fixed centers" begin
+            m = NoLimits.GHQuadrature(; level = 3)
+            gm(θx) = NoLimits.ghq_marginal(dm, θx; level = 3)
+            for s in (1.0, 0.85)
+                θ = ComponentArray(collect(θ0) .* s, getaxes(θ0))
+                v, g = og(m, dm, θ)
+                @test v ≈ gm(θ) rtol = 1.0e-12
+                @test getaxes(g) == getaxes(θ)
+                # FD of `ghq_marginal` pins the fixed-center convention: the adaptive
+                # centers are built from the Dual-stripped θ, so the FD of the scalar cover
+                # and the AD gradient are the same object.
+                fd_check(gm, θ, g)
+                _, gt = og(m, dm, θ; scale = :transformed)
+                fd_check(θtx -> gm(it(θtx)), ft(θ), gt)
+            end
+
+            # per-batch pairs sum to the population pair
+            _, infos, cc = NoLimits.build_re_batch_infos(dm, NamedTuple())
+            cache = NoLimits.build_likelihood_cache(dm; force_saveat = true)
+            v, g = og(m, dm, θ0)
+            vs = 0.0
+            gs = zero(g)
+            for bi in eachindex(infos)
+                vb, gb = og(m, dm, θ0, infos[bi]; const_cache = cc, cache = cache)
+                vs += vb
+                gs .+= gb
+            end
+            @test vs ≈ v rtol = 1.0e-8
+            @test gs ≈ g rtol = 1.0e-6
+
+            # second-order ForwardDiff sweep
+            v3, g3, H = og(m, dm, θ0; hessian = true)
+            @test v3 ≈ v rtol = 1.0e-12
+            @test H ≈ H'
+            @test H ≈ ForwardDiff.hessian(
+                xv -> NoLimits.ghq_marginal(
+                    dm, ComponentArray(xv, getaxes(θ0)); level = 3
+                ), collect(θ0)
+            ) rtol = 1.0e-8
+
+            res = fit_model(dm, m; serialization = ser)
+            _, gc = og(
+                m, dm, NoLimits.get_params(res; scale = :untransformed);
+                scale = :transformed
+            )
+            @test maximum(abs, gc) < 1.0e-3
+        end
+
+        @testset "Pooled differentiates through η(θ)" begin
+            m = NoLimits.Pooled()
+            pv(θx) = og(m, dm, θx; serialization = ser)[1]
+            for s in (1.0, 0.85)
+                θ = ComponentArray(collect(θ0) .* s, getaxes(θ0))
+                v, g = og(m, dm, θ; serialization = ser)
+                @test isfinite(v)
+                fd_check(pv, θ, g)
+            end
+            v3, g3, H = og(m, dm, θ0; serialization = ser, hessian = true)
+            @test H ≈ H'
+
+            # value bookkeeping: the pooled fit minimizes `-value`
+            res = fit_model(dm, NoLimits.Pooled(); serialization = ser)
+            θ̂ = NoLimits.get_params(res; scale = :untransformed)
+            strat = NoLimits.get_result(res).strategies
+            vo, go = og(
+                m, dm, θ̂; serialization = ser, strategies = strat, scale = :transformed
+            )
+            @test vo ≈ -NoLimits.get_objective(res) rtol = 1.0e-8
+            @test maximum(abs, go) < 1.0e-4
+        end
+
+        @testset "MLE / MAP sweep the (prior-augmented) log-likelihood" begin
+            dmn = fx_nore_dm()
+            fen = NoLimits.get_fixed(NoLimits.get_model(dmn))
+            θn = NoLimits.get_θ0_untransformed(fen)
+            ll(θx) = NoLimits.loglikelihood(
+                dmn, θx, ComponentArray(); serialization = ser
+            )
+            v, g = og(NoLimits.MLE(), dmn, θn; serialization = ser)
+            @test v ≈ ll(θn) rtol = 1.0e-12
+            fd_check(ll, θn, g)
+            v3, g3, H = og(NoLimits.MLE(), dmn, θn; serialization = ser, hessian = true)
+            @test H ≈ H'
+            @test H ≈ ForwardDiff.hessian(
+                xv -> ll(ComponentArray(xv, getaxes(θn))), collect(θn)
+            ) rtol = 1.0e-8
+
+            # penalty is opt-in and enters the log-objective negatively
+            vp, gp = og(
+                NoLimits.MLE(), dmn, θn; serialization = ser,
+                include_penalty = true, penalty = (; a = 10.0)
+            )
+            @test vp ≈ v - 10.0 * θn.a^2 rtol = 1.0e-10
+            @test gp.a ≈ g.a - 20.0 * θn.a rtol = 1.0e-8
+
+            # per-individual contributions sum to the population pair
+            vs = 0.0
+            gs = zero(g)
+            for i in 1:length(NoLimits.get_individuals(dmn))
+                vi, gi = og(NoLimits.MLE(), dmn, θn, i)
+                vs += vi
+                gs .+= gi
+            end
+            @test vs ≈ v rtol = 1.0e-10
+            @test gs ≈ g rtol = 1.0e-8
+
+            res_m = fit_model(dmn, NoLimits.MLE(); serialization = ser)
+            _, gc = og(
+                NoLimits.MLE(), dmn, NoLimits.get_params(res_m; scale = :untransformed);
+                serialization = ser, scale = :transformed
+            )
+            @test maximum(abs, gc) < 1.0e-4
+
+            # MAP: the log-priors are part of the objective, not a penalty
+            dmp = fx_nore_prior_dm()
+            fep = NoLimits.get_fixed(NoLimits.get_model(dmp))
+            θp = NoLimits.get_θ0_untransformed(fep)
+            map_obj(θx) = NoLimits.loglikelihood(
+                dmp, θx, ComponentArray(); serialization = ser
+            ) + NoLimits.logprior(fep, θx)
+            vm, gm = og(NoLimits.MAP(), dmp, θp; serialization = ser)
+            @test vm ≈ map_obj(θp) rtol = 1.0e-12
+            fd_check(map_obj, θp, gm)
+            res_map = fit_model(dmp, NoLimits.MAP(); serialization = ser)
+            _, gmc = og(
+                NoLimits.MAP(), dmp, NoLimits.get_params(res_map; scale = :untransformed);
+                serialization = ser, scale = :transformed
+            )
+            @test maximum(abs, gmc) < 1.0e-4
+        end
+
+        # sampling-based methods have no deterministic θ-objective, and the scale is checked
+        @test_throws ErrorException og(NoLimits.SAEM(), dm, θ0)
+        @test_throws ErrorException og(NoLimits.Laplace(), dm, θ0; scale = :nonsense)
+        @test_throws ErrorException og(NoLimits.GHQuadrature(), dm, θ0; scale = :nonsense)
+    end
+
     # Issue #116: per-individual quantities must key off identity, not row position, so
     # permuting/relabelling individuals may only change the order of the outer sum.
     @testset "per-individual terms are position-independent" begin

--- a/test/api_primitives_tests.jl
+++ b/test/api_primitives_tests.jl
@@ -669,6 +669,28 @@ end
         @test_throws ErrorException og(NoLimits.SAEM(), dm, θ0)
         @test_throws ErrorException og(NoLimits.Laplace(), dm, θ0; scale = :nonsense)
         @test_throws ErrorException og(NoLimits.GHQuadrature(), dm, θ0; scale = :nonsense)
+
+        # MLE/MAP carry `fit_model`'s no-random-effects precondition, with its message
+        for m in (NoLimits.MLE(), NoLimits.MAP())
+            err = try
+                og(m, dm, θ0; serialization = ser)
+                nothing
+            catch e
+                e
+            end
+            @test err isa ErrorException
+            @test occursin("without random effects", err.msg)
+        end
+        @test_throws ErrorException og(NoLimits.MLE(), dm, θ0, 1)
+
+        # Issue #256: `scale` also accepts strings, and an invalid one is a domain error
+        vs, gs2 = og(NoLimits.Laplace(), dm, θ0; serialization = ser, scale = "transformed")
+        vr, gr = og(NoLimits.Laplace(), dm, θ0; serialization = ser, scale = :transformed)
+        @test vs == vr
+        @test collect(gs2) == collect(gr)
+        @test og(NoLimits.GHQuadrature(), dm, θ0; scale = "untransformed")[1] ==
+            og(NoLimits.GHQuadrature(), dm, θ0; scale = :untransformed)[1]
+        @test_throws ErrorException og(NoLimits.Laplace(), dm, θ0; scale = "nonsense")
     end
 
     # Issue #116: per-individual quantities must key off identity, not row position, so


### PR DESCRIPTION
Adds one method-dispatched dev_api protocol that returns an estimator's log-objective value and its theta-gradient together, plus an optional Hessian.

```julia
value, grad    = objective_and_gradient(Laplace(), dm, θ)
value, grad, H = objective_and_gradient(GHQuadrature(; level = 3), dm, θ; hessian = true)
```

## Per-method implementation

Each dispatch reuses the route its own `fit_model` differentiates, so the returned gradient is the one that optimizer consumed.

- **Laplace / FOCEI**: thin forward to the #270 analytic kernel `laplace_marginal_gradient`, with the method's own curvature (`ExactHessianCurvature` / `FisherInformationCurvature(interaction)`) and its `LaplaceHessianOptions` block (jitter, trace estimator, ...) so the primitive is configured like the fit. Per-batch form `(method, dm, θ, batch, b_star; const_cache, ...)`.
- **GHQuadrature**: single ForwardDiff/DiffResults sweep of `ghq_marginal`, whose adaptive centers come from the Dual-stripped theta and are therefore constants w.r.t. the gradient - the fit's own convention (`ghquadrature.jl` objective), documented in the docstring. Per-batch form `(method, dm, θ, batch; const_cache, ...)`.
- **Pooled**: sweep of `loglikelihood(dm, θ, η(θ))` with AD flowing through `_compute_pooled_etas`, exactly as the pooled fit's `OptimizationFunction(obj, AutoForwardDiff())` does, minus the optimizer-only wrapping (negation, preconditioning, free/constant merging). Plug-in `strategies` are derived from the method and theta as `_fit_pooled` does, or supplied (`strategies = get_result(res).strategies`); `eta = ...` freezes them. Population form only - the strategies are calibrated on the whole data set.
- **MLE / MAP**: sweep of `loglikelihood` (`+ logprior` for MAP; the priors are part of the MAP objective, not a penalty). MLE also has a per-individual form.
- Any other `FittingMethod` hits an explanatory error; sampling-based methods have no deterministic theta-objective by design.

## Defaults

- Value = the method's core LOG-objective (higher is better), matching `laplace_marginal` / `ghq_marginal` / `loglikelihood`.
- `scale = :untransformed` (natural) or `:transformed` (through the transform Jacobian for the analytic kernel, through the inverse transform for the AD sweeps); gradients are `ComponentArray`s on the corresponding axes.
- `hessian = false`. When on: central FD over the ANALYTIC gradient for Laplace/FOCEI (2p gradient evaluations, symmetrized, ~5-6 digits), second-order ForwardDiff elsewhere. Returned as a plain symmetric `Matrix` in the gradient's flat coordinate order.
- `include_penalty = false`, with `penalty = (; a = ...)` for callers replicating a penalized fit.
- DiffResults is reached through `ForwardDiff.DiffResults` - no new dependency, no manifest churn.

## Tests

Extended the existing `dev-API primitives` testset in `test/api_primitives_tests.jl` (shared fixtures only): value equals each scalar cover; gradient vs central FD on both scales at two theta points per method; Laplace/FOCEI equal the kernel bit-for-bit; batch and per-individual pairs sum to the population pair (federation property); Hessians symmetric and matching an independent higher-order FD rule (rtol 1e-4 for the FD-based Laplace Hessian) or `ForwardDiff.hessian` (1e-8); near-zero gradient at each method's own converged optimum; pooled value equals `-get_objective(res)`; GHQ gradient vs FD of `ghq_marginal` pins the fixed-center convention; penalty value and gradient bookkeeping.

Runs (all green): `api_primitives_tests.jl` 331/331; `aqua_tests.jl` 9/9; `aqua_ambiguities_tests.jl` 1/1; `estimation_mle_tests.jl` 53/53; `estimation_map_tests.jl` 6/6; `estimation_laplace_tests.jl` 34/34; `estimation_focei_tests.jl` 116/116; `estimation_pooled_tests.jl` 101/101; `estimation_ghquadrature_tests.jl` 290/290. `fit_model` paths are untouched.

Docs: new section in `docs/src/method-developer-api.md` and the docstring entry in `docs/src/api.md`.

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
