### PR TITLE
feat: FitContext forms for the gradient-bearing dev-API primitives (#273)

### DIFF
--- a/docs/src/method-developer-api.md
+++ b/docs/src/method-developer-api.md
@@ -82,6 +82,25 @@ A user-defined `FittingMethod` joins this protocol by adding its own `objective_
 method; sampling-based methods (SAEM, MCEM, MCMC, VI) have no deterministic θ-objective and
 deliberately have none.
 
+Inside a loop that evaluates the objective many times at different θ - a custom optimizer, or a
+federated round trip - pass a `FitContext` instead of the `DataModel` and the θ-independent
+setup is reused instead of rebuilt per call:
+
+```julia
+ctx = build_fit_context(dm)                       # once per fit
+value, grad = laplace_marginal_gradient(ctx, θ)   # == the dm form, caches reused
+value, grad = objective_and_gradient(Laplace(), ctx, θ; scale = :transformed)
+value, grad, H = objective_and_gradient(GHQuadrature(; level = 3), ctx, θ; hessian = true)
+```
+
+The context forms exist for `Laplace`, `FOCEI`, `GHQuadrature`, `MLE`, `MAP` and `Pooled`, take
+the same keywords, and return identical results. `Pooled`, `MLE` and `MAP` reuse only the
+likelihood cache: they have no free random effects to batch, and `Pooled` recalibrates its
+plug-in `strategies` at every θ by construction. Keywords the context already fixed at build
+time (`constants_re`, `ode_args`, `ode_kwargs`, and the caches themselves) are rejected with an
+error rather than silently diverging from the cached state - set them in `build_fit_context`, or
+use the `dm` form when they must vary per call.
+
 ## Building a new fitting method
 
 A new estimator is a `struct MyMethod <: FittingMethod` plus one method,
@@ -129,7 +148,8 @@ with the context's stored objects - results are identical, and the explicit laye
 the full-control path (own caches per thread, `BatchThetaContext` amortisation, custom bounds).
 Note that the population primitives called with a bare `dm` (e.g. `empirical_bayes(dm, θ)`)
 rebuild the caches on every call - inside a loop, prefer the context forms or the explicit
-layer. See the [Building Custom Estimators](tutorials/building-custom-estimators.md) tutorial
+layer. The gradient-bearing primitives take a context too: `laplace_marginal_gradient(ctx, θ)`
+and `objective_and_gradient(method, ctx, θ)`, described above. See the [Building Custom Estimators](tutorials/building-custom-estimators.md) tutorial
 for the full walkthrough.
 
 ### A fixed-effects method

--- a/src/estimation/dev_api.jl
+++ b/src/estimation/dev_api.jl
@@ -436,6 +436,7 @@ end
 """
     laplace_marginal_gradient(dm, θ, batch, b_star; const_cache, cache=nothing, scale=:untransformed, curvature=ExactHessianCurvature(), jitter=1e-6, max_tries=6, growth=10.0, adaptive=false, scale_factor=0.0, use_trace_logdet_grad=true, use_hutchinson=false, hutchinson_n=8, rng=Random.default_rng()) -> (value, gradient)
     laplace_marginal_gradient(dm, θ; constants_re=NamedTuple(), scale=:untransformed, kwargs...) -> (value, gradient)
+    laplace_marginal_gradient(ctx::FitContext, θ; scale=:untransformed, kwargs...) -> (value, gradient)
 
 Value AND analytic θ-gradient of the Laplace-approximate marginal log-likelihood
 [`laplace_marginal`](@ref) - the exact gradient the `Laplace` fit optimizes, including the
@@ -443,7 +444,9 @@ implicit `db*/dθ` envelope correction, so naive AD through the re-optimized mod
 needed. `value` is identical to `laplace_marginal` at the same arguments. The batch form
 takes one supplied mode `b_star`; the population form finds the modes and sums both value and
 gradient over batches (subjects are independent, so per-site sums are exact - this is the
-federation property).
+federation property). The `FitContext` form is the same population computation with the
+context's caches reused instead of rebuilt per call; kwargs frozen by the context
+(`constants_re`, `ode_args`, `ode_kwargs`, the caches) error rather than silently diverge.
 
 Scale contract: `θ` is natural-scale (as everywhere in this API) and `scale` selects the
 scale of the RETURNED gradient. `:untransformed` (default) is `∂/∂θ` on the natural scale;
@@ -799,6 +802,7 @@ end
 """
     objective_and_gradient(method, dm, θ; scale=:untransformed, hessian=false, include_penalty=false, penalty=NamedTuple(), kwargs...)
         -> (value, gradient) | (value, gradient, hessian)
+    objective_and_gradient(method, ctx::FitContext, θ; same kwargs) -> same
 
 Value AND θ-gradient of `method`'s log-objective at natural-scale `θ`, computed together the
 way the corresponding `fit_model` computes them - the shared analytic kernel for
@@ -837,6 +841,14 @@ Shipped dispatches, and the finer-grained forms:
     per-individual form `objective_and_gradient(MLE(), dm, θ, idx)`. Like `fit_model`, these
     require a model WITHOUT random effects; use `Laplace`, `SAEM` or `MCMC` otherwise.
 
+The `FitContext` form (`Laplace`, `FOCEI`, `GHQuadrature`, `MLE`, `MAP`, `Pooled`) returns
+identical results and reuses the context's batch infos, constant-RE cache and likelihood cache
+instead of rebuilding them per call - the form to use inside an iterating (e.g. federated)
+loop. `Pooled`/`MLE`/`MAP` reuse only the likelihood cache (they have no free random effects to
+batch, and `Pooled` recalibrates its plug-in `strategies` at every θ by construction). Options
+frozen at `build_fit_context` time (`constants_re`, `ode_args`, `ode_kwargs`, and the caches
+themselves) are not accepted per call and error if passed.
+
 A user-defined `FittingMethod` plugs into downstream tooling (federated aggregation,
 uncertainty workflows) by adding its own `objective_and_gradient` method.
 """
@@ -861,8 +873,11 @@ function _dev_laplace_kwargs(method, kwargs)
     return merge((; curvature = _dev_curvature(method)), opts, NamedTuple(kwargs))
 end
 
-function _dev_laplace_pair(dm::DataModel, θ::ComponentArray, call_kwargs, include_penalty, penalty)
-    v, g = laplace_marginal_gradient(dm, θ; scale = :untransformed, call_kwargs...)
+# `target` is a `DataModel` or a `FitContext` (defined below); dispatch picks the route.
+_dev_dm(dm::DataModel) = dm
+
+function _dev_laplace_pair(target, θ::ComponentArray, call_kwargs, include_penalty, penalty)
+    v, g = laplace_marginal_gradient(target, θ; scale = :untransformed, call_kwargs...)
     if include_penalty && !isempty(keys(penalty))
         v += _dev_penalty_term(θ, true, penalty)
         g = _dev_penalty_gradient!(g, θ, penalty)
@@ -871,7 +886,14 @@ function _dev_laplace_pair(dm::DataModel, θ::ComponentArray, call_kwargs, inclu
 end
 
 function objective_and_gradient(
-        method::Union{Laplace, FOCEI}, dm::DataModel, θ::ComponentArray;
+        method::Union{Laplace, FOCEI}, dm::DataModel, θ::ComponentArray; kwargs...
+    )
+    return _dev_laplace_og(method, dm, θ; kwargs...)
+end
+
+# Shared body for the `dm` and `FitContext` forms (`target` is either).
+function _dev_laplace_og(
+        method::Union{Laplace, FOCEI}, target, θ::ComponentArray;
         scale::Union{Symbol, AbstractString} = :untransformed, hessian::Bool = false,
         include_penalty::Bool = false,
         penalty::Union{NamedTuple, AbstractDict} = NamedTuple(),
@@ -880,9 +902,10 @@ function objective_and_gradient(
     scale = _dev_check_scale(scale)
     penalty = _as_namedtuple(penalty)
     call_kwargs = _dev_laplace_kwargs(method, kwargs)
+    dm = _dev_dm(target)
     fe = get_fixed(get_model(dm))
     θ_re = symmetrize_psd_parameters(θ, fe)
-    value, grad = _dev_laplace_pair(dm, θ_re, call_kwargs, include_penalty, penalty)
+    value, grad = _dev_laplace_pair(target, θ_re, call_kwargs, include_penalty, penalty)
     scaled = _dev_gradient_scale(dm, θ_re, grad, scale)
     hessian || return (value, scaled)
     # FD over the analytic gradient, in the coordinates of the requested scale.
@@ -891,7 +914,7 @@ function objective_and_gradient(
         x0 = collect(ComponentArrays.getdata(θ_re))
         g_of_x = function (xv)
             θx = ComponentArray(xv, axs)
-            _, gx = _dev_laplace_pair(dm, θx, call_kwargs, include_penalty, penalty)
+            _, gx = _dev_laplace_pair(target, θx, call_kwargs, include_penalty, penalty)
             return collect(gx)
         end
     else
@@ -901,7 +924,7 @@ function objective_and_gradient(
         it = get_inverse_transform(fe)
         g_of_x = function (xv)
             θx = symmetrize_psd_parameters(it(ComponentArray(xv, axs)), fe)
-            _, gx = _dev_laplace_pair(dm, θx, call_kwargs, include_penalty, penalty)
+            _, gx = _dev_laplace_pair(target, θx, call_kwargs, include_penalty, penalty)
             return collect(_dev_gradient_scale(dm, θx, gx, :transformed))
         end
     end
@@ -1250,6 +1273,8 @@ With a context, the primitives lose their cache arguments and address batches by
     empirical_bayes(ctx, θ)                     # per-batch modes b* (no Hessian computed)
     empirical_bayes_covariance(ctx, θ, modes)   # per-batch Σ = (−H)⁻¹ at the modes
     laplace_marginal(ctx, θ)                    # marginal log-likelihood at θ
+    laplace_marginal_gradient(ctx, θ)           # value + analytic θ-gradient of the marginal
+    objective_and_gradient(Laplace(), ctx, θ)   # method-dispatched value + gradient
     sample_random_effect_draws(ctx, θ)          # posterior draws per batch
     θ̂, sol = optimize_parameters(f, ctx)        # natural-scale objective, handled transforms
     build_fit_result(ctx, method, θ̂; kind=:frequentist_re, objective=...)  # eb_modes=:auto
@@ -1281,6 +1306,24 @@ primitives index into this vector.
 @inline get_batch_infos(ctx::FitContext) = ctx.batch_infos
 
 @inline get_data_model(ctx::FitContext) = ctx.dm
+@inline _dev_dm(ctx::FitContext) = ctx.dm
+
+# Everything the context froze at build time. Accepting these per call would silently diverge
+# from the cached state, so the context methods reject them.
+const _CTX_FIXED_KWARGS = (
+    :constants_re, :ode_args, :ode_kwargs, :const_cache, :cache, :serialization,
+)
+
+function _ctx_check_kwargs(fname::Symbol, kwargs)
+    for k in keys(kwargs)
+        k in _CTX_FIXED_KWARGS && error(
+            "$fname(ctx, ...): `$k` is fixed by the FitContext and cannot be passed per call. " *
+                "Set constants_re/ode_args/ode_kwargs in build_fit_context, or use the explicit " *
+                "`dm` form for per-call control."
+        )
+    end
+    return nothing
+end
 
 """
     initial_parameters(ctx::FitContext) -> ComponentArray
@@ -1368,6 +1411,112 @@ function laplace_marginal(
             )
             for bi in eachindex(ctx.batch_infos)
     )
+end
+
+# Batch-index cover, mirroring `ghq_marginal(ctx, bi, θ)`.
+@inline function laplace_marginal(
+        ctx::FitContext, bi::Integer, θ::ComponentArray, b_star; kwargs...
+    )
+    return laplace_marginal(
+        ctx.dm, θ, ctx.batch_infos[bi], b_star;
+        const_cache = ctx.const_cache, cache = ctx.cache, kwargs...
+    )
+end
+
+function laplace_marginal_gradient(
+        ctx::FitContext, θ::ComponentArray;
+        scale::Union{Symbol, AbstractString} = :untransformed,
+        curvature::AbstractCurvature = ExactHessianCurvature(),
+        ebe_options::EBEOptions = EBEOptions(), rescue = nothing,
+        rng::AbstractRNG = Random.default_rng(), kwargs...
+    )
+    _ctx_check_kwargs(:laplace_marginal_gradient, kwargs)
+    scale = _dev_check_scale(scale)
+    θ_re = symmetrize_psd_parameters(θ, get_fixed(get_model(ctx.dm)))
+    value = zero(eltype(θ_re))
+    grad = ComponentArray(zeros(eltype(θ_re), length(θ_re)), getaxes(θ_re))
+    isempty(ctx.batch_infos) && return (value, _dev_gradient_scale(ctx.dm, θ_re, grad, scale))
+    bstars = empirical_bayes(ctx, θ_re; ebe_options = ebe_options, rescue = rescue, rng = rng)
+    for bi in eachindex(ctx.batch_infos)
+        v, g = laplace_marginal_gradient(
+            ctx.dm, θ_re, ctx.batch_infos[bi], bstars[bi];
+            const_cache = ctx.const_cache, cache = ctx.cache, scale = :untransformed,
+            curvature = curvature, rng = rng, kwargs...
+        )
+        value += v
+        grad .+= g
+    end
+    return (value, _dev_gradient_scale(ctx.dm, θ_re, grad, scale))
+end
+
+# Context forms of the joint value+gradient primitive: same results, caches reused.
+function objective_and_gradient(
+        method::Union{Laplace, FOCEI}, ctx::FitContext, θ::ComponentArray; kwargs...
+    )
+    _ctx_check_kwargs(:objective_and_gradient, kwargs)
+    return _dev_laplace_og(method, ctx, θ; kwargs...)
+end
+
+function objective_and_gradient(
+        method::GHQuadrature, ctx::FitContext, θ::ComponentArray;
+        scale::Union{Symbol, AbstractString} = :untransformed, hessian::Bool = false,
+        include_penalty::Bool = false,
+        penalty::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        level = method.level, kwargs...
+    )
+    _ctx_check_kwargs(:objective_and_gradient, kwargs)
+    scale = _dev_check_scale(scale)
+    f = _DevGHQObjective(
+        ctx.dm, ctx.batch_infos, ctx.const_cache, ctx.cache, level,
+        _as_namedtuple(penalty), include_penalty
+    )
+    return _dev_sweep(f, ctx.dm, θ, scale, hessian)
+end
+
+function objective_and_gradient(
+        method::Union{MLE, MAP}, ctx::FitContext, θ::ComponentArray;
+        scale::Union{Symbol, AbstractString} = :untransformed, hessian::Bool = false,
+        include_penalty::Bool = false,
+        penalty::Union{NamedTuple, AbstractDict} = NamedTuple(), kwargs...
+    )
+    _ctx_check_kwargs(:objective_and_gradient, kwargs)
+    scale = _dev_check_scale(scale)
+    _require_no_random_effects(ctx.dm)
+    f = _DevNoREObjective(
+        ctx.dm, ctx.cache, EnsembleSerial(), _as_namedtuple(penalty), include_penalty,
+        method isa MAP ? get_fixed(get_model(ctx.dm)) : nothing
+    )
+    return _dev_sweep(f, ctx.dm, θ, scale, hessian)
+end
+
+function objective_and_gradient(
+        ::MLE, ctx::FitContext, θ::ComponentArray, idx::Integer;
+        scale::Union{Symbol, AbstractString} = :untransformed, hessian::Bool = false
+    )
+    scale = _dev_check_scale(scale)
+    _require_no_random_effects(ctx.dm)
+    f = _DevIndividualObjective(ctx.dm, Int(idx), ctx.cache)
+    return _dev_sweep(f, ctx.dm, θ, scale, hessian)
+end
+
+function objective_and_gradient(
+        method::Pooled, ctx::FitContext, θ::ComponentArray;
+        scale::Union{Symbol, AbstractString} = :untransformed, hessian::Bool = false,
+        include_penalty::Bool = false,
+        penalty::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        strategies = nothing, eta = nothing, rng::AbstractRNG = Random.default_rng(),
+        kwargs...
+    )
+    _ctx_check_kwargs(:objective_and_gradient, kwargs)
+    scale = _dev_check_scale(scale)
+    θ_re = symmetrize_psd_parameters(θ, get_fixed(get_model(ctx.dm)))
+    strat = strategies === nothing ?
+        _dev_pooled_strategies(ctx.dm, θ_re, method, rng) : strategies
+    f = _DevPooledObjective(
+        ctx.dm, ctx.cache, EnsembleSerial(), strat, eta, _as_namedtuple(penalty),
+        include_penalty
+    )
+    return _dev_sweep(f, ctx.dm, θ, scale, hessian)
 end
 
 function sample_random_effect_draws(

--- a/test/api_primitives_tests.jl
+++ b/test/api_primitives_tests.jl
@@ -1101,6 +1101,116 @@ end
         @test NoLimits.get_random_effects(dm, res) isa NamedTuple
     end
 
+    # Issue #273: the gradient-bearing primitives get FitContext forms that reuse the
+    # context's caches. Same results as the `dm` forms, no per-call rebuild.
+    @testset "FitContext gradient forms" begin
+        og = NoLimits.objective_and_gradient
+        ser = NoLimits.EnsembleSerial()
+        dm = fx_re_dm()
+        ctx = build_fit_context(dm)
+        θ0 = NoLimits.get_θ0_untransformed(NoLimits.get_fixed(NoLimits.get_model(dm)))
+
+        for s in (1.0, 0.85, 1.2), sc in (:untransformed, :transformed)
+            θ = ComponentArray(collect(θ0) .* s, getaxes(θ0))
+            v, g = NoLimits.laplace_marginal_gradient(ctx, θ; scale = sc)
+            vd, gd = NoLimits.laplace_marginal_gradient(
+                dm, θ; scale = sc, serialization = ser
+            )
+            @test v ≈ vd rtol = 1.0e-12
+            @test g ≈ gd rtol = 1.0e-12
+            @test getaxes(g) == getaxes(gd)
+
+            for m in (NoLimits.Laplace(), NoLimits.FOCEI())
+                vc, gc = og(m, ctx, θ; scale = sc)
+                vm, gm = og(m, dm, θ; scale = sc, serialization = ser)
+                @test vc ≈ vm rtol = 1.0e-12
+                @test gc ≈ gm rtol = 1.0e-12
+            end
+
+            ghq = NoLimits.GHQuadrature(; level = 2)
+            vc, gc = og(ghq, ctx, θ; scale = sc)
+            vm, gm = og(ghq, dm, θ; scale = sc)
+            @test vc == vm
+            @test gc == gm
+
+            pl = NoLimits.Pooled()
+            vc, gc = og(pl, ctx, θ; scale = sc, rng = Random.MersenneTwister(7))
+            vm, gm = og(pl, dm, θ; scale = sc, rng = Random.MersenneTwister(7))
+            @test vc ≈ vm rtol = 1.0e-12
+            @test gc ≈ gm rtol = 1.0e-12
+        end
+
+        # hessian = true is offered by every ctx form that offers it on `dm`
+        θ = ComponentArray(collect(θ0), getaxes(θ0))
+        vc, gc, Hc = og(NoLimits.Laplace(), ctx, θ; hessian = true)
+        vm, gm, Hm = og(NoLimits.Laplace(), dm, θ; hessian = true, serialization = ser)
+        @test vc ≈ vm rtol = 1.0e-12
+        @test gc ≈ gm rtol = 1.0e-12
+        @test Hc ≈ Hm rtol = 1.0e-10
+        ghq = NoLimits.GHQuadrature(; level = 2)
+        @test og(ghq, ctx, θ; hessian = true)[3] == og(ghq, dm, θ; hessian = true)[3]
+
+        # scalar-cover symmetry: batch-index laplace_marginal == the explicit call
+        modes = NoLimits.empirical_bayes(ctx, θ)
+        _, infos_c, cc_c = NoLimits.build_re_batch_infos(dm, NamedTuple())
+        cache_c = NoLimits.build_likelihood_cache(dm; force_saveat = true)
+        @test NoLimits.laplace_marginal(ctx, 1, θ, modes[1]) ===
+            NoLimits.laplace_marginal(
+            dm, θ, infos_c[1], modes[1]; const_cache = cc_c, cache = cache_c
+        )
+
+        # MLE / MAP (no random effects) reuse the likelihood cache
+        for (dmn, m) in (
+                (fx_nore_dm(), NoLimits.MLE()), (fx_nore_prior_dm(), NoLimits.MAP()),
+            )
+            cn = build_fit_context(dmn)
+            θn = NoLimits.get_θ0_untransformed(NoLimits.get_fixed(NoLimits.get_model(dmn)))
+            for sc in (:untransformed, :transformed)
+                vc, gc = og(m, cn, θn; scale = sc)
+                vm, gm = og(m, dmn, θn; scale = sc)
+                @test vc == vm
+                @test gc == gm
+            end
+            if m isa NoLimits.MLE
+                @test og(m, cn, θn, 1) == og(m, dmn, θn, 1)
+            end
+        end
+
+        # 20 sequential evaluations through one ctx == 20 dm-form calls (speedup is
+        # informational: the ctx form skips the per-call cache/batch-info rebuild)
+        og(NoLimits.Laplace(), ctx, θ)                       # warm up
+        og(NoLimits.Laplace(), dm, θ; serialization = ser)
+        vs_ctx = [og(NoLimits.Laplace(), ctx, θ) for _ in 1:20]
+        vs_dm = [og(NoLimits.Laplace(), dm, θ; serialization = ser) for _ in 1:20]
+        @test all(
+            vs_ctx[i][1] ≈ vs_dm[i][1] && vs_ctx[i][2] ≈ vs_dm[i][2] for i in 1:20
+        )
+        @test all(vs_ctx[i] == vs_ctx[1] for i in 1:20)      # reuse is stateless in θ
+
+        # Informational only (min of two rounds each): on these 2-subject fixtures the
+        # avoided rebuild is noise, so expect ~1x here - the gain scales with the data set
+        # (~1.75x on a 50-subject ODE model).
+        dmo = fx_ode_dm()
+        ctxo = build_fit_context(dmo)
+        θo = NoLimits.get_θ0_untransformed(NoLimits.get_fixed(NoLimits.get_model(dmo)))
+        f_ctx() = og(NoLimits.Laplace(), ctxo, θo)
+        f_dm() = og(NoLimits.Laplace(), dmo, θo; serialization = ser)
+        f_ctx()
+        f_dm()
+        t_ctx = minimum(@elapsed([f_ctx() for _ in 1:20]) for _ in 1:2)
+        t_dm = minimum(@elapsed([f_dm() for _ in 1:20]) for _ in 1:2)
+        @info "FitContext objective_and_gradient, 20 calls (ODE fixture)" t_ctx t_dm speedup = t_dm / t_ctx
+
+        # kwargs the context already fixed must error, not silently diverge
+        @test_throws ErrorException NoLimits.laplace_marginal_gradient(
+            ctx, θ; constants_re = (; η = (; var"1" = 0.0))
+        )
+        @test_throws ErrorException og(NoLimits.Laplace(), ctx, θ; ode_kwargs = (; abstol = 1.0e-8))
+        @test_throws ErrorException og(ghq, ctx, θ; constants_re = NamedTuple())
+        @test_throws ErrorException og(NoLimits.Pooled(), ctx, θ; ode_args = ())
+        @test_throws ErrorException og(NoLimits.MLE(), build_fit_context(fx_nore_dm()), θ0; cache = nothing)
+    end
+
     @testset "custom Bayesian estimator: build_fit_result(chain)" begin
         base = fx_mcmc()                       # built-in MCMC fit; reuse its chain + dm
         dm = NoLimits.get_data_model(base)


### PR DESCRIPTION
## What

`FitContext` forms for the gradient-bearing dev-API primitives, so an iterating consumer (the Flower federated loop) stops rebuilding the theta-independent setup once per optimizer round per site.

Added:

- `laplace_marginal_gradient(ctx, theta; scale, curvature, ebe_options, rescue, rng, <hessian opts>)`
- `objective_and_gradient(method, ctx, theta; ...)` for `Laplace`, `FOCEI` (shared kernel, incl. `hessian = true`), `GHQuadrature`, `MLE`, `MAP`, `Pooled`, and `objective_and_gradient(MLE(), ctx, theta, idx)`
- `laplace_marginal(ctx, bi, theta, b_star)` - the batch-index cover `ghq_marginal` already had (the symmetry gap the audit found)

All of them forward to the existing cache-explicit primitives with `ctx.batch_infos`, `ctx.const_cache` and `ctx.cache`; the `dm` forms are untouched (the Laplace/FOCEI body was extracted into an internal `_dev_laplace_og` shared by both). Keywords the context froze at build time (`constants_re`, `ode_args`, `ode_kwargs`, `const_cache`, `cache`, `serialization`) error instead of silently diverging from the cached state.

Deliberately not given ctx forms: the per-batch `objective_and_gradient(method, dm, theta, batch, b_star)` / `objective_and_gradient(method, dm, theta, batch)` forms - they already take explicit caches, so a context buys nothing; and the sampling-based methods (SAEM/MCEM/MCMC/VI), which have no deterministic theta-objective at all. `Pooled`/`MLE`/`MAP` reuse only the likelihood cache (no free RE batches to reuse, and `Pooled` recalibrates its plug-in `strategies` at every theta by construction) - documented in the docstring and the docs page.

## Testing

Extended `test/api_primitives_tests.jl` ("FitContext gradient forms", existing fixtures only): ctx == dm equality for value/gradient/Hessian per method at 3 theta points on both scales (bit-identical for the AD-swept methods, `rtol = 1e-12` for the Laplace/FOCEI analytic kernel, `1e-10` for its FD Hessian), the batch-index `laplace_marginal` cover, 20 sequential ctx calls matching 20 dm calls, the conflict-kwarg errors, and an informational timing report.

Measured speedup (informational): ~1.0x on the 2-subject test fixtures, where the avoided rebuild is noise, and ~1.75x for 20 `objective_and_gradient(Laplace(), ...)` calls on a 50-subject ODE model - the case the federated loop actually runs.

`NL_TEST_FILES="api_primitives_tests.jl,aqua_tests.jl,aqua_ambiguities_tests.jl"`: 427 + 9 + 1 passed, 0 failed. `fit_model` paths untouched.

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)