### PR TITLE
docs: lead with Julia before the R/Python interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,38 +47,6 @@ at the University of Bonn, with
 [Manuel Huth](https://www.mathematics-and-life-sciences.uni-bonn.de/en/group-members/people/hasenauer-group-members/manuel-huth)
 as lead developer.
 
-## R and Python interfaces
-
-NoLimits is fully usable from R and Python. Two thin wrapper packages,
-[NoLimitsR](https://github.com/manuhuth/NoLimitsR) and
-[NoLimitsPy](https://github.com/manuhuth/NoLimitsPy), expose every exported NoLimits.jl name
-dynamically, so there is no per-function glue code and new features are available as soon as
-the Julia package is updated. Models are written as strings, native data frames go straight
-into `DataModel`, and results come back as `data.frame`s or pandas `DataFrame`s.
-
-```r
-remotes::install_github("manuhuth/NoLimitsR"); NoLimitsR::install_nolimits()
-nl <- NoLimitsR::nolimits()
-dm <- nl$DataModel(nl_model(model_string), nl_data(df),
-                   primary_id = "ID", time_col = "time")
-res <- nl$fit_model(dm, nl$Laplace())
-head(nl_collect(nl$predict(res, nl_data(df))))
-```
-
-```python
-# pip install git+https://github.com/manuhuth/NoLimitsPy.git
-import NoLimitsPy as nl
-dm = nl.DataModel(nl.model(model_string), df,
-                  primary_id="ID", time_col="time")
-res = nl.fit_model(dm, nl.Laplace())
-print(nl.collect(nl.predict(res, df)).head())
-```
-
-See the
-[Using NoLimits from R and Python](https://manuhuth.github.io/NoLimits.jl/dev/tutorials/r-and-python)
-tutorial for installation, the full quickstart in both languages, and how Julia concepts such as
-Symbols and NamedTuples map onto native R and Python ones.
-
 ## Why NoLimits.jl?
 
 Nonlinear mixed-effects (NLME) models are the standard tool for longitudinal analysis in the
@@ -238,6 +206,38 @@ Swapping the inference paradigm is a one-line change: `fit_model(dm, SAEM())`, `
 or `fit_model(dm, MCMC())` all fit the *same* model (`MCMC` needs `using Turing`). More examples — neural-ODE models, Markov-model
 outcomes, normalizing-flow random effects, count outcomes, censored data, and multi-method
 comparison — are in the [Tutorials](https://manuhuth.github.io/NoLimits.jl/dev/tutorials/mixed-effects-multiple-methods).
+
+## R and Python interfaces
+
+NoLimits is fully usable from R and Python. Two thin wrapper packages,
+[NoLimitsR](https://github.com/manuhuth/NoLimitsR) and
+[NoLimitsPy](https://github.com/manuhuth/NoLimitsPy), expose every exported NoLimits.jl name
+dynamically, so there is no per-function glue code and new features are available as soon as
+the Julia package is updated. Models are written as strings, native data frames go straight
+into `DataModel`, and results come back as `data.frame`s or pandas `DataFrame`s.
+
+```r
+remotes::install_github("manuhuth/NoLimitsR"); NoLimitsR::install_nolimits()
+nl <- NoLimitsR::nolimits()
+dm <- nl$DataModel(nl_model(model_string), nl_data(df),
+                   primary_id = "ID", time_col = "time")
+res <- nl$fit_model(dm, nl$Laplace())
+head(nl_collect(nl$predict(res, nl_data(df))))
+```
+
+```python
+# pip install git+https://github.com/manuhuth/NoLimitsPy.git
+import NoLimitsPy as nl
+dm = nl.DataModel(nl.model(model_string), df,
+                  primary_id="ID", time_col="time")
+res = nl.fit_model(dm, nl.Laplace())
+print(nl.collect(nl.predict(res, df)).head())
+```
+
+See the
+[Using NoLimits from R and Python](https://manuhuth.github.io/NoLimits.jl/dev/tutorials/r-and-python)
+tutorial for installation, the full quickstart in both languages, and how Julia concepts such as
+Symbols and NamedTuples map onto native R and Python ones.
 
 ## Built on the Julia ecosystem
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -77,7 +77,6 @@ makedocs(;
         ],
         "Plotting" => "plotting/index.md",
         "Tutorials" => [
-            "Using NoLimits from R and Python" => "tutorials/r-and-python.md",
             "Multi-Method Comparison" => "tutorials/mixed-effects-multiple-methods.md",
             "ODE Model with Dosing (MCEM)" => "tutorials/mixed-effects-ode-mcem.md",
             "Neural Differential Equations (SAEM)" => "tutorials/mixed-effects-nn-saem.md",
@@ -89,6 +88,7 @@ makedocs(;
             "Fixed-Effects: MLE & MAP" => "tutorials/fixed-effects-nonlinear-mle-map.md",
             "Fixed-Effects: Variational Inference" => "tutorials/fixed-effects-vi.md",
             "Hidden & Observed Markov Models" => "tutorials/markov-models-observed-hidden-coarsed.md",
+            "Using NoLimits from R and Python" => "tutorials/r-and-python.md",
             "Building Custom Estimators" => "tutorials/building-custom-estimators.md",
         ],
         "Method-Developer API" => "method-developer-api.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -65,6 +65,17 @@ NoLimits.jl is designed to avoid these trade-offs. It supports:
 NoLimits.jl is designed for mixed-effects models, but it can equally be used for
 fixed-effects-only analysis when random effects are not required.
 
+## Getting Started
+
+New users should begin with the [Installation](installation.md) page and the
+[Quickstart](quickstart.md), then work through the
+[Tutorials](tutorials/mixed-effects-multiple-methods.md) for hands-on examples covering
+fixed-effects models, mixed-effects estimation with multiple methods, ODE-based models, and
+machine-learning-augmented dynamics.
+
+For a concise overview of what the package can do, see [Capabilities](capabilities.md). For
+the mathematical foundations, see [NLME Methodology](nlme-methodology.md).
+
 ## R and Python Interfaces
 
 NoLimits is fully usable from R and Python through two thin wrapper packages,
@@ -78,17 +89,6 @@ pandas `DataFrame`s.
 See [Using NoLimits from R and Python](tutorials/r-and-python.md) for installation, the
 quickstart in both languages, and how Julia concepts such as Symbols and NamedTuples map
 onto native R and Python ones.
-
-## Getting Started
-
-New users should begin with the [Installation](installation.md) page and the
-[Quickstart](quickstart.md), then work through the
-[Tutorials](tutorials/mixed-effects-multiple-methods.md) for hands-on examples covering
-fixed-effects models, mixed-effects estimation with multiple methods, ODE-based models, and
-machine-learning-augmented dynamics.
-
-For a concise overview of what the package can do, see [Capabilities](capabilities.md). For
-the mathematical foundations, see [NLME Methodology](nlme-methodology.md).
 
 ## How to Cite
 


### PR DESCRIPTION
Repositions the R/Python interface material so the package introduces itself in Julia first. The wrappers stay prominent, just not the first thing a reader sees.

- **README.md**: "R and Python interfaces" moved from directly after the intro to after the Quickstart (follows Quickstart, precedes "Built on the Julia ecosystem"), so the reader gets "Why NoLimits.jl?", Key Features, Installation and the Julia Quickstart first.
- **docs/src/index.md**: "R and Python Interfaces" moved to below "Getting Started" (precedes "How to Cite").
- **docs/make.jl**: "Using NoLimits from R and Python" moved from the first Tutorials entry to second-to-last, after the core Julia tutorials and before "Building Custom Estimators", which stays the closing deep dive.

Content is unchanged: every moved line is byte-identical, all relative links point at the same unchanged targets, no em-dashes introduced, and the AI-disclosure section is untouched. `docs/make.jl` parse-checked with `Meta.parseall`.

Needs to merge **before** the release PR #275 so the release ships the reordered docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)