### PR TITLE
docs: briefly mention the experimental Flower federated-learning showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,10 @@ See the
 tutorial for installation, the full quickstart in both languages, and how Julia concepts such as
 Symbols and NamedTuples map onto native R and Python ones.
 
+## Federated learning (experimental)
+
+NoLimits exposes the per-site objective and gradient primitives for federated estimation, where several sites fit one shared model without pooling their data. [NoLimitsFlowerDemo](https://github.com/manuhuth/NoLimitsFlowerDemo) is a public showcase that runs this over [Flower](https://flower.ai), matches the equivalent pooled fit, and adds optional secure aggregation and differential privacy. It is under active development and not yet a released package, so its interfaces may change.
+
 ## Built on the Julia ecosystem
 
 NoLimits.jl builds directly on established Julia packages, so their interfaces stay familiar:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -90,6 +90,10 @@ See [Using NoLimits from R and Python](tutorials/r-and-python.md) for installati
 quickstart in both languages, and how Julia concepts such as Symbols and NamedTuples map
 onto native R and Python ones.
 
+## Federated Learning (experimental)
+
+NoLimits exposes the per-site objective and gradient primitives for federated estimation, where several sites fit one shared model without pooling their data. [NoLimitsFlowerDemo](https://github.com/manuhuth/NoLimitsFlowerDemo) is a public showcase that runs this over [Flower](https://flower.ai), matches the equivalent pooled fit, and adds optional secure aggregation and differential privacy. It is under active development and not yet a released package, so its interfaces may change.
+
 ## How to Cite
 
 If you use NoLimits.jl in your research, please cite the software:


### PR DESCRIPTION
Docs-only. Adds a brief, clearly-experimental mention of the Flower federated-learning capability to the README and the docs landing page, right after the "R and Python interfaces" section.

The new section links only the **public** showcase repo ([NoLimitsFlowerDemo](https://github.com/manuhuth/NoLimitsFlowerDemo)) and states plainly that this is under active development and not yet a released package. The deployable app and any R (DataSHIELD) integration are intentionally not mentioned yet.

No code, no API, no CI-affecting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyJy54X6qhmkr5Dtcqt1bT
