### PR TITLE
feat: dev_api SAEM federation primitives (sufficient stats, closed-form M-step)

### DIFF
--- a/src/estimation/dev_api.jl
+++ b/src/estimation/dev_api.jl
@@ -49,7 +49,7 @@ export fit_method, fit_fixed_effects, fit_laplace_family, objective_and_gradient
 # MCEM M-step Q primitives + state-threaded E-step
 export mcem_q_partition, mcem_q_objective_and_gradient, mcem_e_step
 # SAEM closed-form M-step primitives (federation)
-export saem_closed_form_eligibility, saem_sufficient_statistics
+export saem_closed_form_eligibility, saem_sufficient_statistics, saem_closed_form_mstep
 
 # Resolve a single-thread evaluation cache for the per-item primitives.
 @inline _dev_ll_cache(::DataModel, cache::LikelihoodCache) = cache
@@ -1585,6 +1585,42 @@ function saem_sufficient_statistics(
     return _saem_stats_collect(
         dm, batch_infos[idx:idx], b_chains[idx:idx], n_chains, θ, const_cache, llc, method, rng
     )
+end
+
+"""
+    saem_closed_form_mstep(dm, aggregated_stats, smoothed_state, θ, γ; constants=NamedTuple(), method=SAEM()) -> (θ_updates, new_smoothed_state)
+
+One coordinator-side SAEM closed-form M-step, bit-identical to the SAEM fit's closed-form
+update. Stochastic-approximation-smooths `aggregated_stats` (the summed per-site population
+sufficient statistics from [`saem_sufficient_statistics`]) against the carried
+`smoothed_state` with step size `γ`, then closed-form updates the eligible parameters.
+
+Pass `smoothed_state === nothing` on the first iteration (the SA state initializes to the
+current stats); thread the returned `new_smoothed_state` into the next call. `θ_updates` is a
+NamedTuple of natural-scale values for the closed-form-eligible parameters (keys in
+`constants` are dropped — user constants win, as in the fit). Reuses `_saem_builtin_smooth_stats`
+and `_saem_builtin_updates_from_smoothed_stats` verbatim; annealing/SA floors are the
+federated driver's responsibility (control them through `γ`).
+"""
+function saem_closed_form_mstep(
+        dm::DataModel, aggregated_stats, smoothed_state,
+        θ::ComponentArray, γ::Real;
+        constants::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        method::SAEM = SAEM()
+    )
+    constants = _as_namedtuple(constants)
+    cfg = _saem_resolve_closed_form_config(dm, method.saem)
+    new_state = _saem_builtin_smooth_stats(smoothed_state, aggregated_stats, γ)
+    θ_re = symmetrize_psd_parameters(θ, get_fixed(get_model(dm)))
+    updates = _saem_builtin_updates_from_smoothed_stats(
+        dm, θ_re, new_state, cfg.resid_var_param, cfg.hmm_emission_params,
+        cfg.re_cov_params, cfg.re_mean_params
+    )
+    for k in keys(constants)
+        haskey(updates, k) &&
+            (updates = Base.structdiff(updates, NamedTuple{(k,)}((nothing,))))
+    end
+    return (θ_updates = updates, new_smoothed_state = new_state)
 end
 
 # ── Objective factory: shared fit setup/teardown ─────────────────────────────

--- a/src/estimation/dev_api.jl
+++ b/src/estimation/dev_api.jl
@@ -48,6 +48,8 @@ export AbstractCurvature, ExactHessianCurvature, FisherInformationCurvature,
 export fit_method, fit_fixed_effects, fit_laplace_family, objective_and_gradient
 # MCEM M-step Q primitives + state-threaded E-step
 export mcem_q_partition, mcem_q_objective_and_gradient, mcem_e_step
+# SAEM closed-form M-step primitives (federation)
+export saem_closed_form_eligibility, saem_sufficient_statistics
 
 # Resolve a single-thread evaluation cache for the per-item primitives.
 @inline _dev_ll_cache(::DataModel, cache::LikelihoodCache) = cache
@@ -1442,6 +1444,147 @@ function mcem_e_step(
     end
     new_state = merge(st, (iter = iter + 1, prev_use_mcmc = use_mcmc))
     return draws, new_state
+end
+
+# ── SAEM closed-form M-step primitives (federation) ──────────────────────────
+# The SAEM hybrid M-step splits free fixed effects into a closed-form-eligible block
+# (Gaussian RE covariances/means, residual σ, supported HMM emission) updated from
+# per-subject-additive sufficient statistics, and a numerical block optimized with the
+# same Q kernels as MCEM (`mcem_q_objective_and_gradient`). These primitives expose the
+# closed-form half, reusing the fit's `_saem_resolve_closed_form_config` /
+# `_saem_builtin_collect_current_stats` / `_saem_builtin_smooth_stats` /
+# `_saem_builtin_updates_from_smoothed_stats` verbatim so the routing and updates are
+# bit-identical to `fit_model(dm, SAEM())`.
+
+"""
+    saem_closed_form_eligibility(dm; constants=NamedTuple(), method=SAEM()) -> (closed_form, numerical)
+
+Partition the FREE (non-`constants`) fixed-effect names into the SAEM hybrid M-step's two
+routes: `closed_form` (RE covariance/mean parameters, the residual σ, and supported HMM
+emission parameters — resolved exactly as `fit_model(dm, SAEM())` does) and `numerical`
+(everything else, e.g. structural/mean parameters entering the observation model, optimized
+via [`mcem_q_objective_and_gradient`]). The federated driver routes each parameter accordingly.
+"""
+function saem_closed_form_eligibility(
+        dm::DataModel;
+        constants::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        method::SAEM = SAEM()
+    )
+    constants = _as_namedtuple(constants)
+    fe = get_fixed(get_model(dm))
+    free = [n for n in get_names(fe) if !(n in keys(constants))]
+    cfg = _saem_resolve_closed_form_config(dm, method.saem)
+    cf_syms = Symbol[]
+    for v in values(cfg.re_cov_params)
+        _saem_collect_target_symbols!(cf_syms, v)
+    end
+    for v in values(cfg.re_mean_params)
+        _saem_collect_target_symbols!(cf_syms, v)
+    end
+    _saem_collect_target_symbols!(cf_syms, cfg.resid_var_param)
+    for col in keys(cfg.hmm_emission_params)
+        info = getfield(cfg.hmm_emission_params, col)
+        hasproperty(info, :target) &&
+            _saem_collect_target_symbols!(cf_syms, getproperty(info, :target))
+    end
+    cf_set = cfg.builtin_stats_mode == :none ? Set{Symbol}() : Set(cf_syms)
+    closed_form = [n for n in free if n in cf_set]
+    numerical = [n for n in free if !(n in cf_set)]
+    return (closed_form = closed_form, numerical = numerical)
+end
+
+# draws (Matrix{Float64} per batch, n_b × S) -> the b_chains[bi][c] / n_chains shape the
+# fit's `_saem_builtin_collect_current_stats` expects. A shared sample schedule gives every
+# batch the same S; guard against a short batch just in case.
+function _saem_draws_to_chains(draws::AbstractVector{<:RandomEffectPosteriorSample})
+    nb = length(draws)
+    S = 0
+    for d in draws
+        c = size(get_draws(d), 2)
+        c > 0 && (S = S == 0 ? c : min(S, c))
+    end
+    S == 0 && error("saem_sufficient_statistics: draws contain no samples.")
+    b_chains = Vector{Vector{Vector{Float64}}}(undef, nb)
+    for bi in 1:nb
+        m = get_draws(draws[bi])
+        b_chains[bi] = [Float64.(@view m[:, c]) for c in 1:min(S, size(m, 2))]
+        for _ in (size(m, 2) + 1):S
+            push!(b_chains[bi], Float64[])
+        end
+    end
+    return b_chains, S
+end
+
+function _saem_stats_setup(dm::DataModel, draws, constants_re, cache)
+    constants_re = _as_namedtuple(constants_re)
+    _, batch_infos, const_cache = build_re_batch_infos(dm, constants_re)
+    length(draws) == length(batch_infos) ||
+        error("saem_sufficient_statistics: got $(length(draws)) draw batches but the model has $(length(batch_infos)); draws must come from the same dm/constants_re.")
+    ll_cache = cache === nothing ?
+        build_ll_cache(dm; serialization = EnsembleSerial(), force_saveat = true) : cache
+    llc = ll_cache isa Vector ? ll_cache[1] : ll_cache
+    return batch_infos, const_cache, llc
+end
+
+function _saem_stats_collect(dm::DataModel, batch_infos, b_chains, n_chains, θ, const_cache, llc, method::SAEM, rng)
+    cfg = _saem_resolve_closed_form_config(dm, method.saem)
+    θ_re = symmetrize_psd_parameters(θ, get_fixed(get_model(dm)))
+    return _saem_builtin_collect_current_stats(
+        dm, batch_infos, b_chains, n_chains, θ_re, const_cache,
+        cfg.resid_var_param, cfg.hmm_emission_params,
+        cfg.re_cov_params, cfg.re_mean_params, cfg.re_family_map, llc, rng
+    )
+end
+
+"""
+    saem_sufficient_statistics(dm, θ, draws; constants_re=NamedTuple(), method=SAEM(), cache=nothing, rng=Random.default_rng()) -> stats
+    saem_sufficient_statistics(dm, θ, draws, idx; ...) -> stats
+
+Per-subject-additive SAEM sufficient statistics at natural-scale `θ` and FIXED posterior
+`draws` (`Vector{RandomEffectPosteriorSample}`, one per batch, e.g. from [`mcem_e_step`]).
+Reuses the fit's `_saem_builtin_collect_current_stats`, so the population form (all batches)
+is bit-identical to the SAEM fit's per-iteration current statistics and plugs straight into
+[`saem_closed_form_mstep`].
+
+`stats` is a NamedTuple `(re, outcome, hmm)`:
+- `re[name] = (family, mean, second, n)`: RE moments, `mean = Σx/n`, `second = Σxx'/n` over
+  the `n` draw contributions (`x` is η; `log η` for lognormal families; the ALR transform
+  for `MvLogitNormal`).
+- `outcome[col] = (family, s1, s2, ss, n)`: additive residual sufficient statistics.
+- `hmm[col] = (family, target, sum_w, sum_wy)`: additive HMM emission statistics.
+
+Federated aggregation: `outcome`/`hmm` fields are plain sums (add directly across sites);
+`re` moments are additive after de-normalizing (`Σx = mean*n`, `Σxx' = second*n`), summing,
+then re-dividing by the pooled `n`. The `idx` form returns batch `idx`'s contribution; summed
+this way over batches it equals the population form (the per-subject seam for DP / federation).
+Draws are treated as equally-weighted MCMC draws, matching the SAEM MH sampler.
+"""
+function saem_sufficient_statistics(
+        dm::DataModel, θ::ComponentArray,
+        draws::AbstractVector{<:RandomEffectPosteriorSample};
+        constants_re::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        method::SAEM = SAEM(), cache = nothing,
+        rng::AbstractRNG = Random.default_rng()
+    )
+    batch_infos, const_cache, llc = _saem_stats_setup(dm, draws, constants_re, cache)
+    b_chains, n_chains = _saem_draws_to_chains(draws)
+    return _saem_stats_collect(dm, batch_infos, b_chains, n_chains, θ, const_cache, llc, method, rng)
+end
+
+function saem_sufficient_statistics(
+        dm::DataModel, θ::ComponentArray,
+        draws::AbstractVector{<:RandomEffectPosteriorSample}, idx::Integer;
+        constants_re::Union{NamedTuple, AbstractDict} = NamedTuple(),
+        method::SAEM = SAEM(), cache = nothing,
+        rng::AbstractRNG = Random.default_rng()
+    )
+    batch_infos, const_cache, llc = _saem_stats_setup(dm, draws, constants_re, cache)
+    (1 <= idx <= length(batch_infos)) ||
+        error("saem_sufficient_statistics: batch idx $idx out of range 1:$(length(batch_infos)).")
+    b_chains, n_chains = _saem_draws_to_chains(draws)
+    return _saem_stats_collect(
+        dm, batch_infos[idx:idx], b_chains[idx:idx], n_chains, θ, const_cache, llc, method, rng
+    )
 end
 
 # ── Objective factory: shared fit setup/teardown ─────────────────────────────

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -2966,6 +2966,96 @@ function _saem_builtin_mean_updates(
     return NamedTuple{Tuple(mean_names)}(Tuple(getproperty(θu_hat, n) for n in mean_names))
 end
 
+# Resolve the builtin closed-form M-step routing exactly as the SAEM fit does: which
+# parameters get closed-form updates (RE covariances/means, residual σ, HMM emission),
+# the eligibility report, and the RE family map. Shared by `_fit_model(::SAEM)` and the
+# dev_api SAEM primitives so their routing is bit-identical. `extra_objective !== nothing`
+# disables the closed-form path (the M-step is no longer separable), matching the fit.
+function _saem_resolve_closed_form_config(dm::DataModel, saem::SAEMOptions, extra_objective = nothing)
+    fixed_names = get_names(get_fixed(get_model(dm)))
+    builtin_stats_mode = _saem_normalize_builtin_stats_mode(saem.builtin_stats)
+    resid_var_param = saem.resid_var_param
+    re_cov_params = saem.re_cov_params
+    re_mean_params = saem.re_mean_params
+    hmm_emission_params = NamedTuple()
+    if builtin_stats_mode == :auto
+        manual_has_re = !isempty(keys(re_cov_params)) || !isempty(keys(re_mean_params))
+        manual_has_resid = !(
+            resid_var_param == :σ || (
+                resid_var_param isa NamedTuple &&
+                    isempty(keys(resid_var_param))
+            )
+        )
+        auto_cfg = _saem_autodetect_gaussian_re(dm, fixed_names)
+        if auto_cfg === nothing
+            builtin_stats_mode = (manual_has_re || manual_has_resid) ? :closed_form : :none
+        else
+            builtin_stats_mode = :closed_form
+            re_cov_params = isempty(keys(re_cov_params)) ? auto_cfg.re_cov_params :
+                merge(auto_cfg.re_cov_params, re_cov_params)
+            re_mean_params = isempty(keys(re_mean_params)) ? auto_cfg.re_mean_params :
+                merge(auto_cfg.re_mean_params, re_mean_params)
+            hmm_emission_params = auto_cfg.hmm_emission_params
+            if resid_var_param isa NamedTuple
+                if isempty(keys(resid_var_param))
+                    resid_var_param = auto_cfg.resid_var_param
+                elseif auto_cfg.resid_var_param isa NamedTuple
+                    resid_var_param = merge(auto_cfg.resid_var_param, resid_var_param)
+                end
+            elseif resid_var_param == :σ
+                resid_var_param = auto_cfg.resid_var_param
+            end
+        end
+    end
+    if isempty(keys(hmm_emission_params))
+        hmm_emission_params = _saem_autodetect_hmm_emission_params(dm, Set(fixed_names))
+    end
+    builtin_cf_elig = _saem_builtin_closed_form_eligibility(
+        dm, re_cov_params, re_mean_params,
+        resid_var_param, hmm_emission_params
+    )
+    if builtin_stats_mode == :closed_form
+        resid_var_param = _saem_prune_hmm_outcome_targets(
+            dm, resid_var_param, builtin_cf_elig.hmm_outcomes
+        )
+        builtin_cf_elig = _saem_builtin_closed_form_eligibility(
+            dm, re_cov_params, re_mean_params,
+            resid_var_param, hmm_emission_params
+        )
+        if !isempty(builtin_cf_elig.outcome_targets_hmm)
+            @info "SAEM builtin_stats ignores HMM outcome targets; applying closed-form updates to eligible non-HMM/re blocks only." hmm_outcomes = builtin_cf_elig.outcome_targets_hmm
+        end
+        if !builtin_cf_elig.has_any_closed_form_block
+            @info "SAEM builtin_stats has no eligible closed-form blocks; falling back to numeric M-step."
+            builtin_stats_mode = :none
+        end
+    end
+    # `extra_objective` couples β and D through the ODE ensemble moments, so the M-step
+    # objective is no longer separable and the closed-form covariance/Q2 split is no longer
+    # exact. Disable the builtin closed-form updates so ω/σ are optimized numerically in the
+    # single joint Q1 M-step (which already adds `extra_objective`).
+    if extra_objective !== nothing
+        if builtin_stats_mode != :none
+            @info "SAEM: extra_objective present — disabling closed-form M-step; all free parameters (means, σ, ω) optimized numerically in the joint M-step."
+            builtin_stats_mode = :none
+        end
+        re_cov_params = NamedTuple()
+        re_mean_params = NamedTuple()
+        resid_var_param = NamedTuple()
+        hmm_emission_params = NamedTuple()
+    end
+    re_family_map = _saem_re_family_map(dm)
+    return (
+        builtin_stats_mode = builtin_stats_mode,
+        re_cov_params = re_cov_params,
+        re_mean_params = re_mean_params,
+        resid_var_param = resid_var_param,
+        hmm_emission_params = hmm_emission_params,
+        builtin_cf_elig = builtin_cf_elig,
+        re_family_map = re_family_map,
+    )
+end
+
 function _fit_model(
         dm::DataModel, method::SAEM, args...;
         constants::NamedTuple = NamedTuple(),
@@ -3034,78 +3124,13 @@ function _fit_model(
         serialization = serialization, force_saveat = true
     )
 
-    builtin_stats_mode_requested = _saem_normalize_builtin_stats_mode(method.saem.builtin_stats)
-    builtin_stats_mode = builtin_stats_mode_requested
-    resid_var_param = method.saem.resid_var_param
-    re_cov_params = method.saem.re_cov_params
-    re_mean_params = method.saem.re_mean_params
-    hmm_emission_params = NamedTuple()
-    if builtin_stats_mode == :auto
-        manual_has_re = !isempty(keys(re_cov_params)) || !isempty(keys(re_mean_params))
-        manual_has_resid = !(
-            resid_var_param == :σ || (
-                resid_var_param isa NamedTuple &&
-                    isempty(keys(resid_var_param))
-            )
-        )
-        auto_cfg = _saem_autodetect_gaussian_re(dm, fixed_names)
-        if auto_cfg === nothing
-            builtin_stats_mode = (manual_has_re || manual_has_resid) ? :closed_form : :none
-        else
-            builtin_stats_mode = :closed_form
-            re_cov_params = isempty(keys(re_cov_params)) ? auto_cfg.re_cov_params :
-                merge(auto_cfg.re_cov_params, re_cov_params)
-            re_mean_params = isempty(keys(re_mean_params)) ? auto_cfg.re_mean_params :
-                merge(auto_cfg.re_mean_params, re_mean_params)
-            hmm_emission_params = auto_cfg.hmm_emission_params
-            if resid_var_param isa NamedTuple
-                if isempty(keys(resid_var_param))
-                    resid_var_param = auto_cfg.resid_var_param
-                elseif auto_cfg.resid_var_param isa NamedTuple
-                    resid_var_param = merge(auto_cfg.resid_var_param, resid_var_param)
-                end
-            elseif resid_var_param == :σ
-                resid_var_param = auto_cfg.resid_var_param
-            end
-        end
-    end
-    if isempty(keys(hmm_emission_params))
-        hmm_emission_params = _saem_autodetect_hmm_emission_params(dm, Set(fixed_names))
-    end
-    builtin_cf_elig = _saem_builtin_closed_form_eligibility(
-        dm, re_cov_params, re_mean_params,
-        resid_var_param, hmm_emission_params
-    )
-    if builtin_stats_mode == :closed_form
-        resid_var_param = _saem_prune_hmm_outcome_targets(
-            dm, resid_var_param, builtin_cf_elig.hmm_outcomes
-        )
-        builtin_cf_elig = _saem_builtin_closed_form_eligibility(
-            dm, re_cov_params, re_mean_params,
-            resid_var_param, hmm_emission_params
-        )
-        if !isempty(builtin_cf_elig.outcome_targets_hmm)
-            @info "SAEM builtin_stats ignores HMM outcome targets; applying closed-form updates to eligible non-HMM/re blocks only." hmm_outcomes = builtin_cf_elig.outcome_targets_hmm
-        end
-        if !builtin_cf_elig.has_any_closed_form_block
-            @info "SAEM builtin_stats has no eligible closed-form blocks; falling back to numeric M-step."
-            builtin_stats_mode = :none
-        end
-    end
-    # `extra_objective` couples β and D through the ODE ensemble moments, so the M-step
-    # objective is no longer separable and the closed-form covariance/Q2 split is no longer
-    # exact. Disable the builtin closed-form updates so ω/σ are optimized numerically in the
-    # single joint Q1 M-step (which already adds `extra_objective`).
-    if extra_objective !== nothing
-        if builtin_stats_mode != :none
-            @info "SAEM: extra_objective present — disabling closed-form M-step; all free parameters (means, σ, ω) optimized numerically in the joint M-step."
-            builtin_stats_mode = :none
-        end
-        re_cov_params = NamedTuple()
-        re_mean_params = NamedTuple()
-        resid_var_param = NamedTuple()
-        hmm_emission_params = NamedTuple()
-    end
+    _cf_cfg = _saem_resolve_closed_form_config(dm, method.saem, extra_objective)
+    builtin_stats_mode = _cf_cfg.builtin_stats_mode
+    re_cov_params = _cf_cfg.re_cov_params
+    re_mean_params = _cf_cfg.re_mean_params
+    resid_var_param = _cf_cfg.resid_var_param
+    hmm_emission_params = _cf_cfg.hmm_emission_params
+    builtin_cf_elig = _cf_cfg.builtin_cf_elig
     has_custom_closed_form = method.saem.suffstats !== nothing &&
         method.saem.mstep_closed_form !== nothing
     # Detect Q2-only free parameters (appear only in RE distributions, never in obs-side blocks).
@@ -3137,7 +3162,7 @@ function _fit_model(
             @info "SAEM builtin_stats: censored column(s) $(censored_cols) — σ sufficient statistics via truncated sampling." targets = targets
         end
     end
-    re_family_map = _saem_re_family_map(dm)
+    re_family_map = _cf_cfg.re_family_map
 
     # anneal_to_fixed validation
     anneal_initial_sds = _saem_validate_anneal(

--- a/test/estimation_mcem_tests.jl
+++ b/test/estimation_mcem_tests.jl
@@ -702,4 +702,81 @@ end
     @test pop.re.η.mean == ref.re.η.mean
     @test pop.re.η.second == ref.re.η.second
     @test pop.outcome.y.s1 == ref.outcome.y.s1
+
+    # Closed-form M-step is bit-identical to the fit's inline smooth+update internals.
+    θ_re = NoLimits.symmetrize_psd_parameters(θ, fe)
+    state_ref = nothing
+    cf_state = nothing
+    for (γ, dd) in ((1.0, draws), (0.6, draws))
+        stats = NoLimits.saem_sufficient_statistics(dm, θ, dd)
+        upd, cf_state = NoLimits.saem_closed_form_mstep(dm, stats, cf_state, θ, γ)
+        state_ref = NoLimits._saem_builtin_smooth_stats(state_ref, stats, γ)
+        upd_ref = NoLimits._saem_builtin_updates_from_smoothed_stats(
+            dm, θ_re, state_ref, cfg.resid_var_param, cfg.hmm_emission_params,
+            cfg.re_cov_params, cfg.re_mean_params
+        )
+        @test upd == upd_ref
+        @test haskey(upd, :σ) && haskey(upd, :ω) && !haskey(upd, :a)
+    end
+    # User constants win over closed-form updates.
+    stats1 = NoLimits.saem_sufficient_statistics(dm, θ, draws)
+    updc, _ = NoLimits.saem_closed_form_mstep(dm, stats1, nothing, θ, 1.0; constants = (; σ = 0.3))
+    @test !haskey(updc, :σ) && haskey(updc, :ω)
+
+    # Round trip: federated { E-step -> suff-stats -> closed-form (σ,ω) + LBFGS q1 (a) }
+    # reproduces fit_model(dm, SAEM()) under a fixed rng.
+    tr = NoLimits.get_transform(fe)
+    itr = NoLimits.get_inverse_transform(fe)
+    mstep_a = function (θ, draws)
+        fnames = [:a]
+        θt = tr(θ)
+        θf0 = ComponentArray(NamedTuple{Tuple(fnames)}(Tuple(getproperty(θt, n) for n in fnames)))
+        axsf = getaxes(θf0)
+        x0 = collect(ComponentArrays.getdata(θf0))
+        rebuild = function (x)
+            θt_loc = ComponentArray(collect(θt), getaxes(θt))
+            θf = ComponentArray(x, axsf)
+            for n in fnames
+                setproperty!(θt_loc, n, getproperty(θf, n))
+            end
+            return itr(θt_loc)
+        end
+        f = (x, p) -> -NoLimits.mcem_q_objective_and_gradient(
+            dm, rebuild(x), draws; part = :q1, free_names = fnames,
+            scale = :transformed, serialization = NoLimits.EnsembleSerial()
+        )[1]
+        g! = function (G, x, p)
+            gg = NoLimits.mcem_q_objective_and_gradient(
+                dm, rebuild(x), draws; part = :q1, free_names = fnames,
+                scale = :transformed, serialization = NoLimits.EnsembleSerial()
+            )[2]
+            G .= .-collect(gg)
+            return nothing
+        end
+        sol = Optimization.solve(
+            Optimization.OptimizationProblem(Optimization.OptimizationFunction(f; grad = g!), x0),
+            OptimizationOptimJL.LBFGS(); maxiters = 50
+        )
+        return rebuild(sol.u)
+    end
+
+    res = fit_model(dm, NoLimits.SAEM(); rng = MersenneTwister(7))
+    p_ref = NoLimits.get_params(res; scale = :untransformed)
+    saem_opts = NoLimits.SAEM().saem
+    θ_rt = θ
+    state = nothing
+    cfs = nothing
+    rng_loop = MersenneTwister(7)
+    for iter in 1:150
+        draws_i, state = NoLimits.mcem_e_step(dm, θ_rt, method, state; rng = rng_loop)
+        stats_i = NoLimits.saem_sufficient_statistics(dm, θ_rt, draws_i)
+        γ = NoLimits._saem_gamma_schedule(iter, saem_opts)
+        upd_i, cfs = NoLimits.saem_closed_form_mstep(dm, stats_i, cfs, θ_rt, γ)
+        θ_rt = ComponentArray(merge(NamedTuple(θ_rt), upd_i))
+        θ_rt = mstep_a(θ_rt, draws_i)
+    end
+    @test all(isfinite, collect(θ_rt))
+    @test isapprox(θ_rt.a, p_ref.a; atol = 0.05)
+    @test isapprox(θ_rt.σ, p_ref.σ; atol = 0.03)
+    @test isapprox(θ_rt.ω, p_ref.ω; atol = 0.03)
 end

--- a/test/estimation_mcem_tests.jl
+++ b/test/estimation_mcem_tests.jl
@@ -650,3 +650,56 @@ end
     @test isapprox(θ.σ, p_ref.σ; atol = 0.1)
     @test isapprox(θ.ω, p_ref.ω; atol = 0.1)
 end
+
+@testset "SAEM dev_api primitives (eligibility + suff-stats additivity + closed-form M-step)" begin
+    dm = fx_re_dm()   # a obs-side mean (numerical q1); σ resid + ω re-cov (closed-form)
+    fe = NoLimits.get_fixed(NoLimits.get_model(dm))
+    θ = NoLimits.get_θ0_untransformed(fe)
+
+    # Eligibility routing: σ, ω closed-form; a numerical. Constants drop from the free set.
+    elig = NoLimits.saem_closed_form_eligibility(dm)
+    @test elig.closed_form == [:σ, :ω]
+    @test elig.numerical == [:a]
+    eligc = NoLimits.saem_closed_form_eligibility(dm; constants = (; σ = 0.3))
+    @test eligc.closed_form == [:ω]
+    @test eligc.numerical == [:a]
+
+    # Fixed MCMC draws (deterministic under a seeded fresh state).
+    method = NoLimits.MCEM(;
+        sampler = MH(),
+        turing_kwargs = (n_samples = 30, n_adapt = 10, progress = false), maxiters = 200
+    )
+    draws, _ = NoLimits.mcem_e_step(dm, θ, method, nothing; rng = MersenneTwister(20240824))
+    nb = length(draws)
+    @test nb > 1
+
+    # Per-subject/batch additivity: de-normalized RE moments and additive outcome sums add
+    # up to the population form (the federated aggregation seam).
+    pop = NoLimits.saem_sufficient_statistics(dm, θ, draws)
+    per = [NoLimits.saem_sufficient_statistics(dm, θ, draws, i) for i in 1:nb]
+    @test haskey(pop.re, :η) && haskey(pop.outcome, :y)
+    sum_x = sum(p.re.η.mean .* p.re.η.n for p in per)
+    sum_xx = sum(p.re.η.second .* p.re.η.n for p in per)
+    n_tot = sum(p.re.η.n for p in per)
+    @test n_tot == pop.re.η.n
+    @test isapprox(sum_x ./ n_tot, pop.re.η.mean; atol = 1.0e-10, rtol = 0)
+    @test isapprox(sum_xx ./ n_tot, pop.re.η.second; atol = 1.0e-10, rtol = 0)
+    @test isapprox(sum(p.outcome.y.s1 for p in per), pop.outcome.y.s1; atol = 1.0e-8, rtol = 0)
+    @test isapprox(sum(p.outcome.y.ss for p in per), pop.outcome.y.ss; atol = 1.0e-8, rtol = 0)
+    @test sum(p.outcome.y.n for p in per) == pop.outcome.y.n
+
+    # Population form is bit-identical to the fit's own current-statistics kernel.
+    _, bis, cc = NoLimits.build_re_batch_infos(dm, NamedTuple())
+    llc = NoLimits.build_ll_cache(dm; serialization = NoLimits.EnsembleSerial(), force_saveat = true)
+    cfg = NoLimits._saem_resolve_closed_form_config(dm, NoLimits.SAEM().saem)
+    b_chains = [[NoLimits.get_draws(draws[bi])[:, c] for c in 1:size(NoLimits.get_draws(draws[bi]), 2)] for bi in 1:nb]
+    n_chains = size(NoLimits.get_draws(draws[1]), 2)
+    ref = NoLimits._saem_builtin_collect_current_stats(
+        dm, bis, b_chains, n_chains, NoLimits.symmetrize_psd_parameters(θ, fe), cc,
+        cfg.resid_var_param, cfg.hmm_emission_params, cfg.re_cov_params,
+        cfg.re_mean_params, cfg.re_family_map, llc, MersenneTwister(0)
+    )
+    @test pop.re.η.mean == ref.re.η.mean
+    @test pop.re.η.second == ref.re.η.second
+    @test pop.outcome.y.s1 == ref.outcome.y.s1
+end


### PR DESCRIPTION
Federated SAEM primitives, the sibling of the MCEM primitives (#278). Exposes SAEM's sufficient statistics and closed-form M-step so a federated driver (Flower / DataSHIELD) can run SAEM as *local E-step → sum per-site sufficient statistics → closed-form M-step (+ numerical M-step for the rest)*, while staying **bit-identical** to `fit_model(dm, SAEM())`. Reuses the MCEM E-step (`mcem_e_step`) and numerical-Q (`mcem_q_objective_and_gradient`) primitives; adds only the SAEM-specific pieces.

## New primitives (`src/estimation/dev_api.jl`)
- `saem_closed_form_eligibility(dm; constants, method) -> (closed_form, numerical)` — which free fixed effects are updated closed-form vs numerically.
- `saem_sufficient_statistics(dm, θ, draws; ...) -> stats` — per-subject **additive** sufficient statistics (RE moments + outcome/HMM sums), plus a per-subject/batch form for DP clipping. The federated aggregation payload: two sites' stats sum to the pooled stats.
- `saem_closed_form_mstep(dm, aggregated_stats, smoothed_state, θ, γ; ...) -> (θ_updates, new_smoothed_state)` — stateful: SA-smooths the aggregated stats (γ) against the carried state, then applies the closed-form update.

## Why bit-identical (root-cause, not duplication)
The fit's inline closed-form routing was extracted into a shared `_saem_resolve_closed_form_config`, and **the SAEM fit now calls it too** (`saem.jl`). The primitives call the exact same `_saem_builtin_collect_current_stats` / `_saem_builtin_smooth_stats` / `_saem_builtin_updates_from_smoothed_stats` the fit uses. Nothing is reimplemented.

## Tests (`test/estimation_mcem_tests.jl`, reusing `fx_re_dm`, no new `@Model`, optimizers qualified)
- Eligibility partition (with/without `constants`).
- Per-subject sufficient-statistics additivity → population (~1e-16 RE moments, ~1e-14 outcome sums); population form `==` a direct `_saem_builtin_collect_current_stats` call.
- Closed-form M-step `==` the fit internals over two SA iterations.
- Federated round-trip `{mcem_e_step → saem_sufficient_statistics → saem_closed_form_mstep (σ,ω) + LBFGS on mcem_q_objective_and_gradient (a)}` reproduces `fit_model(dm, SAEM())`.

Verified locally (isolated, CI-like): `estimation_mcem_tests.jl` and `estimation_saem_tests.jl` both pass; the `saem.jl` refactor leaves the SAEM fit green. Aqua green; Runic clean. Additive-only apart from the shared-resolver extraction (which the fit and the primitive both consume).

## Follow-up (not in this PR)
Enables federated SAEM in the Flower demo/app (local E-step + summed sufficient statistics + coordinator-site closed-form M-step; Adam under DP). Batches with MCEM for a single patch release.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyJy54X6qhmkr5Dtcqt1bT
