### PR TITLE
release: v0.2.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NoLimits"
 uuid = "1d491b74-35a5-408f-ae19-cf8524c3769d"
 license = "MIT"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Manuel Huth", "Jonas Arruda", "Clemens Peiter", "Roy Gusinow", "Nina Schmid", "Jan Hasenauer"]
 
 [deps]


### PR DESCRIPTION
Version bump 0.2.6 -> 0.2.7. Ships the federated-EM dev_api primitives merged in #278 (MCEM) and #279 (SAEM): the E-step, M-step Q, sufficient-statistics, and closed-form M-step primitives that let a federated driver run MCEM and SAEM exactly (verified bit-identical to fit_model). Additive-only; no behavior change to existing estimators.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyJy54X6qhmkr5Dtcqt1bT