### PR TITLE
Fix _detect_closed_form is not thread-safe

### DIFF
--- a/src/model/closed_form_ode.jl
+++ b/src/model/closed_form_ode.jl
@@ -130,6 +130,8 @@ function _cf_depends_on(e, svars, tvar)
     return false
 end
 
+const _CLOSED_FORM_LOCK = ReentrantLock()
+
 """
     _detect_closed_form(model) -> ClosedFormPlan
 
@@ -142,8 +144,13 @@ rest are integrated numerically. `mode` is `:diagonal` (the subset's coefficient
 matrix is diagonal — scalar closed form) or `:linear` (general/triangular — matrix-
 exponential action). `cf_states == 1:n` means the whole system is closed-form.
 Anything untraceable is conservatively excluded (numerical is always correct).
+
+Serialized: the Symbolics term caches this drives are process-wide and not thread-safe,
+and racing them silently returns a wrong plan. Runs once per `DataModel`, sub-millisecond.
 """
-function _detect_closed_form(model)
+_detect_closed_form(model) = @lock _CLOSED_FORM_LOCK _detect_closed_form_impl(model)
+
+function _detect_closed_form_impl(model)
     de = get_de(model)
     de === nothing && return _NO_CLOSED_FORM
     # Crossing (time-to-event) models need solver-native event detection and

--- a/test/closed_form_ode_tests.jl
+++ b/test/closed_form_ode_tests.jl
@@ -233,6 +233,28 @@ end
     )
 end
 
+# Symbolics' term caches are process-wide and not thread-safe: racing detection used to
+# return a corrupted plan (wrong `mode`/`cf_states`), which under `:auto` can silently
+# solve a coupled system as decoupled scalars. Reproduced on every unpatched run at 4
+# threads; the plan is a pure function of the model, so every draw must match.
+@testset "closed-form detection is thread-safe" begin
+    if Threads.nthreads() < 2
+        @info "skipped: needs Threads.nthreads() > 1"
+    else
+        m = _cf_diag2_model(:auto)
+        ref = NoLimits._detect_closed_form(m)
+        plans = Vector{Any}(undef, 400)
+        Threads.@threads for i in eachindex(plans)
+            plans[i] = NoLimits._detect_closed_form(m)
+        end
+        @test all(
+            p -> p.mode === ref.mode && p.eligible == ref.eligible &&
+                p.n == ref.n && p.cf_states == ref.cf_states,
+            plans
+        )
+    end
+end
+
 @testset "closed_form = :diagonal errors on ineligible model" begin
     mnl = set_solver_config(
         (


### PR DESCRIPTION
`_detect_closed_form` drives `Symbolics.derivative` / `expand_derivatives`, whose SymbolicUtils term caches are process-wide and not thread-safe. When several `DataModel`s trigger detection concurrently — `fit_cv(...; fold_serialization=EnsembleThreads())`, or a user's own `Threads.@threads` over `simulate_data` / `fit_model` — two threads race on the same shared cache.

**The crash is the lucky outcome.** `ConcurrencyViolationError("Vector can not be resized concurrently")` and `UndefRefError` both reproduce, but the common result is a silently corrupted `ClosedFormPlan`. Stressed at 4 and 12 threads:

```
WRONG PLAN: got (diagonal,true,4,[1])   want (linear,true,4,[1,2,3,4])
WRONG PLAN: got (linear,true,4,[1,2])   want (linear,true,4,[1,2,3,4])
WRONG PLAN: got (none,false,0,[])       want (linear,true,4,[1,2,3,4])
```

Most misdetections degrade to `:none` or to a non-whole plan, which `closed_form=:auto` gates out — safe, just slower. But the corruption is symmetric: a coupled depot/central model whose true plan is `:none` returned a whole-system `(diagonal,true,2,[1,2])`. Whole-system `:diagonal` **passes** the `:auto` gate, so that one solves a coupled system as two decoupled scalars and returns wrong likelihoods with no error at all.

## Fix

Serialize the function behind a `ReentrantLock`, as a one-line wrapper over an unchanged `_detect_closed_form_impl`. Every `Symbolics` call reachable at runtime (`variable`, `@variables`, `derivative`, `substitute`, `expand`, `get_variables`, via `_cf_to_sym` / `_cf_is_zero` / `_cf_depends_on` / `_cf_fresh`) sits under `_detect_closed_form`, so this one lock covers the whole exposure.

Cost is nil: detection runs once per `DataModel` behind the `get_closed_form_plan` cache and takes 0.25 ms for a 4-state coupled system, so a 20-fold threaded `fit_cv` serializes ~10 ms against fits measured in seconds. The fitting and quadrature that follow stay fully parallel, and the cached path stays lock-free. Nothing inside the critical section yields, spawns, or takes another lock.

## Verification

- Regression test: 400 concurrent detections of the existing `_cf_diag2_model` fixture must all match the single-threaded reference. Fails on **every** unpatched run at `JULIA_NUM_THREADS=4` (22–382 of 400 wrong); passes clean with the lock. ~0.5 s, no new `@Model`.
- 1200 concurrent detections across 3 stress runs at 12 threads: 0 wrong, 0 errors.
- `closed_form_ode_tests.jl` + `closed_form_ode2_tests.jl` at 4 threads: 57/57 pass.
- Aqua: 9/9. Runic (pinned v1): clean.
