### PR TITLE
fix: apply the NormalizingPlanarFlow rewrite in @formulas

### DIFF
--- a/docs/src/model-building/formulas.md
+++ b/docs/src/model-building/formulas.md
@@ -40,6 +40,14 @@ Expressions inside `@formulas` can reference symbols drawn from several model na
 
 If a symbol name is shared across more than one namespace among fixed effects, random effects, preDE outputs, and covariates, the macro raises an ambiguity error to prevent silent resolution conflicts.
 
+`NormalizingPlanarFlow(ψ)` is also accepted as an outcome distribution, with `ψ` an `NPFParameter` fixed effect. The flow is multivariate, so the observation column holds vectors, `[y]` cells even for a one-dimensional flow, and no `η[1]`-style indexing is needed. See [Flows as Outcome Distributions](random-effects.md#flows-as-outcome-distributions).
+
+```julia
+@formulas begin
+    z ~ NormalizingPlanarFlow(ψ)
+end
+```
+
 ## State and Signal Access from ODE Models
 
 When the model includes a differential equation system, ODE states and derived signals can be referenced in formulas subject to the following rules:

--- a/docs/src/model-building/random-effects.md
+++ b/docs/src/model-building/random-effects.md
@@ -173,6 +173,20 @@ model_t = @Model begin
 end
 ```
 
+### Flows as Outcome Distributions
+
+The same `NormalizingPlanarFlow(ψ)` spelling is also allowed as an outcome distribution in `@formulas`. A flow is always multivariate, so the observation column must hold vectors, `[y]` cells even for a one-dimensional flow, and outcomes are matched by name without any `η[1]`-style indexing.
+
+```julia
+@fixedEffects begin
+    ψ = NPFParameter(2, 3; seed=1, calculate_se=false)
+end
+
+@formulas begin
+    z ~ NormalizingPlanarFlow(ψ)
+end
+```
+
 ## Metadata and Builder Accessors
 
 The parsed random-effects object exposes accessor functions for its components. The most commonly used are:

--- a/src/model/Formulas.jl
+++ b/src/model/Formulas.jl
@@ -742,10 +742,19 @@ state/signal accessors. State and signal names must be called with a time argume
 Dynamic covariates used without an explicit `(t)` call are evaluated implicitly at the
 current time `t`.
 
+As in `@randomEffects`, `NormalizingPlanarFlow(ψ)` is rewritten to the generated
+`NPF_ψ(ψ)` model function, so a flow can be used directly as an outcome distribution.
+The flow is multivariate, so the observation column must hold vectors.
+
 The `@formulas` block is required in every `@Model`.
 """
 macro formulas(block)
     det_names, det_exprs, obs_names, obs_exprs, line_exprs = _parse_formulas(block)
+    # `NormalizingPlanarFlow(ψ)` is sugar for the generated `NPF_ψ(ψ)` model function,
+    # in @formulas as well as in @randomEffects (#288). `line_exprs` keeps the original
+    # spelling for display.
+    det_exprs = _rewrite_npf_calls.(det_exprs)
+    obs_exprs = _rewrite_npf_calls.(obs_exprs)
     all_exprs = vcat(det_exprs, obs_exprs)
     det_set = Set(det_names)
 

--- a/src/model/MacroUtils.jl
+++ b/src/model/MacroUtils.jl
@@ -124,3 +124,18 @@ function _macro_forbidden_symbol(ex)
     end
     return nothing
 end
+
+# Convenience rewrite shared by @randomEffects and @formulas: `NormalizingPlanarFlow(ψ)`
+# becomes a call to the generated `NPF_ψ(ψ)` model function registered from the
+# corresponding `NPFParameter`. Only the exact one-argument call on a bare symbol is
+# rewritten; every other spelling is left untouched.
+function _rewrite_npf_calls(ex)
+    ex isa Expr || return ex
+    if ex.head == :call && ex.args[1] == :NormalizingPlanarFlow && length(ex.args) == 2
+        arg = ex.args[2]
+        if arg isa Symbol
+            return Expr(:call, Symbol("NPF_", arg), arg)
+        end
+    end
+    return Expr(ex.head, map(_rewrite_npf_calls, ex.args)...)
+end

--- a/src/model/RandomEffects.jl
+++ b/src/model/RandomEffects.jl
@@ -288,17 +288,6 @@ function _dist_type_symbol(dist_expr)
     return :unknown
 end
 
-function _rewrite_npf_calls(ex)
-    ex isa Expr || return ex
-    if ex.head == :call && ex.args[1] == :NormalizingPlanarFlow && length(ex.args) == 2
-        arg = ex.args[2]
-        if arg isa Symbol
-            return Expr(:call, Symbol("NPF_", arg), arg)
-        end
-    end
-    return Expr(ex.head, map(_rewrite_npf_calls, ex.args)...)
-end
-
 """
     @randomEffects begin
         name = RandomEffect(dist; column=:GroupCol)

--- a/src/model/Validation.jl
+++ b/src/model/Validation.jl
@@ -241,8 +241,13 @@ function _validate_model_symbols(
     unknown = _nl_unknown_syms(
         vcat(ir.det_exprs, ir.obs_exprs), known, context_module
     )
-    isempty(unknown) ||
-        error("@formulas references undefined symbol(s) $(join(string.(unknown), ", ")). They are not a fixed effect, random effect, pre-DE variable, covariate, helper, model function or DE state/signal.")
+    if !isempty(unknown)
+        # `NPF_x` can only come from the `NormalizingPlanarFlow(x)` rewrite -- point back
+        # at the spelling the user actually wrote.
+        npf_hint = any(startswith(string(s), "NPF_") for s in unknown) ?
+            " `NormalizingPlanarFlow(x)` requires `x` to be an `NPFParameter` in @fixedEffects." : ""
+        error("@formulas references undefined symbol(s) $(join(string.(unknown), ", ")). They are not a fixed effect, random effect, pre-DE variable, covariate, helper, model function or DE state/signal.$(npf_hint)")
+    end
 
     # Varying covariates in an RE distribution are rejected later, by DataModel, with a
     # message about `constant_on` -- do not pre-empt it here.

--- a/test/formulas_tests.jl
+++ b/test/formulas_tests.jl
@@ -2,6 +2,7 @@ using Test
 using NoLimits
 using ComponentArrays
 using Distributions
+import DataFrames
 
 struct FakeSol end
 
@@ -510,4 +511,50 @@ end
     @test_throws ErrorException ConstantCovariate(:x; constant_on = "ID")
     @test_throws ErrorException CovariateVector(Symbol[])
     @test_throws ErrorException ConstantCovariateVector(Symbol[])
+end
+
+@testset "Formulas NormalizingPlanarFlow outcome" begin
+    # `NormalizingPlanarFlow(ψ)` must be rewritten to the generated `NPF_ψ(ψ)` model
+    # function in @formulas too, not only in @randomEffects (#288).
+    model = @Model begin
+        @fixedEffects begin
+            phi = NPFParameter(2, 3; seed = 7, calculate_se = false)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @formulas begin
+            z ~ NormalizingPlanarFlow(phi)
+        end
+    end
+    ir = get_formulas_ir(get_formulas(model))
+    @test ir.obs_exprs[1] == :(NPF_phi(phi))
+
+    df = DataFrames.DataFrame(
+        ID = [1, 1], t = [0.0, 1.0], z = [[0.1, -0.2], [0.3, 0.05]]
+    )
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+    θ = NoLimits.get_params(dm; scale = :untransformed)
+    ll = complete_data_loglikelihood(dm, θ; eta = :mean)
+
+    flow = get_model_funs(model).NPF_phi(θ.phi)
+    @test isapprox(ll, sum(logpdf(flow, y) for y in df.z))
+
+    # A flow call on a non-NPF fixed effect fails at model build with a clear message.
+    @test_throws ErrorException Core.eval(
+        @__MODULE__, Expr(
+            :macrocall, Symbol("@Model"), LineNumberNode(0),
+            quote
+                @fixedEffects begin
+                    mu = RealNumber(1.0)
+                end
+                @covariates begin
+                    t = Covariate()
+                end
+                @formulas begin
+                    z ~ NormalizingPlanarFlow(mu)
+                end
+            end
+        )
+    )
 end


### PR DESCRIPTION
## Summary
`NormalizingPlanarFlow(ψ)` now works as an outcome distribution in `@formulas`, the same spelling that already worked in `@randomEffects`.

## Root cause
`_rewrite_npf_calls` (`NormalizingPlanarFlow(ψ)` -> `NPF_ψ(ψ)`) was invoked only by the `@randomEffects` macro. `@formulas` left the literal call in the generated code, so the model built fine and then threw `MethodError: no method matching NormalizingPlanarFlow(::SubArray...)` on the first likelihood evaluation.

## Fix
- Moved `_rewrite_npf_calls` to `src/model/MacroUtils.jl` (shared macro helpers) and applied it to the deterministic and observation expressions in `@formulas`. Display lines keep the original spelling.
- `@formulas` docstring and the `formulas.md` / `random-effects.md` docs now cover flows as outcome distributions (vector-valued observation column).
- An unknown `NPF_x` symbol at model build time now names the `NormalizingPlanarFlow(x)`/`NPFParameter` requirement.

## Test
New testset in `test/formulas_tests.jl`: the flow-outcome model builds, its IR carries the rewritten `NPF_phi(phi)` call, `complete_data_loglikelihood` equals `sum(logpdf(flow, y))` from the generated model function, and a flow call on a non-NPF fixed effect errors at build time. Fails before the fix (2 failures), passes after.

Ran `NL_TEST_FILES="formulas_tests.jl,model_macro_tests.jl,random_effects_tests.jl,ad_random_effects.jl,equation_display_tests.jl,aqua_tests.jl"`: all batches passed.

Fixes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)