### PR TITLE
fix: apply ODE events at their recorded time and validate formula times against the real integration start

### DIFF
--- a/src/data_model/DataModel.jl
+++ b/src/data_model/DataModel.jl
@@ -1127,7 +1127,10 @@ function _build_obs(df, rows, obs_rows, obs_cols)
     return NamedTuple(pairs)
 end
 
-function _build_callbacks(model, df, rows, config::DataModelConfig)
+# `t0` is the individual's actual integration start (see the `tspan` construction in
+# `_data_model`): only events recorded exactly there are folded into u0 / the initial
+# infusion rates, every later event becomes a PresetTimeCallback at its own time.
+function _build_callbacks(model, df, rows, config::DataModelConfig, t0)
     config.evid_col === nothing && return nothing
     model.de.de === nothing && return nothing
     evid = _get_col(df, config.evid_col)[rows]
@@ -1147,7 +1150,6 @@ function _build_callbacks(model, df, rows, config::DataModelConfig)
     bolus_by_time = Dict{Tt, Vector{Float64}}()
     reset_by_time = Dict{Tt, Vector{Tuple{Int, Float64}}}()
     rate_delta_by_time = Dict{Tt, Vector{Float64}}()
-    t0 = minimum(_get_col(df, config.time_col)[rows])
     init_bolus = zeros(Float64, n_states)
     init_resets = Tuple{Int, Float64}[]
     init_rate_starts = zeros(Float64, n_states)
@@ -1609,7 +1611,7 @@ function DataModel(
     obs_groups = Vector{Vector{Int}}(undef, length(groups))
 
     bad_ids = Any[]
-    bad_tmin = Dict{Any, Float64}()
+    bad_tmin = Dict{Any, Tuple{Float64, Float64}}()
     for (i, rows) in enumerate(groups)
         tvals = _get_col(df, time_col)[rows]
         _validate_dynamic_covariates(cov, rows, tvals, keys_sorted[i])
@@ -1625,26 +1627,29 @@ function DataModel(
         dyn = _build_dyn_cov(cov, df, rows, time_col)
         series = IndividualSeries(obs, vary, dyn)
         const_cov = _build_const_cov(cov, df, rows)
-        callbacks = _build_callbacks(model, df, rows, config)
         # Integration start defaults to `t0` (0.0) so the initial conditions are applied
         # at t = 0 even when the first observation is later; `t0 = nothing` recovers the
         # legacy behaviour of starting at the first data time. The lower bound is never
         # raised above the data (extended down to `t0`, not truncated).
+        lo = minimum(tvals)
+        start = t0 === nothing ? lo : min(oftype(lo, t0), lo)
         if isempty(time_offsets)
-            lo = minimum(tvals)
-            tspan = (t0 === nothing ? lo : min(oftype(lo, t0), lo), maximum(tvals))
+            tspan = (start, maximum(tvals))
         else
             extra_min = minimum(time_offsets)
             extra_max = maximum(time_offsets)
             tmin = minimum(tvals) + extra_min
             tmax = maximum(tvals) + extra_max
-            if tmin < 0
+            # Only a formula time before the actual integration start is invalid; a
+            # negative time is fine when the solve starts at or below it.
+            if tmin < start
                 id_val = keys_sorted[i]
                 push!(bad_ids, id_val)
-                bad_tmin[id_val] = tmin
+                bad_tmin[id_val] = (tmin, float(start))
             end
-            tspan = (t0 === nothing ? tmin : min(oftype(tmin, t0), tmin), tmax)
+            tspan = (oftype(tmin, start), tmax)
         end
+        callbacks = _build_callbacks(model, df, rows, config, tspan[1])
         if !isempty(de_dyn) && tspan[1] < minimum(tvals)
             error("Formulas request times earlier than the dynamic covariate support for individual $(keys_sorted[i]): the integration span starts at t=$(tspan[1]) (smallest formula time offset $(off_min)), but the dynamic covariate(s) $(join(de_dyn, ", ")) used in @DifferentialEquation are only supported on [$(minimum(tvals)), $(maximum(tvals))] and cannot be extrapolated. Add covariate rows covering t=$(tspan[1]), or change the formula offset (or t0) so that the integration starts at or after $(minimum(tvals)).")
         end
@@ -1655,8 +1660,8 @@ function DataModel(
     end
 
     if !isempty(bad_ids)
-        details = join(["$(id) => $(bad_tmin[id])" for id in bad_ids], ", ")
-        error("Formulas request times earlier than the first observation for individual ids: $(details). This would require to calculate the value of the ODE solution prior to the initial conditions (at t=0). Change the offset in your model or remove the corresponding data points that are observed at t_k for which t_k - offset < 0.")
+        details = join(["$(id) => $(bad_tmin[id][1]) (start t=$(bad_tmin[id][2]))" for id in bad_ids], ", ")
+        error("Formulas request times earlier than the start of the integration for individual ids: $(details). This would require to calculate the value of the ODE solution prior to the initial conditions. Change the offset in your model, pass an earlier t0, or remove the corresponding data points that are observed at t_k for which t_k - offset is before the integration start.")
     end
 
     # Narrow the element type (individuals of a homogeneous dataset share one concrete

--- a/test/data_model_ode_tests.jl
+++ b/test/data_model_ode_tests.jl
@@ -89,6 +89,20 @@ end
         loglik += logpdf(obs.y, y)
     end
     @test isfinite(loglik)
+
+    # Negative observation times are legitimate (#287): the integration starts at `t0`
+    # when it is given and at the individual's first time when it is `nothing`.
+    df_neg = DataFrame(ID = [1, 1, 1], t = [-6.0, -4.0, -2.0], y = [1.0, 0.9, 0.8])
+    for (t0_val, start) in ((nothing, -6.0), (-10.0, -10.0))
+        dm_neg = DataModel(
+            model_saveat, df_neg; primary_id = :ID, time_col = :t, t0 = t0_val
+        )
+        @test get_individual(dm_neg, 1).tspan == (start, -2.0)
+        mu = [exp(-0.2 * (tt - start)) for tt in df_neg.t]
+        ll_ref = sum(logpdf.(Normal.(mu, 0.5), df_neg.y))
+        ll_neg = NoLimits.loglikelihood(dm_neg, θ, ComponentArray())
+        @test isapprox(ll_neg, ll_ref; rtol = 1.0e-5)
+    end
 end
 
 @testset "DataModel ODE logpdf with time offsets" begin

--- a/test/data_model_tests.jl
+++ b/test/data_model_tests.jl
@@ -1277,6 +1277,18 @@ end
 
     model_saveat = set_solver_config(model; saveat_mode = :saveat)
     @test_throws ErrorException DataModel(model_saveat, df; primary_id = :ID, time_col = :t)
+
+    # The guard compares against the actual integration start, not the literal t=0
+    # (#287): a lag below the individual's first time still errors at negative times.
+    df_neg = DataFrame(ID = [1, 1], t = [-6.0, -4.0], y = [1.0, 1.1])
+    @test_throws ErrorException DataModel(
+        model_saveat, df_neg; primary_id = :ID, time_col = :t, t0 = nothing
+    )
+    # ... while an explicit t0 below the lagged time makes the same model valid.
+    dm_ok = DataModel(
+        model_saveat, df_neg; primary_id = :ID, time_col = :t, t0 = -10.0
+    )
+    @test get_individual(dm_ok, 1).tspan[1] == -10.0
 end
 
 @testset "DataModel errors on offsets below dynamic covariate support" begin

--- a/test/ode_callbacks_tests.jl
+++ b/test/ode_callbacks_tests.jl
@@ -459,3 +459,103 @@ end
     # than t=1 and later than t=0 (i.e. t=1 IS the first interior grid point).
     @test minimum(filter(t -> t > 0.0, grid)) ≤ 1.0
 end
+
+@testset "ODE callbacks: dose at a first row later than t0 (#285)" begin
+    model = @Model begin
+        @covariates begin
+            t = Covariate()
+        end
+
+        @fixedEffects begin
+            k = RealNumber(0.2)
+            σ = RealNumber(0.01)
+        end
+
+        @DifferentialEquation begin
+            D(x1) ~ -k * x1
+        end
+
+        @initialDE begin
+            x1 = 0.0
+        end
+
+        @formulas begin
+            y ~ Normal(x1(t), σ)
+        end
+    end
+
+    kk = 0.2
+
+    function _dm(df; kwargs...)
+        return DataModel(
+            model, df; primary_id = :ID, time_col = :t, evid_col = :EVID,
+            amt_col = :AMT, rate_col = :RATE, cmt_col = :CMT, kwargs...
+        )
+    end
+    _fitted(dm) = get_residuals(
+        dm; params = NamedTuple(NoLimits.get_params(dm; scale = :untransformed))
+    ).fitted
+
+    @testset "Bolus" begin
+        df = DataFrame(
+            ID = [1, 1, 1, 1],
+            t = [10.0, 11.0, 13.0, 16.0],
+            EVID = [1, 0, 0, 0],
+            AMT = [100.0, 0.0, 0.0, 0.0],
+            RATE = [0.0, 0.0, 0.0, 0.0],
+            CMT = [1, 1, 1, 1],
+            y = [missing, 1.0, 1.0, 1.0]
+        )
+        dm = _dm(df)
+        ind = get_individual(dm, 1)
+        # Integration starts at t0 = 0, so the dose is a mid-solve event, not part of u0.
+        @test ind.tspan == (0.0, 16.0)
+        @test 10.0 in ind.callbacks.all_times
+        @test ind.callbacks.init_bolus === nothing
+        expected = [100.0 * exp(-kk * (tt - 10.0)) for tt in (11.0, 13.0, 16.0)]
+        @test isapprox(_fitted(dm), expected; rtol = 1.0e-5)
+        # `t0 = nothing` starts at the dose row, which then folds into u0.
+        dm_n = _dm(df; t0 = nothing)
+        @test get_individual(dm_n, 1).callbacks.init_bolus == [(1, 100.0)]
+        @test isapprox(_fitted(dm_n), expected; rtol = 1.0e-5)
+    end
+
+    @testset "Infusion" begin
+        # RATE = 50, AMT = 100 => infusion runs on [2, 4].
+        df = DataFrame(
+            ID = [1, 1, 1],
+            t = [2.0, 3.0, 4.0],
+            EVID = [1, 0, 0],
+            AMT = [100.0, 0.0, 0.0],
+            RATE = [50.0, 0.0, 0.0],
+            CMT = [1, 1, 1],
+            y = [missing, 1.0, 1.0]
+        )
+        dm = _dm(df)
+        ind = get_individual(dm, 1)
+        @test ind.tspan == (0.0, 4.0)
+        @test 2.0 in ind.callbacks.all_times
+        @test 4.0 in ind.callbacks.all_times
+        @test all(iszero, ind.callbacks.init_infusion_rates)
+        expected = [50.0 / kk * (1 - exp(-kk * (tt - 2.0))) for tt in (3.0, 4.0)]
+        @test isapprox(_fitted(dm), expected; rtol = 1.0e-5)
+    end
+
+    @testset "Individuals starting at different times" begin
+        df = DataFrame(
+            ID = [1, 1, 1, 2, 2, 2],
+            t = [0.0, 1.0, 3.0, 5.0, 6.0, 8.0],
+            EVID = [1, 0, 0, 1, 0, 0],
+            AMT = [100.0, 0.0, 0.0, 100.0, 0.0, 0.0],
+            RATE = zeros(6),
+            CMT = fill(1, 6),
+            y = [missing, 1.0, 1.0, missing, 1.0, 1.0]
+        )
+        expected = [
+            100.0 * exp(-kk * 1.0), 100.0 * exp(-kk * 3.0),
+            100.0 * exp(-kk * 1.0), 100.0 * exp(-kk * 3.0),
+        ]
+        @test isapprox(_fitted(_dm(df)), expected; rtol = 1.0e-5)
+        @test isapprox(_fitted(_dm(df; t0 = nothing)), expected; rtol = 1.0e-5)
+    end
+end


### PR DESCRIPTION
## Summary

Both issues live in the ODE time handling of `src/data_model/DataModel.jl` and share a
single notion of "where does this individual's integration actually start": `t0` when it
is given, the individual's first row time when `t0 === nothing` (never above the data).

That start is now computed once per individual, before the callbacks are built, and used
for the event classification, the formula-offset validation and the `tspan`.

## Root cause

- **#285** `_build_callbacks` recomputed a local `t0 = minimum(times of this individual)`,
  shadowing the DataModel-level integration start. An event on the individual's first row
  was therefore always treated as an "initial" event and folded into `u0` / the initial
  infusion rates by `_apply_initial_events!`, which is applied at the real solve start. A
  bolus at `t = 10` with the default `t0 = 0.0` fired at `t = 0`, scaling every downstream
  value by `exp(-k*10)`; an infusion turned on at the solve start rather than its own time.
  Events are now folded into `u0` only when their time equals the integration start, and
  otherwise become a `PresetTimeCallback` at their recorded time. No event can precede the
  start (the start is never above the individual's first row), so no new error path is
  needed. The closed-form linear path (`_cf_build_segments`) reads the same
  `EventCallbacks` with `t0f = tspan[1]` and stays consistent automatically.

- **#287** The offsets branch guarded with `tmin < 0`, comparing the earliest requested
  state time against the literal `0` rather than the integration start. Since every plain
  `x1(t)` reference registers a `0.0` offset, that branch is taken by essentially every
  ODE model, so all negative observation times were rejected even with `t0 = nothing` or an
  explicit negative `t0`. The guard now compares against the actual start, so a genuine lag
  (`x1(t - 5)` at the first observation) still errors while negative times build and
  evaluate. The error message names the actual start instead of a hard-coded `t=0`.

## Tests

- `test/ode_callbacks_tests.jl`: new testset for a dose on an individual's first row later
  than `t0` (bolus and infusion checked against the analytic one-compartment solution, with
  and without `t0 = nothing`), plus a two-individual case whose subjects start at different
  times.
- `test/data_model_ode_tests.jl`: negative observation times with `t0 = nothing` and an
  explicit negative `t0` build with the right `tspan` and reproduce the analytic
  loglikelihood.
- `test/data_model_tests.jl`: a lag below the integration start still errors at negative
  times, while an early explicit `t0` makes the same model valid.

All of these fail on `main` (7 failed, 2 errored) and pass with the fix.

Run through `Pkg.test()`: `ode_callbacks_tests.jl`, `data_model_ode_tests.jl`,
`data_model_tests.jl`, `closed_form_ode_tests.jl`, `closed_form_ode2_tests.jl`,
`data_simulation_tests.jl`, `estimation_cv_tests.jl`, `aqua_tests.jl` - all green.

Fixes #285
Fixes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)
