### PR TITLE
fix: random-effect post-processing at non-primary levels, log-scale standardization, pairplot labels

### DIFF
--- a/ext/plotting/plotting_random_effects.jl
+++ b/ext/plotting/plotting_random_effects.jl
@@ -523,7 +523,8 @@ function plot_random_effect_pairplot(
                 if length(cols) == 1
                     push!(labels, Symbol(string(r)))
                 else
-                    push!(labels, Symbol(string(r), "_", c))
+                    # `c` already carries the RE-name prefix (flatten_re_names).
+                    push!(labels, Symbol(c))
                 end
             end
         end

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -1744,29 +1744,58 @@ end
 
     get_random_effects(dm::DataModel, res::FitResult, re::Symbol; kwargs...) -> Vector
 
-Return the empirical Bayes estimates for a single random effect `re` as a plain vector,
-ordered by individual index in `dm`.
+Return the empirical Bayes estimates for a single random effect `re` as a plain vector.
+For an effect grouped at the primary id the vector is ordered by individual index in
+`dm`; for an effect grouped at any other level (e.g. `:SITE`) it holds one value per
+level of that grouping column, in level order.
 """
 function get_random_effects(
         dm::DataModel, res::FitResult, re::Symbol;
         constants_re::Union{NamedTuple, AbstractDict} = NamedTuple(),
         include_constants::Bool = true
     )
-    constants_re = _as_namedtuple(constants_re)
+    group_col, levels, vals = _re_level_values(
+        dm, res, re; constants_re = _as_namedtuple(constants_re),
+        include_constants = include_constants
+    )
+    group_col == get_primary_id(dm) || return vals
+    id_order = [_individual_id(dm, i) for i in 1:length(get_individuals(dm))]
+    id_to_val = Dict(levels[i] => vals[i] for i in eachindex(levels))
+    return [id_to_val[id] for id in id_order]
+end
+
+# Per-level EBEs of a scalar random effect at its OWN grouping level.
+# Returns (grouping column, level values, EBE values).
+function _re_level_values(
+        dm::DataModel, res::FitResult, re::Symbol;
+        constants_re::NamedTuple = NamedTuple(),
+        include_constants::Bool = true
+    )
     nt = get_random_effects(
         dm, res; constants_re = constants_re, flatten = true,
         include_constants = include_constants
     )
     haskey(nt, re) || error("Random effect :$(re) not found. Available: $(keys(nt)).")
     df = getfield(nt, re)
-    id_col = get_primary_id(dm)
-    val_cols = [c for c in propertynames(df) if c != id_col]
+    group_col = getfield(get_re_groups(get_random(get_model(dm))), re)
+    val_cols = [c for c in propertynames(df) if c != group_col]
     length(val_cols) == 1 ||
         error("Random effect :$(re) is multivariate ($(length(val_cols)) components); use get_random_effects(res) to access the full DataFrame.")
-    val_col = val_cols[1]
-    id_order = [_individual_id(dm, i) for i in 1:length(get_individuals(dm))]
-    id_to_val = Dict(row[id_col] => row[val_col] for row in eachrow(df))
-    return [id_to_val[id] for id in id_order]
+    return group_col, df[!, group_col], df[!, val_cols[1]]
+end
+
+# First individual carrying each level of random effect `re` (fallback: individual 1).
+# Used to instantiate covariate-dependent RE distributions at non-primary levels.
+function _re_level_representatives(dm::DataModel, re::Symbol, levels)
+    inds = get_individuals(dm)
+    pos = Dict{Any, Int}()
+    for i in eachindex(inds)
+        g = getfield(get_re_groups(inds[i]), re)
+        for lvl in (g isa AbstractVector ? g : (g,))
+            get!(pos, lvl, i)
+        end
+    end
+    return [get(pos, lvl, 1) for lvl in levels]
 end
 
 function get_random_effects(
@@ -4458,20 +4487,23 @@ function compute_shrinkage(
 
     pairs = Pair{Symbol, NamedTuple}[]
     for re in re_names
-        # get_random_effects(res, re) returns a vector ordered by individual index
-        ebes = try
-            get_random_effects(dm_use, res, re; constants_re = constants_re)
-        catch
+        # EBEs at the random effect's own grouping level (one value per level).
+        levels, ebes = try
+            _, lv, vals = _re_level_values(dm_use, res, re; constants_re = constants_re)
+            (lv, vals)
+        catch e
+            @warn "compute_shrinkage: skipping random effect $re; $(sprint(showerror, e))"
             continue
         end
-        length(ebes) == length(get_individuals(dm_use)) || continue
+        isempty(levels) && continue
+        reps = _re_level_representatives(dm_use, re, levels)
 
         etas = Float64[]
         sigma = NaN
         valid = true
 
-        for i in eachindex(get_individuals(dm_use))
-            ind = get_individuals(dm_use)[i]
+        for i in eachindex(levels)
+            ind = get_individuals(dm_use)[reps[i]]
             ebe = Float64(ebes[i])
             isfinite(ebe) || continue
 

--- a/src/plotting/plotting_random_effects.jl
+++ b/src/plotting/plotting_random_effects.jl
@@ -181,6 +181,17 @@ function _standardize_re(dist, val::Vector{Float64}; flow_samples::Int = 500)
             return L \ (val .- μv)
         end
     end
+    # Univariate log/logit-scale families: standardize on the transformed scale, matching
+    # the MvLogNormal/MvLogitNormal branches below and compute_shrinkage's convention.
+    if dist isa Distributions.LogNormal
+        dist.σ > 0 || return nothing
+        return [(log(max(val[1], 1.0e-300)) - dist.μ) / dist.σ]
+    end
+    if dist isa Distributions.LogitNormal
+        dist.σ > 0 || return nothing
+        p = clamp(val[1], 1.0e-300, 1 - eps(Float64))
+        return [(log(p / (1 - p)) - dist.μ) / dist.σ]
+    end
     if dist isa Distributions.MvLogNormal
         z = log.(max.(val, 1.0e-300))
         μ = try

--- a/test/accessors_tests.jl
+++ b/test/accessors_tests.jl
@@ -113,3 +113,26 @@ end
     @test usage_fx.η == [:Age]
     @test get_re_covariate_usage(fx_recov_laplace()) == usage_fx
 end
+
+@testset "Shrinkage covers non-primary RE levels (#291)" begin
+    res = fx_mg_laplace()
+    dm = fx_mg_dm()
+
+    # η_site is grouped at :SITE, not the primary id; the single-RE accessor must
+    # return one value per SITE level instead of erroring.
+    site_ebes = NL.get_random_effects(dm, res, :η_site)
+    @test length(site_ebes) == 2
+    @test site_ebes == NL.get_random_effects(res).η_site[!, :η_site_1]
+
+    sh = NL.compute_shrinkage(res)
+    @test haskey(sh, :η_id)
+    @test haskey(sh, :η_site)
+
+    # ω = 1 for both REs in fx_mg_model, so shrinkage = 1 - sd(EBEs).
+    z = Float64.(site_ebes)
+    m = sum(z) / length(z)
+    sd = sqrt(sum(abs2, z .- m) / (length(z) - 1))
+    @test sh.η_site.sigma ≈ 1.0
+    @test sh.η_site.eta_std ≈ sd
+    @test sh.η_site.shrinkage ≈ 1.0 - sd
+end

--- a/test/plot_random_effects2_tests.jl
+++ b/test/plot_random_effects2_tests.jl
@@ -122,6 +122,21 @@ end
 
     # Mahalanobis standardization / scatter / pairplot need multivariate REs
     @test plot_random_effect_standardized_scatter(res) !== nothing
-    @test plot_random_effect_pairplot(res) !== nothing
     @test plot_random_effects_scatter(res) !== nothing
+
+    # Component labels must not be double-prefixed (#293): η_1, not η_η_1.
+    fig = plot_random_effect_pairplot(res)
+    @test fig !== nothing
+    titles = unique(
+        [ax.title[] for ax in fig.content if ax isa Axis && !isempty(ax.title[])]
+    )
+    @test sort(titles) == ["η_1", "η_2"]
+end
+
+@testset "Univariate log/logit RE standardization (#292)" begin
+    d = LogNormal(0.2, 0.3)
+    @test NoLimits._standardize_re(d, [1.5])[1] ≈ (log(1.5) - d.μ) / d.σ
+
+    dl = LogitNormal(0.1, 0.4)
+    @test NoLimits._standardize_re(dl, [0.6])[1] ≈ (log(0.6 / 0.4) - dl.μ) / dl.σ
 end


### PR DESCRIPTION
Three related random-effect post-processing bugs, fixed together.

## Root causes

**#291** `get_random_effects(dm, res, re)` hardcoded `id_col = get_primary_id(dm)` when
splitting the per-RE DataFrame into group/value columns. For a RE grouped at another
level (e.g. `:SITE`), the grouping column was counted as a value column, so a scalar RE
looked multivariate and the accessor threw. `compute_shrinkage` swallowed that error in
a bare `try/catch ... continue` and additionally required one EBE per individual, so the
RE disappeared from the result with no warning.

Now a shared helper `_re_level_values` resolves the RE's own grouping column;
`compute_shrinkage` works on per-level EBEs (one value per level), instantiating
covariate-dependent RE distributions from the first individual at each level, and warns
with the exception message instead of swallowing it. `plot_shrinkage` needs no change,
it just gets more entries.

**#292** `_standardize_re` had no univariate `LogNormal` branch, so it fell through to
the generic `mean`/`var` tail and produced natural-scale z-scores, disagreeing with both
its own `MvLogNormal` branch and `compute_shrinkage`'s documented `log` convention. Added
`LogNormal` (log scale) and, for consistency with `MvLogitNormal`, `LogitNormal` (logit
scale). `plot_random_effect_pit` uses `cdf` on the natural scale and stays correct.

**#293** `plot_random_effect_pairplot` built labels as `Symbol(string(r), "_", c)` while
`c` already came fully prefixed from `flatten_re_names`, yielding `η_η_1`. Now `Symbol(c)`.
This was the only occurrence of the pattern.

## Tests

- `test/accessors_tests.jl`: new testset on the existing `fx_mg_laplace` two-level fixture
  asserting the `:SITE` accessor returns per-level values and that `compute_shrinkage`
  contains both REs, with the SITE value matching the hand formula.
- `test/plot_random_effects2_tests.jl`: pairplot axis titles asserted in the existing
  multivariate testset; new unit testset for LogNormal/LogitNormal standardization.

All three issue repro scripts verified failing before and correct after.

Fixes #291
Fixes #292
Fixes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)
