### PR TITLE
fix: use mode-centered AGHQ for all ℝ-supported random effects

### DIFF
--- a/src/estimation/ghquadrature.jl
+++ b/src/estimation/ghquadrature.jl
@@ -260,10 +260,10 @@ the estimate oscillate and drift *away* from the true integral as the level rise
 regularly turning the batch marginal negative (issue #98). Centered on the mode it
 converges at level 1-3.
 
-Returns `nothing` (keep the prior-centered measure) when the batch is not purely
-Gaussian — `CenteredREMeasure` places nodes anywhere in ℝ^n_b, which only stays
-inside the random-effect support when every RE in the batch is `Normal`/`MvNormal`
-— or when the mode/curvature is unavailable.
+Returns `nothing` (keep the prior-centered measure) when some RE in the batch has
+bounded support — `CenteredREMeasure` places nodes anywhere in ℝ^n_b, which only
+stays inside the random-effect support when every RE in the batch is supported on
+all of ℝ — or when the mode/curvature is unavailable.
 """
 function _ghq_adaptive_measure(
         dm::DataModel, info::REBatchInfo,

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -385,13 +385,15 @@ function _re_start_value(dist, dim::Int, T)
         ok = false
         try
             v = _re_mean(dist)
-            ok = true
+            # Cauchy and TDist(ν<=1) have a NaN mean; a NaN start poisons the whole
+            # mode search, so treat it as unusable and fall through to the median.
+            ok = all(isfinite, v)
         catch
         end
         if !ok
             try
                 v = median(dist)
-                ok = true
+                ok = all(isfinite, v)
             catch
             end
         end
@@ -405,13 +407,13 @@ function _re_start_value(dist, dim::Int, T)
         ok = false
         try
             v = _re_mean(dist)
-            ok = true
+            ok = all(isfinite, v)
         catch
         end
         if !ok
             try
                 v = median(dist)
-                ok = true
+                ok = all(isfinite, v)
             catch
             end
         end

--- a/src/estimation/remeasure.jl
+++ b/src/estimation/remeasure.jl
@@ -134,8 +134,8 @@ struct CompositeRE{T <: Number} <: AbstractREMeasure
     n_b::Int
     has_correction::Bool              # fast-path flag: false if all corrections are nothing
     unbounded::Bool                   # true iff every RE segment has support ℝ^dk, making
-    # b-space mode-centered AGHQ valid; conservatively false for all pre-existing
-    # transports so only marginals-based (copula) measures opt in
+    # b-space mode-centered AGHQ valid; false for bounded-support segments, which must
+    # keep the prior-centered rule
 end
 
 function transform(re::CompositeRE, z::AbstractVector)
@@ -246,21 +246,22 @@ function build_re_measure_from_batch(
             range = get_ranges(info)[li]
             push!(all_ranges, range)
 
-            # ℝ-supported segments allow b-space mode-centered AGHQ. Kept false for
-            # the pre-existing non-Gaussian transports (incl. identity/TDist) so
-            # their quadrature behavior is unchanged; only linear-Gaussian and
-            # all-ℝ marginals (copula) segments qualify.
+            # ℝ-supported segments allow b-space mode-centered AGHQ: CenteredREMeasure
+            # places nodes anywhere in ℝ^n_b and scores them with the prior logpdf at
+            # b, so support ℝ is the only requirement (issue #286). Bounded-support
+            # segments (LogNormal, Gamma, Beta, ...) keep the prior-centered rule.
             seg_marg = _re_marginals(dist)
-            all_unbounded &= dist isa Distributions.Normal ||
-                dist isa Distributions.MvNormal ||
-                (
-                seg_marg !== nothing &&
-                    all(
+            all_unbounded &= if seg_marg !== nothing
+                all(
                     mi -> Distributions.minimum(mi) == -Inf &&
                         Distributions.maximum(mi) == Inf,
                     seg_marg
                 )
-            )
+            elseif dist isa Distributions.ContinuousUnivariateDistribution
+                Distributions.minimum(dist) == -Inf && Distributions.maximum(dist) == Inf
+            else
+                dist isa Distributions.MvNormal
+            end
 
             if dist isa Distributions.Normal
                 μ_k = [Distributions.mean(dist)]

--- a/test/estimation_ghquadrature2_tests.jl
+++ b/test/estimation_ghquadrature2_tests.jl
@@ -1054,3 +1054,66 @@ end
         @test NoLimits.get_objective(res) < 1.0e6
     end
 end
+
+# ============================================================
+# Issue #286: ℝ-supported non-Gaussian REs must get the adaptive (mode-centered)
+# rule; on the prior-centered rule the estimate drifts *away* with the level.
+# ============================================================
+
+# Simpson's rule reference for the 1-D marginal of one subject.
+function _ghq_brute_subject_ll(y_i, a, σ, prior; lo = -40.0, hi = 40.0, npts = 100_001)
+    grid = range(lo, hi; length = npts)
+    logvals = [
+        sum(logpdf(Normal(a + η, σ), yi) for yi in y_i) + logpdf(prior, η)
+            for η in grid
+    ]
+    m = maximum(logvals)
+    w = ones(npts)
+    w[2:2:(end - 1)] .= 4
+    w[3:2:(end - 1)] .= 2
+    return m + log(sum(w .* exp.(logvals .- m)) * step(grid) / 3)
+end
+
+@testset "ghq_marginal converges for ℝ-supported non-Gaussian REs (#286)" begin
+    rng = MersenneTwister(2861)
+    n_id, n_obs = 6, 4
+    ids = repeat(1:n_id, inner = n_obs)
+    tobs = repeat(1:n_obs, n_id) .* 1.0
+    yobs = 0.5 .+ randn(rng, n_id)[ids] .+ 0.2 .* randn(rng, n_id * n_obs)
+    df = DataFrame(ID = ids, t = tobs, y = yobs)
+    dm_t = DataModel(_GHQ_TDIST_MODEL, df; primary_id = :ID, time_col = :t)
+    dm_n = DataModel(_GHQ_SCALAR_MODEL, df; primary_id = :ID, time_col = :t)
+
+    # ν → ∞ makes TDist(ν) indistinguishable from Normal(0, 1); the two models must
+    # give the same marginal. Before the fix the TDist batch stayed on the
+    # prior-centered rule and was tens of nats off.
+    θ_t_big = ComponentArray(a = 0.5, σ = 0.2, ν = 1.0e6)
+    θ_n = ComponentArray(a = 0.5, σ = 0.2, ω = 1.0)
+    @test NoLimits.ghq_marginal(dm_t, θ_t_big; level = 5) ≈
+        NoLimits.ghq_marginal(dm_n, θ_n; level = 5) atol = 1.0e-5
+
+    # Convergence in the quadrature level against a brute-force 1-D integral.
+    θ_t = ComponentArray(a = 0.5, σ = 0.2, ν = 4.0)
+    brute = sum(
+        _ghq_brute_subject_ll(yobs[ids .== i], θ_t.a, θ_t.σ, TDist(θ_t.ν))
+            for i in 1:n_id
+    )
+    @test NoLimits.ghq_marginal(dm_t, θ_t; level = 3) ≈ brute atol = 1.0e-2
+    @test NoLimits.ghq_marginal(dm_t, θ_t; level = 9) ≈ brute atol = 1.0e-5
+
+    # Bounded-support REs must keep the prior-centered rule.
+    dm_w = _ghq_family_dm(
+        _GHQ_WEIB_MODEL,
+        (
+            seed = 2862, n_id = 5, n_obs = 3,
+            eta = (rng, n) -> rand(rng, Weibull(2.0, 1.5), n),
+            y = (η, ε) -> η .+ 0.3 .* ε,
+        )
+    )
+    _, infos_w, cc_w = NoLimits._build_re_batch_infos(dm_w, NamedTuple())
+    ll_w = NoLimits.build_likelihood_cache(dm_w)
+    θ_w = ComponentArray(a = 1.0, σ = 0.3, α = 2.0, θ = 1.5)
+    m_w = NoLimits.build_re_measure_from_batch(infos_w[1], θ_w, cc_w, dm_w, ll_w)
+    @test m_w isa NoLimits.CompositeRE
+    @test !m_w.unbounded
+end


### PR DESCRIPTION
## Summary

`GHQuadrature` / `ghq_marginal` never upgraded a `TDist`, `Cauchy`, `Logistic`,
`Laplace`, ... random effect to the mode-centered (adaptive) AGHQ rule, so those
models were permanently stuck on the prior-centered Smolyak rule whose signed
weights drift *away* from the true integral as `level` rises (issue #98).
Marginal log-likelihoods were off by tens of nats and got worse with more points.

## Root cause

1. `build_re_measure_from_batch` (`src/estimation/remeasure.jl`) set
   `CompositeRE.unbounded` only for `Normal`/`MvNormal` or when `_re_marginals`
   reported all-ℝ marginals. `_re_marginals` returns `nothing` for every
   univariate distribution, so the identity-transport (ℝ-supported) segments were
   flagged `false` and `_ghq_adaptive_measure` refused to build the centered rule.
   `CenteredREMeasure` places nodes anywhere in ℝ^n_b and scores them with the
   prior logpdf at `b`, so support ℝ is the only requirement; the flag now tests
   the segment support directly. Bounded-support REs (LogNormal, Gamma, Beta, ...)
   keep the prior-centered rule.
2. `_re_start_value` (`src/estimation/laplace.jl`) accepted a NaN mean as the EB
   mode start. `Cauchy` and `TDist(ν<=1)` have a NaN mean, so `_ghq_bstar_batch`
   returned `b* = NaN` and the adaptive upgrade was rejected even with the flag
   fixed. The mean is now only used when finite, falling through to the median.

`unbounded` is read in exactly one place (`_ghq_adaptive_measure`); FOCEI and
Laplace do not consult it.

## Verification

Both scripts from the issue, plus a Cauchy/Logistic variant:

| check | before | after |
|---|---|---|
| `ghq_marginal` TDist(ν=1e6) vs Normal(0,1) RE, level 5 | diff -75.5 | diff 4.4e-6 (same as the Laplace diff) |
| TDist(ν=4) vs brute-force Simpson, levels 3/6/10 | -82.3 / -30.5 / -34.4 (truth -7.835) | -7.8351427 / -7.8351426 / -7.83514263785883 (truth -7.83514263785883) |
| Cauchy vs brute force, levels 3/5/9 | n/a (never adaptive) | diff 4.3e-6 / 5.5e-9 / 2.8e-14 |
| Logistic vs brute force, levels 3/5/9 | n/a | diff 3.2e-8 / 1.3e-12 / 0.0 |
| `fit_model(GHQuadrature(level))` on the TDist model | ν̂ 7.5 ... 3.6e6 with level | a, σ stable to 6 digits across levels 3/5/7; ν̂ ~5e6-1.4e7, matching the Laplace fit (ν is genuinely unidentified in that dataset) |

## Test added

`test/estimation_ghquadrature2_tests.jl`, reusing the existing `_GHQ_TDIST_MODEL`,
`_GHQ_SCALAR_MODEL` and `_GHQ_WEIB_MODEL` fixtures: TDist with large ν must match
the equivalent Normal-RE model, `ghq_marginal` must converge in the level against a
brute-force 1-D Simpson integral, and a bounded-support (Weibull) batch must still
report `unbounded == false`.

Tests run (all pass): `estimation_ghquadrature_tests.jl` (290),
`estimation_ghquadrature2_tests.jl` (104), `ad_random_effects.jl`,
`copulas_tests.jl` (38), `estimation_laplace_tests.jl`, `estimation_laplace2_tests.jl`,
`estimation_focei_tests.jl`, `estimation_saem_tests.jl`, `estimation_mcem_tests.jl`.

Fixes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)
