### PR TITLE
ci: pin Runic to 1.9.0 so the format gate is deterministic

### DIFF
--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -10,8 +10,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Formatting gate: Runic (pinned major). Runic has no configuration, so there
-  # is no style file and no v1-vs-v2 drift to guard against.
+  # Formatting gate: Runic, pinned to an exact version. Runic has no
+  # configuration file, but its output changes between minor releases, so a
+  # major-only pin makes the gate non-deterministic. Bump this pin only
+  # together with a repo-wide reformat commit made with the same version.
   format-check:
     name: format check (Runic)
     runs-on: ubuntu-latest
@@ -21,7 +23,7 @@ jobs:
         with:
           version: "1"
       - name: Install Runic
-        run: julia -e 'using Pkg; Pkg.add(PackageSpec(name="Runic", version="1"))'
+        run: julia -e 'using Pkg; Pkg.add(PackageSpec(name="Runic", version=v"1.9.0"))'
       - name: Check formatting
         run: |
           julia -e 'using Runic; exit(Runic.main(ARGS))' -- \


### PR DESCRIPTION
## Problem

`format check (Runic)` installed Runic with a major-only pin
(`PackageSpec(name="Runic", version="1")`), so the gate silently follows every
new 1.x release. Runic 1.10.0 changed its output, and since then `--check` fails
on **unmodified `main`** (about 20 pre-existing files would be reformatted). The
gate therefore fails on every open PR, regardless of what the PR changes.

## Verification

Ran `--check src test docs ext` against unmodified `origin/main` (43a376e2, the
last commit formatted and CI-green) with several Runic versions:

| Runic | `--check` on main |
|-------|-------------------|
| 1.10.0 | FAIL |
| 1.9.0 | pass |
| 1.8.0 | pass |
| 1.7.0 | pass |

## Fix

Pin the exact version (`version=v"1.9.0"`), the newest 1.x that agrees with the
current formatting of the repository. No source is reformatted here, since
several fix PRs are in flight.

Bumping the pin later must happen in the same commit as a repo-wide reformat
run with the new version. The workflow comment says so.

Note: `version="=1.9.0"` is not a valid `PackageSpec` version string in Pkg
(it throws), so the exact pin is expressed as `version=v"1.9.0"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
