### PR TITLE
fix: support univariate HMM outcomes in plot_hidden_states

### DIFF
--- a/ext/NoLimitsMakieExt.jl
+++ b/ext/NoLimitsMakieExt.jl
@@ -59,7 +59,7 @@ using NoLimits: COLOR_ACCENT, COLOR_CI, COLOR_PRIMARY, COLOR_REFERENCE, COLOR_SE
     _flatten_param_with_labels, _float_if_real, _get_dm, _get_observable,
     _get_x_values,
     _histogram_xy, _hmm_with_prior, _individual_id, _interp_linear, _is_bernoulli,
-    _is_discrete,
+    _is_discrete, _is_hmm_dist,
     _is_posterior_draw_fit,
     _kde_xy, _kernel_quantiles, _level_to_individual, _marginal_colors,
     _marginal_label,

--- a/ext/plotting/plots.jl
+++ b/ext/plotting/plots.jl
@@ -810,8 +810,8 @@ function _plot_hidden_states_impl(
                     get_model(dm), θ_ind, η_row, get_const_cov(ind), vary, sol_accessors
                 )
             dist = getproperty(obs, obs_name)
-            dist isa MVDiscreteTimeDiscreteStatesHMM ||
-                error("Observable $(obs_name) must be MVDiscreteTimeDiscreteStatesHMM.")
+            _is_hmm_dist(dist) ||
+                error("Observable $(obs_name) must be a hidden-Markov-model outcome, got $(typeof(dist)).")
             y_val = getfield(get_obs(get_series(ind)), obs_name)[j]
             prior = get(hmm_priors_hs, obs_name, nothing)
             dist_filtered = _hmm_with_prior(dist, prior)
@@ -822,7 +822,7 @@ function _plot_hidden_states_impl(
             post = posterior_hidden_states(dist_filtered, y_val)
             hmm_priors_hs[obs_name] = post
             if n_states === nothing
-                n_states = dist.n_states
+                n_states = length(post)
             end
             push!(times, x_vals[j])
             push!(posteriors, post)
@@ -931,8 +931,6 @@ function plot_hidden_states(
     save_path = _resolve_plot_path(save_path, plot_path)
     constants_re_use = _res_constants_re(res, constants_re)
     obs_name = _get_observable(dm, observable)
-    (is_mv, _) = _obs_multivariate_info(dm, obs_name)
-    is_mv || error("plot_hidden_states requires a multivariate observable.")
     _is_posterior_draw_fit(res) &&
         error("plot_hidden_states does not support posterior draws yet.")
 
@@ -1006,8 +1004,6 @@ function plot_hidden_states(
     end
     save_path = _resolve_plot_path(save_path, plot_path)
     obs_name = _get_observable(dm, observable)
-    (is_mv, _) = _obs_multivariate_info(dm, obs_name)
-    is_mv || error("plot_hidden_states requires a multivariate observable.")
 
     θ = get_θ0_untransformed(get_fixed(get_model(dm)))
     θ = _apply_param_overrides(θ, params)

--- a/test/plotting_functions_tests.jl
+++ b/test/plotting_functions_tests.jl
@@ -386,6 +386,71 @@ end
     end
 end
 
+# #294: plot_hidden_states used to reject any non-multivariate observable, so a plain
+# (univariate) HMM outcome could never be plotted even though its filter supports it.
+@testset "plot_hidden_states univariate HMM (#294)" begin
+    model = @Model begin
+        @fixedEffects begin
+            mu1 = RealNumber(0.0)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @formulas begin
+            P = [0.9 0.1; 0.2 0.8]
+            y ~ DiscreteTimeDiscreteStatesHMM(
+                P, (Normal(mu1, 1.0), Normal(3.0, 1.0)), Categorical([0.5, 0.5])
+            )
+        end
+    end
+
+    df = DataFrame(
+        ID = repeat(1:2, inner = 3),
+        t = repeat([0.0, 1.0, 2.0], 2),
+        y = Union{Missing, Float64}[0.1, missing, 3.1, 3.0, 2.8, 0.2],
+    )
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+
+    fig = plot_hidden_states(dm)
+    @test fig !== nothing
+
+    # Hand-rolled forward filter for individual 1: propagate, then weight by the
+    # emission pdf; a missing observation only propagates.
+    P = [0.9 0.1; 0.2 0.8]
+    em = (Normal(0.0, 1.0), Normal(3.0, 1.0))
+    prior = [0.5, 0.5]
+    expected = Vector{Vector{Float64}}()
+    for y in df.y[1:3]
+        p = transpose(P) * prior
+        p ./= sum(p)
+        if ismissing(y)
+            prior = p
+        else
+            u = p .* [pdf(em[1], y), pdf(em[2], y)]
+            prior = u ./ sum(u)
+            push!(expected, copy(prior))
+        end
+    end
+
+    ax = _first_axis(fig)
+    polys = [p for p in ax.scene.plots if p isa CairoMakie.Makie.Poly]
+    @test length(polys) == 2
+    heights = [
+        [r.widths[2] for r in CairoMakie.Makie.to_value(p[1])] for p in polys
+    ]
+    for state in 1:2
+        @test isapprox(
+            heights[state], [e[state] for e in expected]; atol = 1.0e-6
+        )
+    end
+
+    res = fit_model(dm, NoLimits.MLE(optim_kwargs = (; iterations = 2)))
+    @test plot_hidden_states(res) !== nothing
+    @test isa(
+        plot_hidden_states(res; figure_layout = :vector), Vector{CairoMakie.Figure}
+    )
+end
+
 @testset "plot_fits supports varying non-ODE random-effect groups" begin
     @test plot_fits(
         fx_varyre_dm(); constants_re = fx_varyre_constants_re(),


### PR DESCRIPTION
## Summary

`plot_hidden_states` raised `plot_hidden_states requires a multivariate observable.` for every plain (univariate) `DiscreteTimeDiscreteStatesHMM` / `ContinuousTimeDiscreteStatesHMM` outcome, including the HMM example shown in the model-building docs.

## Root cause

Both `plot_hidden_states` methods in `ext/plotting/plots.jl` guarded on `_obs_multivariate_info`, and `_plot_hidden_states_impl` additionally asserted `dist isa MVDiscreteTimeDiscreteStatesHMM`. The forward filter the impl actually runs (`_hmm_with_prior`, `probabilities_hidden_states`, `posterior_hidden_states`) is already generic over the whole HMM family, so those guards were the only blocker. The state count now comes from `length(post)` instead of `dist.n_states`, which also covers the Coarsed variant that has no such field. Non-HMM observables still error, now naming the offending type.

## Test added

`test/plotting_functions_tests.jl`: new `plot_hidden_states univariate HMM (#294)` testset with a 2-state univariate DT HMM. It compares the stacked-bar heights extracted from the returned `Figure` against a hand-rolled forward filter (propagate, weight by emission pdf, missing observation only propagates) and exercises both the `DataModel` and `FitResult` entry points plus `figure_layout = :vector`. The existing MV-HMM testset is unchanged and still passes.

Verified locally: `NL_TEST_FILES="plotting_functions_tests.jl,hmm_discrete_time_tests.jl,plot_observation_distributions_tests.jl"` -> 99 + 13 + 64 passing, 0 failures.

Fixes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)