### PR TITLE
fix: forward the whole post-processing surface on MultistartFitResult

### DIFF
--- a/docs/src/estimation/multistart.md
+++ b/docs/src/estimation/multistart.md
@@ -187,12 +187,20 @@ best_run = get_multistart_best(res_ms)
 best_idx = get_multistart_best_index(res_ms)
 ```
 
-Standard fit accessors also work directly on a `MultistartFitResult`, dispatching to the best run:
+The whole post-processing surface also works directly on a `MultistartFitResult`, dispatching to the best run:
 
 ```julia
 theta_best = get_params(res_ms; scale=:untransformed)
 obj_best   = get_objective(res_ms)
+
+fit_summary = summarize(res_ms)
+uq          = compute_uq(res_ms; method=:wald)
+resid       = get_residuals(res_ms)
+pred        = predict(res_ms, dm; re_mode=:population)
+fig         = plot_fits(res_ms)
 ```
+
+This covers the accessors, `summarize`, `compute_uq`, `get_residuals`, `predict`, `complete_data_loglikelihood`, `get_marginal_likelihood`, `compute_shrinkage`, and every `plot_*` function. `get_multistart_best(res_ms)` is still available whenever the underlying `FitResult` itself is needed, for example to pass one run to a function that takes several fits.
 
 ## Example: Fixed-Effects MLE with Screening
 

--- a/ext/NoLimitsMakieExt.jl
+++ b/ext/NoLimitsMakieExt.jl
@@ -114,4 +114,22 @@ include("plotting/plotting_residuals.jl")
 include("plotting/plotting_random_effects.jl")
 include("plotting/plotting_uq.jl")
 
+# Plotting a multistart result plots its best run (#295); the plot_multistart_* functions
+# are multistart-specific and stay out of this list.
+for f in (
+        :plot_data, :plot_dv_ipred, :plot_dv_pred, :plot_em_trajectories,
+        :plot_emission_distributions, :plot_fits, :plot_hidden_states,
+        :plot_observation_distributions, :plot_observed_profiles,
+        :plot_random_effect_distributions, :plot_random_effect_pairplot,
+        :plot_random_effect_pit, :plot_random_effect_standardized,
+        :plot_random_effect_standardized_scatter, :plot_random_effects_pdf,
+        :plot_random_effects_scatter, :plot_residual_acf, :plot_residual_distribution,
+        :plot_residual_pit, :plot_residual_qq, :plot_residuals, :plot_shrinkage,
+        :plot_vpc, :plot_wres_pred,
+    )
+    @eval function $f(res::MultistartFitResult, args...; kwargs...)
+        return $f(_as_fit_result_for_plotting(res), args...; kwargs...)
+    end
+end
+
 end # module NoLimitsMakieExt

--- a/src/estimation/Multistart.jl
+++ b/src/estimation/Multistart.jl
@@ -71,6 +71,12 @@ Use the accessor functions to retrieve individual components:
 [`get_multistart_starts`](@ref), [`get_multistart_failed_results`](@ref),
 [`get_multistart_failed_starts`](@ref), [`get_multistart_best_index`](@ref),
 [`get_multistart_best`](@ref).
+
+All post-processing (`summarize`, `compute_uq`, `get_residuals`, `predict`,
+`complete_data_loglikelihood`, `get_marginal_likelihood`, `compute_shrinkage`, every
+`plot_*` function, ...) accepts a `MultistartFitResult` directly and acts on the best
+run. [`get_multistart_best`](@ref) is still available when the underlying
+[`FitResult`](@ref) itself is needed.
 """
 struct MultistartFitResult{M, R, RE, S, E, B}
     method::M
@@ -747,34 +753,34 @@ function fit_model(ms::Multistart, dm::DataModel, method::FittingMethod, args...
     )
 end
 
-get_summary(res::MultistartFitResult) = get_summary(get_multistart_best(res))
-get_diagnostics(res::MultistartFitResult) = get_diagnostics(get_multistart_best(res))
-get_result(res::MultistartFitResult) = get_result(get_multistart_best(res))
+# Post-processing on a multistart result acts on the best run (#295). One list instead of
+# per-function forwarders, so the accessor surface cannot drift out of sync again.
+# `get_method` and the `get_multistart_*` accessors are deliberately not in it.
+const MULTISTART_FORWARDED_FUNCTIONS = (
+    :get_summary, :get_diagnostics, :get_result, :get_objective, :get_converged,
+    :get_data_model, :get_params, :get_chain, :get_iterations, :get_raw, :get_notes,
+    :get_observed, :get_sampler, :get_n_samples, :get_random_effects,
+    :get_laplace_random_effects, :get_loglikelihood, :get_loglikelihood_quadrature,
+    :get_fit_args, :get_fit_kwargs, :get_closed_form_mstep_used,
+    :get_variational_posterior, :get_vi_state, :get_vi_trace, :get_residuals,
+    :summarize, :compute_uq, :compute_shrinkage, :complete_data_loglikelihood,
+    :predict, :reestimate_ebes, :sample_random_effects, :sample_posterior,
+    :identifiability_report,
+)
+
+for f in MULTISTART_FORWARDED_FUNCTIONS
+    @eval function $f(res::MultistartFitResult, args...; kwargs...)
+        return $f(get_multistart_best(res), args...; kwargs...)
+    end
+end
+
 get_method(res::MultistartFitResult) = res.method
-get_objective(res::MultistartFitResult) = get_objective(get_multistart_best(res))
-get_converged(res::MultistartFitResult) = get_converged(get_multistart_best(res))
-get_data_model(res::MultistartFitResult) = get_data_model(get_multistart_best(res))
 
-function get_params(res::MultistartFitResult; kwargs...)
-    return get_params(get_multistart_best(res); kwargs...)
+# Forms that take the DataModel first and the fit second.
+function complete_data_loglikelihood(dm::DataModel, res::MultistartFitResult; kwargs...)
+    return complete_data_loglikelihood(dm, get_multistart_best(res); kwargs...)
 end
 
-get_chain(res::MultistartFitResult) = get_chain(get_multistart_best(res))
-get_iterations(res::MultistartFitResult) = get_iterations(get_multistart_best(res))
-get_raw(res::MultistartFitResult) = get_raw(get_multistart_best(res))
-get_notes(res::MultistartFitResult) = get_notes(get_multistart_best(res))
-get_observed(res::MultistartFitResult) = get_observed(get_multistart_best(res))
-get_sampler(res::MultistartFitResult) = get_sampler(get_multistart_best(res))
-get_n_samples(res::MultistartFitResult) = get_n_samples(get_multistart_best(res))
-
-function get_random_effects(res::MultistartFitResult; kwargs...)
-    return get_random_effects(get_multistart_best(res); kwargs...)
-end
-
-function get_laplace_random_effects(res::MultistartFitResult; kwargs...)
-    return get_laplace_random_effects(get_multistart_best(res); kwargs...)
-end
-
-function get_loglikelihood(res::MultistartFitResult; kwargs...)
-    return get_loglikelihood(get_multistart_best(res); kwargs...)
+function get_loglikelihood_quadrature(dm::DataModel, res::MultistartFitResult; kwargs...)
+    return get_loglikelihood_quadrature(dm, get_multistart_best(res); kwargs...)
 end

--- a/test/estimation_multistart_tests.jl
+++ b/test/estimation_multistart_tests.jl
@@ -472,3 +472,40 @@ end
     @test length(NoLimits.get_multistart_results(res)) >= 1
     @test NoLimits.get_multistart_best(res) !== nothing
 end
+
+# Post-processing used to throw a raw MethodError on a MultistartFitResult because only a
+# hand-maintained subset of accessors forwarded to the best run (#295).
+@testset "Multistart post-processing forwards to the best run" begin
+    ms = NoLimits.Multistart(
+        dists = (; a = Normal(0.2, 0.2)), n_draws_requested = 3, n_draws_used = 2,
+        progress = false, rng = Random.Xoshiro(3)
+    )
+    dm = fx_nore_dm()
+    res = NoLimits.fit_model(ms, dm, NoLimits.MLE(; optim_kwargs = (maxiters = 20,)))
+    best = NoLimits.get_multistart_best(res)
+
+    @test NoLimits.summarize(res).parameter_rows == NoLimits.summarize(best).parameter_rows
+    @test NoLimits.get_uq_estimates(NoLimits.compute_uq(res; method = :wald)) ==
+        NoLimits.get_uq_estimates(NoLimits.compute_uq(best; method = :wald))
+    @test NoLimits.complete_data_loglikelihood(res) == NoLimits.complete_data_loglikelihood(best)
+    @test NoLimits.complete_data_loglikelihood(dm, res) == NoLimits.complete_data_loglikelihood(dm, best)
+    @test isequal(NoLimits.get_residuals(res), NoLimits.get_residuals(best))
+    @test isequal(
+        NoLimits.predict(res, dm; re_mode = :population),
+        NoLimits.predict(best, dm; re_mode = :population)
+    )
+    @test NoLimits.get_fit_args(res) == NoLimits.get_fit_args(best)
+    @test NoLimits.get_fit_kwargs(res) == NoLimits.get_fit_kwargs(best)
+    @test NoLimits.get_closed_form_mstep_used(res) == NoLimits.get_closed_form_mstep_used(best)
+
+    ms_re = NoLimits.Multistart(
+        dists = (; a = Normal(0.2, 0.2)), n_draws_requested = 3, n_draws_used = 2,
+        progress = false, rng = Random.Xoshiro(3)
+    )
+    res_re = NoLimits.fit_model(
+        ms_re, fx_fixre_dm(), NoLimits.Laplace(; optim_kwargs = (maxiters = 3,))
+    )
+    best_re = NoLimits.get_multistart_best(res_re)
+    @test NoLimits.compute_shrinkage(res_re) == NoLimits.compute_shrinkage(best_re)
+    @test NoLimits.get_marginal_likelihood(res_re) == NoLimits.get_marginal_likelihood(best_re)
+end

--- a/test/plotting_functions_tests.jl
+++ b/test/plotting_functions_tests.jl
@@ -114,6 +114,9 @@ end
 
     res_ms = fit_model(ms, fx_nore_dm(), NoLimits.MLE(; optim_kwargs = (maxiters = 2,)))
     @test plot_multistart_waterfall(res_ms) !== nothing
+    # Ordinary plots used to throw a MethodError on a MultistartFitResult (#295).
+    @test plot_fits(res_ms) !== nothing
+    @test plot_data(res_ms) !== nothing
 
     mktempdir() do tmp
         p_path = joinpath(tmp, "plot_multistart_waterfall.png")
@@ -312,10 +315,10 @@ end
         function scatter_counts(fig)
             return [
                 sum(
-                        length(CairoMakie.Makie.to_value(plt[1]))
+                    length(CairoMakie.Makie.to_value(plt[1]))
                         for plt in ax.scene.plots if plt isa CairoMakie.Makie.Scatter;
-                        init = 0
-                    ) for ax in all_axes(fig)
+                    init = 0
+                ) for ax in all_axes(fig)
             ]
         end
 

--- a/test/plotting_functions_tests.jl
+++ b/test/plotting_functions_tests.jl
@@ -315,10 +315,10 @@ end
         function scatter_counts(fig)
             return [
                 sum(
-                    length(CairoMakie.Makie.to_value(plt[1]))
+                        length(CairoMakie.Makie.to_value(plt[1]))
                         for plt in ax.scene.plots if plt isa CairoMakie.Makie.Scatter;
-                    init = 0
-                ) for ax in all_axes(fig)
+                        init = 0
+                    ) for ax in all_axes(fig)
             ]
         end
 


### PR DESCRIPTION
## Summary

`MultistartFitResult` forwarded only a hand-maintained list of accessors to the best run, so most post-processing threw a raw `MethodError`: `summarize`, `compute_uq`, `complete_data_loglikelihood`, `compute_shrinkage`, `get_residuals`, `predict`, `get_marginal_likelihood` / `get_loglikelihood_quadrature`, `get_fit_args` / `get_fit_kwargs`, `get_closed_form_mstep_used`, and every `plot_*` function.

## Root cause

`src/estimation/Multistart.jl` defined roughly 17 one-line forwarders by hand. Every function added elsewhere with a `::FitResult` signature silently missed the multistart path, and `plot_*` had no multistart method at all even though `_as_fit_result_for_plotting` already existed for `plot_fits_comparison`.

## Fix

- One list, `MULTISTART_FORWARDED_FUNCTIONS`, generates `f(res::MultistartFitResult, args...; kwargs...)` for every public single-result function, replacing the hand-written forwarders. `get_method` and the `get_multistart_*` accessors stay as they were.
- Two extra methods for the `(dm, res)` argument order of `complete_data_loglikelihood` and `get_loglikelihood_quadrature`.
- The Makie extension routes 24 `plot_*` functions through the existing `_as_fit_result_for_plotting`; `plot_multistart_waterfall` / `plot_multistart_fixed_effect_variability` are deliberately excluded.
- Docstring and `docs/src/estimation/multistart.md` updated: all post-processing works directly on the multistart result, and `get_multistart_best` is still available.

## Tests

- `test/estimation_multistart_tests.jl`: new testset asserting `summarize`, `compute_uq(:wald)`, `get_residuals`, `predict(:population)`, `complete_data_loglikelihood` (both argument orders), `get_fit_args` / `get_fit_kwargs`, `get_closed_form_mstep_used` on the fixed-effect fixture, plus `compute_shrinkage` and `get_marginal_likelihood` on the random-effect fixture, all equal to the same call on `get_multistart_best(res)`.
- `test/plotting_functions_tests.jl`: the multistart waterfall testset now also calls `plot_fits` and `plot_data` on the multistart result.

Ran locally through the Pkg test sandbox: `estimation_multistart_tests.jl`, `plotting_functions_tests.jl`, `accessors_tests.jl`, `uq_tests.jl`, `aqua_tests.jl` - all pass (Aqua clean, no new ambiguities).

Fixes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)
