### PR TITLE
fix: make the pooled warm-start comparison well-posed (unblocks main)

### DIFF
--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -359,10 +359,10 @@ uuid = "62783981-4cbd-42fc-bca8-16325de8dc4b"
 version = "0.1.6"
 
 [[deps.BlackBoxOptim]]
-deps = ["Compat", "Distributed", "Distributions", "LinearAlgebra", "Printf", "Random", "Statistics", "StatsAPI", "StatsBase"]
-git-tree-sha1 = "4f2a1e153aaf86982be76754aa7c01fea4073e25"
+deps = ["Compat", "Distributed", "Distributions", "LinearAlgebra", "PrecompileTools", "Printf", "Random", "Statistics", "StatsAPI", "StatsBase"]
+git-tree-sha1 = "67dbdbe9b34f7c74c42bb67ea6e75d8c1d8f48c0"
 uuid = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
-version = "0.6.11"
+version = "0.6.12"
 
     [deps.BlackBoxOptim.extensions]
     BlackBoxOptimRealtimePlotServerExt = ["HTTP", "JSON", "Sockets"]
@@ -418,9 +418,9 @@ version = "1.0.1+0"
 
 [[deps.CSV]]
 deps = ["CodecZlib", "Dates", "FilePathsBase", "InlineStrings", "Mmap", "Parsers", "PooledArrays", "PrecompileTools", "SentinelArrays", "Tables", "Unicode", "WeakRefStrings", "WorkerUtilities"]
-git-tree-sha1 = "8d8e0b0f350b8e1c91420b5e64e5de774c2f0f4d"
+git-tree-sha1 = "abed1e735dd4152f48c90cf0767e1790e25f332f"
 uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-version = "0.10.16"
+version = "0.10.17"
 
 [[deps.Cairo]]
 deps = ["Cairo_jll", "Colors", "Glib_jll", "Graphics", "Libdl", "Pango_jll"]
@@ -478,9 +478,9 @@ weakdeps = ["InverseFunctions", "Test"]
     ChangesOfVariablesTestExt = "Test"
 
 [[deps.ChunkCodecCore]]
-git-tree-sha1 = "1a3ad7e16a321667698a19e77362b35a1e94c544"
+git-tree-sha1 = "3496e2b359c27793d12bec54ec94be7983a6ceb2"
 uuid = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
-version = "1.0.1"
+version = "1.0.2"
 
 [[deps.ChunkCodecLibZlib]]
 deps = ["ChunkCodecCore", "Zlib_jll"]
@@ -502,9 +502,9 @@ version = "0.1.13"
 
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "962834c22b66e32aa10f7611c08c8ca4e20749a9"
+git-tree-sha1 = "970758a3d591a2a5c2a907c53f2e2f8c1b1d3537"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.7.8"
+version = "0.7.9"
 
 [[deps.CodecZstd]]
 deps = ["TranscodingStreams", "Zstd_jll"]
@@ -670,9 +670,9 @@ version = "0.6.3"
 
 [[deps.Copulas]]
 deps = ["ADTypes", "Combinatorics", "Distributions", "ForwardDiff", "HCubature", "LambertW", "LinearAlgebra", "LogExpFunctions", "MvNormalCDF", "Optim", "PolyLog", "Printf", "QuadGK", "Random", "Roots", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "TaylorSeries"]
-git-tree-sha1 = "a93c1b254e63a0a2fbce6fb7f3c8d9a54d6ecbe3"
+git-tree-sha1 = "915ebe657620e311f1d685c2653e0540eaf2b3f9"
 uuid = "ae264745-0b69-425e-9d9d-cf662c5eec93"
-version = "0.1.40"
+version = "0.1.42"
 
     [deps.Copulas.extensions]
     CopulasExpectationMaximizationExt = "ExpectationMaximization"
@@ -831,10 +831,10 @@ weakdeps = ["Functors"]
     DiffEqCallbacksFunctorsExt = "Functors"
 
 [[deps.DiffEqNoiseProcess]]
-deps = ["CommonSolve", "DiffEqBase", "Distributions", "GPUArraysCore", "LinearAlgebra", "Markdown", "PoissonRandom", "QuadGK", "Random", "RecipesBase", "RecursiveArrayTools", "ResettableStacks", "SciMLBase", "StaticArraysCore", "Statistics"]
-git-tree-sha1 = "6ecddea5552b0444a39f226a710ba691661ec8b4"
+deps = ["CommonSolve", "DiffEqBase", "Distributions", "GPUArraysCore", "LinearAlgebra", "Markdown", "PoissonRandom", "PrecompileTools", "QuadGK", "Random", "RecipesBase", "RecursiveArrayTools", "ResettableStacks", "SciMLBase", "StaticArraysCore", "Statistics"]
+git-tree-sha1 = "52def2a26a6e0c7940e9f379e74539dbf552a98b"
 uuid = "77a26b50-5914-5dd7-bc55-306e6241c503"
-version = "5.34.1"
+version = "5.36.2"
 weakdeps = ["Optim", "ReverseDiff"]
 
     [deps.DiffEqNoiseProcess.extensions]
@@ -908,9 +908,9 @@ version = "0.7.20"
 
 [[deps.DimensionalData]]
 deps = ["ConstructionBase", "DataAPI", "Dates", "Extents", "Interfaces", "IntervalSets", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "OrderedCollections", "PrecompileTools", "Random", "Statistics", "TableTraits", "Tables"]
-git-tree-sha1 = "57bbee194533adaa755b5cae528eabdea5d05039"
+git-tree-sha1 = "3e5b58039d35b98f425446c099577d67633a7237"
 uuid = "0703355e-b756-11e9-17c0-8b28908087d0"
-version = "0.30.1"
+version = "0.30.2"
 
     [deps.DimensionalData.extensions]
     DimensionalDataAbstractFFTsExt = "AbstractFFTs"
@@ -1091,9 +1091,9 @@ version = "2.2.9"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "e6c4a6407a949e79a9d3f249bf49e6987c80e01f"
+git-tree-sha1 = "f4d39eee89f1e58c26bf447f1d4156c0125d6838"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.8.2+0"
+version = "2.8.3+0"
 
 [[deps.ExponentialAction]]
 deps = ["AbstractDifferentiation", "ChainRulesCore", "LinearAlgebra", "SparseArrays"]
@@ -1107,9 +1107,9 @@ uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 version = "0.1.10"
 
 [[deps.ExpressionExplorer]]
-git-tree-sha1 = "5f1c005ed214356bbe41d442cc1ccd416e510b7e"
+git-tree-sha1 = "678f8b7cd246ed441d29ca42a99f5f138be2ecac"
 uuid = "21656369-7473-754a-2065-74616d696c43"
-version = "1.1.4"
+version = "1.1.5"
 
 [[deps.ExproniconLite]]
 git-tree-sha1 = "c13f0b150373771b0fdc1713c97860f8df12e6c2"
@@ -1277,9 +1277,9 @@ weakdeps = ["Adapt", "Random"]
 
 [[deps.FlexiChains]]
 deps = ["AbstractMCMC", "AbstractPPL", "DelimitedFiles", "DimensionalData", "DocStringExtensions", "LinearAlgebra", "MCMCDiagnosticTools", "OrderedCollections", "PrecompileTools", "Printf", "Random", "Statistics", "StatsBase", "Tables"]
-git-tree-sha1 = "1b35c5d07782e74397e0d0fc0c7a2446d207c024"
+git-tree-sha1 = "844fa0c4d78d1f8d09ac3933a239b4a05b31cb64"
 uuid = "4a37a8b9-6e57-4b92-8664-298d46e639f7"
-version = "0.6.37"
+version = "0.6.38"
 
     [deps.FlexiChains.extensions]
     FlexiChainsAdvancedHMCExt = ["AdvancedHMC", "DimensionalData"]
@@ -1390,9 +1390,10 @@ uuid = "a85aefff-f8ca-4649-a888-c8e5398bc76c"
 version = "0.1.2"
 
 [[deps.FunctionProperties]]
-git-tree-sha1 = "7d245f78ca36f8ec4c7e0d7f72153ff51434e6f2"
+deps = ["PrecompileTools"]
+git-tree-sha1 = "eb42e8cd7bf092337ca385be61b4ca35e8854ea2"
 uuid = "f62d2435-5019-4c03-9749-2d4c77af0cbc"
-version = "1.1.1"
+version = "1.2.0"
 
 [[deps.FunctionWrappers]]
 git-tree-sha1 = "d62485945ce5ae9c0c48f124a84998d755bae00e"
@@ -1449,9 +1450,9 @@ version = "1.1.0"
 
 [[deps.GeometryBasics]]
 deps = ["EarCut_jll", "LinearAlgebra", "PrecompileTools", "Random", "StaticArrays"]
-git-tree-sha1 = "364685f5ffde25deb1bbcfd5bb278a5c6b7a9b37"
+git-tree-sha1 = "592cfb5ed8b02804f6a9c04091571c393081f73a"
 uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
-version = "0.5.11"
+version = "0.5.12"
 
     [deps.GeometryBasics.extensions]
     ExtentsExt = "Extents"
@@ -1523,9 +1524,9 @@ version = "1.8.0"
 
 [[deps.HarfBuzz_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll"]
-git-tree-sha1 = "f923f9a774fcf3f5cb761bfa43aeadd689714813"
+git-tree-sha1 = "c3f99f8e7c98031b8845ece9db86dca713ab9bf8"
 uuid = "2e76f6c2-a576-52d4-95c1-20adfe4de566"
-version = "8.5.1+0"
+version = "100.14003.0+0"
 
 [[deps.HashArrayMappedTries]]
 git-tree-sha1 = "2eaa69a7cab70a52b9687c8bf950a5a93ec895ae"
@@ -1575,9 +1576,9 @@ version = "0.10.5"
 
 [[deps.ImageIO]]
 deps = ["FileIO", "IndirectArrays", "JpegTurbo", "LazyModules", "Netpbm", "OpenEXR", "PNGFiles", "QOI", "Sixel", "TiffImages", "UUIDs", "WebP"]
-git-tree-sha1 = "696144904b76e1ca433b886b4e7edd067d76cbf7"
+git-tree-sha1 = "f0f005f997dfb8c5fe23920d99458a9619873893"
 uuid = "82e4d734-157c-48bb-816b-45c225c6df19"
-version = "0.6.9"
+version = "0.6.10"
 
 [[deps.ImageMetadata]]
 deps = ["AxisArrays", "ImageAxes", "ImageBase", "ImageCore"]
@@ -1653,9 +1654,9 @@ weakdeps = ["ForwardDiff", "Unitful"]
 
 [[deps.IntervalArithmetic]]
 deps = ["CRlibm", "CoreMath", "MacroTools", "OpenBLASConsistentFPCSR_jll", "Printf", "Random", "RoundingEmulator"]
-git-tree-sha1 = "c3ee408ae340565f41699e3a3fa1053698c7626e"
+git-tree-sha1 = "ff294afb9a15d31d8d7422da138844641a73135f"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
-version = "1.0.10"
+version = "1.0.11"
 
     [deps.IntervalArithmetic.extensions]
     IntervalArithmeticArblibExt = "Arblib"
@@ -1726,9 +1727,9 @@ version = "1.0.0"
 
 [[deps.JLD2]]
 deps = ["ChunkCodecLibZlib", "ChunkCodecLibZstd", "FileIO", "MacroTools", "Mmap", "OrderedCollections", "PrecompileTools", "ScopedValues"]
-git-tree-sha1 = "9ebadf3f8f0de07031359917549bbdadc23f5dc3"
+git-tree-sha1 = "877edc1d2f51adcef0bfacd19464a19e7cfddddb"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.6.5"
+version = "0.6.6"
 weakdeps = ["UnPack"]
 
     [deps.JLD2.extensions]
@@ -1813,9 +1814,9 @@ version = "4.1.0+0"
 
 [[deps.LLVM]]
 deps = ["CEnum", "LLVMExtra_jll", "Libdl", "PrecompileTools", "Preferences", "Printf", "Unicode"]
-git-tree-sha1 = "c16e849ea9402330fd9945138bc4247b2d603848"
+git-tree-sha1 = "d4bfee24427f4f441bd9212a107e375c39663aab"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "9.12.0"
+version = "9.13.1"
 weakdeps = ["BFloat16s"]
 
     [deps.LLVM.extensions]
@@ -1823,9 +1824,9 @@ weakdeps = ["BFloat16s"]
 
 [[deps.LLVMExtra_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
-git-tree-sha1 = "7304136286a564be0f909ecf209d1105e6ddf613"
+git-tree-sha1 = "d77aea19c9a71059a021acd99b0a4343e9661d94"
 uuid = "dad2f222-ce93-54a1-a47d-0025e8a3acab"
-version = "0.0.45+0"
+version = "0.0.47+0"
 
 [[deps.LLVMOpenMP_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1846,9 +1847,9 @@ version = "1.0.0"
 
 [[deps.Latexify]]
 deps = ["Format", "Ghostscript_jll", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdown", "OrderedCollections", "Requires"]
-git-tree-sha1 = "24390f715ff0795a1c4b912d788f18c52c6abd19"
+git-tree-sha1 = "df7566479bd64f20bd16b09960145e70160ffb3b"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
-version = "0.16.11"
+version = "0.16.12"
 
     [deps.Latexify.extensions]
     DataFramesExt = "DataFrames"
@@ -1945,9 +1946,9 @@ version = "2.42.0+0"
 
 [[deps.Libtask]]
 deps = ["MistyClosures", "Test"]
-git-tree-sha1 = "188e6364a7bb87f21e37b7545e13ab204614edf0"
+git-tree-sha1 = "d045ad5c965fc46c5d4c459d19a99271887de0e9"
 uuid = "6f1fad26-d15e-5dc8-ae53-837a1d7b8c9f"
-version = "0.9.18"
+version = "0.9.19"
 
 [[deps.Libtiff_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "LERC_jll", "Libdl", "XZ_jll", "Zlib_jll", "Zstd_jll"]
@@ -1962,10 +1963,10 @@ uuid = "38a345b3-de98-5d2b-a5d3-14cd9215e700"
 version = "2.42.0+0"
 
 [[deps.LikelihoodProfiler]]
-deps = ["ADTypes", "ComponentArrays", "DataFrames", "DataInterpolations", "Distributed", "Distributions", "LinearAlgebra", "Optimization", "PreallocationTools", "RecipesBase", "Reexport", "SciMLBase", "SimpleUnPack"]
-git-tree-sha1 = "722cffa1803bcbe52fe2229535ea1ffea99308d2"
+deps = ["ADTypes", "ComponentArrays", "DataFrames", "Distributed", "Distributions", "LinearAlgebra", "Optimization", "PreallocationTools", "RecipesBase", "Reexport", "SciMLBase", "SimpleUnPack"]
+git-tree-sha1 = "77981e7194b9f4fedfdfca98306144491ea941d8"
 uuid = "93acb638-a083-5915-8dce-d129bc6a3f59"
-version = "1.5.4"
+version = "1.6.1"
 
     [deps.LikelihoodProfiler.extensions]
     CICOBaseExt = "CICOBase"
@@ -2439,9 +2440,9 @@ version = "1.8.0"
 
 [[deps.MvNormalCDF]]
 deps = ["Distributions", "FillArrays", "LinearAlgebra", "Primes", "Random", "StatsBase"]
-git-tree-sha1 = "87ce0f8162ba3a9f1b6410d2180be4f04c0baac1"
+git-tree-sha1 = "605be72752f6009eb37afd2a4ce335ded3853f1d"
 uuid = "37188c8d-bc69-4638-b057-733e744175ec"
-version = "0.3.2"
+version = "0.3.3"
 
 [[deps.NLSolversBase]]
 deps = ["ADTypes", "DifferentiationInterface", "FiniteDiff", "LinearAlgebra"]
@@ -2469,9 +2470,9 @@ version = "2.11.0+0"
 
 [[deps.NNlib]]
 deps = ["Adapt", "Atomix", "BFloat16s", "ChainRulesCore", "GPUArraysCore", "KernelAbstractions", "LinearAlgebra", "Random", "ScopedValues", "Statistics"]
-git-tree-sha1 = "e840151ff107c24129f96d971f82b9b97cfd628b"
+git-tree-sha1 = "d450844d195714a2d29b38c231193c0297cf90e8"
 uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
-version = "0.9.43"
+version = "0.9.45"
 
     [deps.NNlib.extensions]
     NNlibAMDGPUExt = "AMDGPU"
@@ -2521,7 +2522,7 @@ version = "1.3.0"
 deps = ["Bijectors", "ComponentArrays", "DataFrames", "DataInterpolations", "DiffEqBase", "DiffEqCallbacks", "Distributions", "Downloads", "ExponentialAction", "ForwardDiff", "FunctionChains", "Functors", "KernelDensity", "LineSearches", "LinearAlgebra", "Logging", "MCMCChains", "Optimisers", "Optimization", "OptimizationOptimJL", "OrdinaryDiffEq", "ProgressMeter", "Random", "Roots", "RuntimeGeneratedFunctions", "SciMLBase", "SciMLStructures", "SpecialFunctions", "StaticArrays", "Statistics", "StatsFuns", "Symbolics"]
 path = ".."
 uuid = "1d491b74-35a5-408f-ae19-cf8524c3769d"
-version = "0.2.2"
+version = "0.2.7"
 weakdeps = ["CSV", "Copulas", "JLD2", "Latexify", "LikelihoodProfiler", "Lux", "Makie", "OptimizationNLopt", "SciMLSensitivity", "SimpleChains", "Turing"]
 
     [deps.NoLimits.extensions]
@@ -2672,9 +2673,9 @@ version = "0.3.3"
 
 [[deps.OpenEXR_jll]]
 deps = ["Artifacts", "Imath_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "0d621a4beb5e48d195f907c3c5b0bea285d9ff9d"
+git-tree-sha1 = "fd09db52a90efaae33a3d91f0bc71a22c429e8f1"
 uuid = "18a262bb-aa17-5467-a713-aee519bc75cb"
-version = "3.4.13+0"
+version = "3.4.14+0"
 
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -2764,10 +2765,10 @@ version = "5.2.0"
     Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [[deps.OptimizationNLopt]]
-deps = ["NLopt", "OptimizationBase", "Random", "Reexport", "SciMLBase", "SciMLLogging"]
-git-tree-sha1 = "f39f875caa7ec66e507aea2f7e79f9e4f4e663c5"
+deps = ["NLopt", "OptimizationBase", "Random", "SciMLBase", "SciMLLogging"]
+git-tree-sha1 = "2263c7326f64c57caa80e877f3a1533ef5474205"
 uuid = "4e6fcdb7-1186-4e1f-a706-475e75c168bb"
-version = "0.3.15"
+version = "0.3.16"
 
 [[deps.OptimizationOptimJL]]
 deps = ["Optim", "OptimizationBase", "Reexport", "SciMLBase", "SparseArrays"]
@@ -2776,10 +2777,10 @@ uuid = "36348300-93cb-4f02-beb5-3c3902f8871e"
 version = "0.4.15"
 
 [[deps.OptimizationOptimisers]]
-deps = ["Logging", "Optimisers", "OptimizationBase", "Reexport", "SciMLBase", "SciMLLogging"]
-git-tree-sha1 = "d7414b3eb9fec8ad9d77aed6730eaff6276e35a0"
+deps = ["Logging", "Optimisers", "OptimizationBase", "SciMLBase", "SciMLLogging"]
+git-tree-sha1 = "13996ac6fef67ab9792919c0eaa92141a9845db3"
 uuid = "42dfb2eb-d2b4-4451-abcd-913932933ac1"
-version = "0.3.21"
+version = "0.3.22"
 
 [[deps.Opus_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -2906,9 +2907,9 @@ version = "0.5.12"
 
 [[deps.Pango_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "FriBidi_jll", "Glib_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "7126b66b721a605a2fec966a2874c5ed53258eb3"
+git-tree-sha1 = "1912a9f1b9ca55005b03ba075f8e19993583e237"
 uuid = "36c8627f-9965-5494-a995-c6b170f724f3"
-version = "1.58.0+0"
+version = "1.58.2+0"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
@@ -3205,10 +3206,10 @@ uuid = "ae029012-a4dd-5104-9daa-d747884805df"
 version = "1.3.1"
 
 [[deps.ResettableStacks]]
-deps = ["StaticArrays"]
-git-tree-sha1 = "3447fddbf95171fe3a255f174194eba23a584b1e"
+deps = ["PrecompileTools", "StaticArrays"]
+git-tree-sha1 = "ed16b7ff60555aa33a8013b9a165c404da3685b3"
 uuid = "ae5879a3-cd67-5da8-be7f-38c6eb64a37b"
-version = "1.3.0"
+version = "1.4.0"
 
 [[deps.ReverseDiff]]
 deps = ["ChainRulesCore", "DiffResults", "DiffRules", "ForwardDiff", "FunctionWrappers", "LinearAlgebra", "LogExpFunctions", "MacroTools", "NaNMath", "Random", "SpecialFunctions", "StaticArrays", "Statistics"]
@@ -3862,9 +3863,9 @@ version = "0.5.29"
 
 [[deps.Tracker]]
 deps = ["Adapt", "ChainRulesCore", "DiffRules", "ForwardDiff", "Functors", "LinearAlgebra", "LogExpFunctions", "MacroTools", "NNlib", "NaNMath", "Optimisers", "Printf", "Random", "Requires", "SpecialFunctions", "Statistics"]
-git-tree-sha1 = "83697ba2237663355de8fb0a800144cda44848a0"
+git-tree-sha1 = "19b3f57d1b9f9aeff1f905a41818c75e467d07a2"
 uuid = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-version = "0.2.38"
+version = "0.2.39"
 weakdeps = ["PDMats"]
 
     [deps.Tracker.extensions]
@@ -3952,9 +3953,9 @@ weakdeps = ["ConstructionBase", "ForwardDiff", "InverseFunctions", "LaTeXStrings
     PrintfExt = "Printf"
 
 [[deps.UnsafeAtomics]]
-git-tree-sha1 = "0f30765c32d66d58e41f4cb5624d4fc8a82ec13b"
+git-tree-sha1 = "21b39bfb1fab6156b61fbcba4c86c57b6216d2c3"
 uuid = "013be700-e6cd-48c3-b4a1-df204f14c38f"
-version = "0.3.1"
+version = "0.3.2"
 weakdeps = ["LLVM"]
 
     [deps.UnsafeAtomics.extensions]
@@ -4097,9 +4098,9 @@ version = "1.5.7+1"
 
 [[deps.Zygote]]
 deps = ["AbstractFFTs", "ChainRules", "ChainRulesCore", "DiffRules", "Distributed", "FillArrays", "ForwardDiff", "GPUArraysCore", "IRTools", "InteractiveUtils", "LinearAlgebra", "LogExpFunctions", "MacroTools", "NaNMath", "PrecompileTools", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "ZygoteRules"]
-git-tree-sha1 = "b6a713b80d2b8fd515bf46e9c499dd9cb96bae3d"
+git-tree-sha1 = "a1ec45a8a0adee4d581a37f7e1a0fb401c1cb113"
 uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.7.12"
+version = "0.7.13"
 
     [deps.Zygote.extensions]
     ZygoteAtomExt = "Atom"
@@ -4135,9 +4136,9 @@ version = "3.14.1+0"
 
 [[deps.libass_jll]]
 deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "125eedcb0a4a0bba65b657251ce1d27c8714e9d6"
+git-tree-sha1 = "cb007192783c56d8249db4cf0e3495001edfe414"
 uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
-version = "0.17.4+0"
+version = "0.17.5+0"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/test/estimation_pooled_tests.jl
+++ b/test/estimation_pooled_tests.jl
@@ -599,23 +599,25 @@ end
     )
     @test θi3.b == 0.1
 
+    # ω held at its true value: see the note on the assertion below.
+    _POOLED_WARM_CST = (; ω = 0.5)
+
     # full warm-started fit reaches the same optimum as a cold fit
-    res_cold = fit_model(dm, NoLimits.Laplace(); serialization = NoLimits.EnsembleSerial())
-    res_warm = fit_model(
-        dm, NoLimits.Laplace(); pooled_init = true,
+    res_cold = fit_model(
+        dm, NoLimits.Laplace(); constants = _POOLED_WARM_CST,
         serialization = NoLimits.EnsembleSerial()
     )
-    # Convergence-gated: a converged warm-started fit must reach the same optimum
-    # as the cold fit. We don't assert unconditional equality because the warm
-    # start begins at the fully-converged pooled estimate, from which this tiny
-    # 12-individual problem can slide into a σ→0 likelihood degeneracy under
-    # reduced-optimization (-O1/-O0) arithmetic and not converge. The robust
-    # "reaches the same optimum" coverage comes from the custom-Pooled check below
-    # (which converges) plus the _pooled_init_theta mechanics tests above.
-    # 1.12-only: on Julia 1.10 (x86) the warm fit CONVERGES into that degeneracy,
-    # so the equality is a knife-edge there; the mechanics stay tested everywhere.
-    @test VERSION < v"1.12" || !NoLimits.get_converged(res_warm) ||
-        isapprox(
+    res_warm = fit_model(
+        dm, NoLimits.Laplace(); pooled_init = true, constants = _POOLED_WARM_CST,
+        serialization = NoLimits.EnsembleSerial()
+    )
+    # ω is unidentifiable on this 12-individual fixture and collapses toward 0, leaving
+    # the likelihood flat along that direction. Comparing two optimizer paths with ω free
+    # compares where each happened to stop on a flat ridge, so it flaked on FP noise
+    # alone; the old `!get_converged` escape hatch hid that (and get_converged is not a
+    # quality signal). Holding ω at its true value removes the degeneracy and makes
+    # "reaches the same optimum" well-posed on every Julia version.
+    @test isapprox(
         NoLimits.get_objective(res_warm), NoLimits.get_objective(res_cold); atol = 1.0e-2
     )
 
@@ -623,10 +625,9 @@ end
     res_custom = fit_model(
         dm, NoLimits.Laplace();
         pooled_init = NoLimits.Pooled(optim_kwargs = (; maxiters = 5)),
-        serialization = NoLimits.EnsembleSerial()
+        constants = _POOLED_WARM_CST, serialization = NoLimits.EnsembleSerial()
     )
-    @test VERSION < v"1.12" || !NoLimits.get_converged(res_custom) ||
-        isapprox(
+    @test isapprox(
         NoLimits.get_objective(res_custom), NoLimits.get_objective(res_cold); atol = 1.0e-2
     )
 


### PR DESCRIPTION
Fixes the red `main` (`c17c9859`): `test shard 13,14` → `estimation_pooled_tests.jl`, testset "pooled_init warm start", 99 passed / 2 failed.

## Root cause: the assertion was ill-posed, not the code

`ω` is unidentifiable on this 12-individual fixture and collapses toward 0, so the likelihood is flat along that direction. The two assertions compared where two optimizer paths *happened to stop* on that flat ridge, behind a `!get_converged` gate — so they asserted nothing whenever the optimizer failed to converge, and flaked whenever it succeeded. `get_converged` is not a quality signal and should never gate an assertion.

## Evidence

| Commit | Delta | shard 13,14 |
|---|---|---|
| `c17c9859` | main | FAIL, twice |
| `4612d810` | + manifest reseed | FAIL |
| `b9ae23b5` | + diagnostic prints only | **PASS** |

`b9ae23b5` differs from `4612d810` only by `@info` lines, which cannot affect numerics — so the failure is **intermittent**, not deterministic. That passing run also resolved the *same* dependency set as the failing runs (`OptimizationNLopt 0.3.17`, `SciMLSensitivity 7.119.2`, `DynamicPPL 0.42.9`, `AdvancedVI 0.7.0`, `Turing 0.46.1`).

Its diagnostics show why the comparison is meaningless:

```
cold    converged=true   obj=-7.837383769123205   ω=2.00e-7
warm    converged=true   obj=-7.837383769180050   ω=4.52e-8
custom  converged=false  obj=-7.837383769204454   ω=1.72e-7
```

`Δobj = 5.7e-11` against `atol = 1e-2`, with `ω` pinned to the boundary. A flat ridge, sampled at whatever point FP noise stopped each path — plausibly from `NL_BATCH_PARALLEL=true` running two fit-heavy groups against shared BLAS threads.

**Neither #299 nor #302 nor dependency drift is implicated.** All three were investigated and ruled out.

## Fix

Hold `ω` at its true value in the three comparison fits, removing the degeneracy, and drop the `VERSION` and `get_converged` gates:

```
cold    obj=9.422742359  ω=0.5  σ=0.224337  μ=1.17427
warm    obj=9.422741240  ω=0.5  σ=0.224337  μ=1.17427
custom  obj=9.422742358  ω=0.5  σ=0.224337  μ=1.17427
Δwarm = 1.12e-6      Δcust = 5.59e-10      (atol = 1e-2)
```

Four orders of magnitude of headroom instead of a knife edge, and the assertion now holds on every Julia version, so the 1.10 carve-out goes away. The `_pooled_init_theta` mechanics assertions above are untouched.

## Second commit: manifest housekeeping (not the fix)

`test/Manifest.toml` recorded `NoLimits v0.2.2` against a v0.2.7 package; reseeded per CLAUDE.md. **This does not make the pins bind** — the manifest records `julia_version = "1.12.2"` while CI's `version: "1.12"` floats to 1.12.7, and that mismatch forces stdlib rewrites which cascade into re-resolving 14-44 packages. Verified: a run on the reseeded manifest still upgraded from exactly the new pins. `project_hash` was already correct, so the stale entry was never the trigger.

## Follow-up worth its own decision

Making these pins actually bind needs CI's Julia pinned to an exact patch *and* the manifest regenerated with that same version, moved together thereafter — the same coupled-pin discipline as the Runic gate. Until then CI's dependency set floats with the registry and the shared depot cache. Not guessed at here.

## Verification

- `NL_TEST_GROUP=13,14` under CI's env (`NL_BATCH_PARALLEL=true`, `OPENBLAS_NUM_THREADS=2`, `--check-bounds=auto`): 277/277 pass.
- Runic (pinned 1.9.0): clean.
