### PR TITLE
ci: bound test job runtimes and serialize Documenter deploys

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,9 @@ jobs:
   shard:
     name: test shard ${{ matrix.group }}
     runs-on: ubuntu-latest
+    # Slowest shard on a green run is ~15 min; GitHub's 360-minute default let a
+    # hung shard burn 6 h and block the PR before reporting anything.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -82,6 +85,7 @@ jobs:
   threaded:
     name: test threaded (invariance oracles)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
@@ -107,6 +111,8 @@ jobs:
   compat-lts:
     name: test compat (Julia 1.10)
     runs-on: ubuntu-latest
+    # Own cache lane, so cold-cache runs reach ~42 min.
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -6,6 +6,14 @@ on:
     tags: ['*']
   pull_request:
 
+# deploydocs(push_preview=true) pushes every PR's preview to gh-pages, so runs racing
+# each other lose on non-fast-forward and report a spurious red `Documentation`. Serialize
+# repo-wide (one group, no cancel) so previews queue instead of colliding. Not per-ref:
+# the collision is between different refs.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pages: write
@@ -16,6 +24,7 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
Two self-inflicted CI failure modes seen on 2026-09-02, both unrelated to any product change. Workflow config only; no source or test changes.

## 1. `timeout-minutes` on the test jobs

No job set one, so GitHub's 360-minute default applied. A hung `test shard 7,23` ran **07:29 → 13:30 (6h 1m)**, was killed by the platform, and only then reported failure — blocking the PR for six hours and reaping three orphan `julia` processes at cleanup. It passed on re-run, so it was a hang, not a defect.

Longest honest runtimes on a green `main` run:

| Job | Observed | New timeout |
|---|---|---|
| slowest shard (`9,10`) | 15 min | 60 |
| threaded oracles | 13 min | 60 |
| compat (Julia 1.10) | 42 min | 120 |

3-4x headroom over observed, and a hang now surfaces in 1-2h instead of 6. The aggregator `test (Julia 1.12, ubuntu)` needs none — it only evaluates `needs.*.result` and runs in ~0 min.

## 2. Serialize Documenter deploys

`deploydocs(push_preview=true)` pushes each PR's preview to `gh-pages`, and `Documenter.yml` had **no `concurrency` block at all**, so runs raced. Nine simultaneous runs (a `gh pr update-branch` batch across 8 PRs) collided and one lost:

```
! [rejected]  HEAD -> gh-pages (fetch first)
hint: Updates were rejected because the remote contains work that you do not have
```

That reported a spurious red required `Documentation` check on a PR whose docs had built fine — the failure was purely in the deploy step.

Serialized repo-wide with one group and no cancel, so previews queue instead of colliding:

```yaml
concurrency:
  group: ${{ github.workflow }}
  cancel-in-progress: false
```

Deliberately **not** keyed on `github.ref`. The collision is between *different* refs, so the per-ref group that `CI.yml` and `Format.yml` use would not prevent it.

Trade-off, stated plainly: PR docs feedback now serializes at roughly 5 min per queued run. With the usual one or two open PRs that is invisible; during a large batch the last PR waits. That is the cost of not getting spurious red checks that need manual re-runs, and the batch case is itself the anomaly.

A `timeout-minutes: 60` is on the docs job too.

## Verification

Both files parse as YAML with the expected jobs and concurrency values. The real check is this PR's own run: CI's shards and the `Documentation` gate exercise both changes directly.
