### PR TITLE
fix: bug batch for #283 #284 #304 #306 #308 #309 #310

### DIFF
--- a/docs/src/uncertainty-quantification/index.md
+++ b/docs/src/uncertainty-quantification/index.md
@@ -24,14 +24,14 @@ The table below summarizes the available UQ backends, their associated estimatio
 
 | Backend | `method` | Typical source fit | Output style |
 | --- | --- | --- | --- |
-| Wald | `:wald` | `MLE`, `MAP`, `Laplace`, `MCEM`, `SAEM`, `GHQuadrature` | covariance + Gaussian-draw intervals |
+| Wald | `:wald` | `MLE`, `MAP`, `Laplace`, `MCEM`, `SAEM`, `GHQuadrature` | covariance + normal-quantile intervals |
 | Chain | `:chain` | `MCMC`, `VI` | posterior-draw intervals |
 | Profile likelihood | `:profile` | `MLE`, `MAP`, `Laplace` | profile intervals |
 | MCMC refit | `:mcmc_refit` | non-`MCMC` fits | posterior-draw intervals from refit |
 
 ### Wald (`method=:wald`)
 
-The Wald backend computes an approximate variance-covariance matrix for selected fixed-effect coordinates, then draws from a Gaussian approximation to construct confidence intervals. This is the most computationally efficient approach and works well for well-identified models whose log-likelihood surface is approximately quadratic near the optimum.
+The Wald backend computes an approximate variance-covariance matrix for selected fixed-effect coordinates, then reports confidence intervals as `estimate ± z * SE` on the transformed scale, back-transformed exactly for coordinates whose transform is monotone. Draws from the Gaussian approximation are still returned and are used for the coordinates that have no closed form. This is the most computationally efficient approach and works well for well-identified models whose log-likelihood surface is approximately quadratic near the optimum.
 
 ```julia
 uq_wald = compute_uq(

--- a/docs/src/uncertainty-quantification/wald.md
+++ b/docs/src/uncertainty-quantification/wald.md
@@ -2,7 +2,7 @@
 
 The Wald method is the most widely used approach to uncertainty quantification for maximum likelihood and related estimators. It approximates the log-likelihood surface as locally quadratic at the optimum, yielding a Gaussian approximation to the sampling distribution of the parameter estimates. This approximation is computationally inexpensive and accurate when the model is well-identified and the sample size is adequate.
 
-In NoLimits.jl, Wald UQ is accessed via `compute_uq(...; method=:wald)`. It constructs an approximate variance-covariance matrix for eligible fixed-effect coordinates, then draws from the implied Gaussian distribution to form confidence intervals.
+In NoLimits.jl, Wald UQ is accessed via `compute_uq(...; method=:wald)`. It constructs an approximate variance-covariance matrix for eligible fixed-effect coordinates and reports `estimate ± z * SE` intervals on the transformed scale, back-transformed exactly for coordinates whose transform is monotone. Draws from the implied Gaussian distribution are also returned and cover the remaining coordinates.
 
 For visualization of Wald-based densities, closed-form curves are used when available:
 
@@ -97,7 +97,7 @@ end
 
 ### Choosing `n_draws`
 
-The `n_draws` parameter controls the number of Monte Carlo samples drawn from the Wald Gaussian approximation. These draws are used to compute draw-based summaries (accessible via `get_uq_draws`), interval estimates, and the natural-scale covariance matrix.
+The `n_draws` parameter controls the number of Monte Carlo samples drawn from the Wald Gaussian approximation. These draws are used for draw-based summaries (accessible via `get_uq_draws`) and for the parts of the natural-scale covariance matrix that have no closed form. Intervals and the natural-scale variances of identity- and log-scale coordinates are computed in closed form and do not depend on `n_draws` or on the seed.
 
 Importantly, `n_draws` does not affect the transformed-scale covariance matrix itself (`get_uq_vcov(...; scale=:transformed)`), which is derived directly from the Hessian or sandwich calculation.
 

--- a/src/data_model/DataModel.jl
+++ b/src/data_model/DataModel.jl
@@ -129,6 +129,8 @@ struct Individual{S, C, CB, TS, RG, SA}
     tspan::TS
     re_groups::RG
     saveat::SA
+    # Dynamic-covariate knot times inside `tspan`; empty unless the DE reads one (#309).
+    tstops::Vector{Float64}
 end
 
 struct EventCallbacks{C, R, RS, B}
@@ -349,8 +351,10 @@ function _validate_schema(model, df, config::DataModelConfig)
     for c in config.obs_cols
         _check_finite(_get_col(df, c), c)
     end
-    for c in model.covariates.covariates.flat_names
-        hasproperty(df, c) && _check_finite(_get_col(df, c), c)
+    for name in model.covariates.covariates.names
+        for c in _covariate_data_columns(getfield(model.covariates.covariates.params, name))
+            hasproperty(df, c) && _check_finite(_get_col(df, c), c)
+        end
     end
     _warn_time_layout(df, config)
 
@@ -577,6 +581,11 @@ function _validate_time_col_covariate(model, config::DataModelConfig)
     return found ||
         error("time_col $(time_col) must be declared as Covariate() or DynamicCovariate() in @covariates.")
 end
+
+# `flat_names` synthesizes `x_1, x_2, ...` for the vector covariate types, which are never
+# data columns, so column-level validation has to walk the declared columns (#309).
+_covariate_data_columns(p::Union{ConstantCovariate, Covariate, DynamicCovariate}) = (p.column,)
+_covariate_data_columns(p::Union{ConstantCovariateVector, CovariateVector, DynamicCovariateVector}) = p.columns
 
 function _const_cov_columns(covariates, name::Symbol)
     p = getfield(covariates.params, name)
@@ -1083,11 +1092,26 @@ function _validate_dynamic_covariates(covariates, rows, t, id_val)
         end
         return sort!(unique!(opts))
     end
+    # Interpolation nodes are the individual's row times; a repeated time NaN-poisons the
+    # polynomial/spline interpolants globally rather than locally (#309).
+    dup_t = nothing
+    for i in 2:length(t)
+        if t[i] == t[i - 1]
+            dup_t = t[i]
+            break
+        end
+    end
+    function _dup_offender(label, itp)
+        return "Dynamic covariate $(label) uses $(Symbol(itp)) as interpolation method, which requires strictly increasing times, but individual $(id_val) has the repeated time $(dup_t). Repeated times make this interpolant return NaN over its whole support. Merge the duplicated rows (or nudge one of the times), or use ConstantInterpolation, SmoothedConstantInterpolation or LinearInterpolation."
+    end
     params = covariates.params
     offenders = String[]
     for name in covariates.dynamic
         p = getfield(params, name)
         if p isa DynamicCovariate
+            if dup_t !== nothing && p.interpolation in _DUP_TIME_UNSAFE_INTERPOLATIONS
+                push!(offenders, _dup_offender(name, p.interpolation))
+            end
             req = get(min_obs, p.interpolation, 1)
             if n < req
                 itp_name = Symbol(p.interpolation)
@@ -1100,6 +1124,9 @@ function _validate_dynamic_covariates(covariates, rows, t, id_val)
             end
         elseif p isa DynamicCovariateVector
             for (i, itp) in enumerate(p.interpolations)
+                if dup_t !== nothing && itp in _DUP_TIME_UNSAFE_INTERPOLATIONS
+                    push!(offenders, _dup_offender("$(name).$(p.columns[i])", itp))
+                end
                 req = get(min_obs, itp, 1)
                 if n < req
                     itp_name = Symbol(itp)
@@ -1606,6 +1633,7 @@ function DataModel(
     de_fun_syms = model.de.de === nothing ? Symbol[] : get_de_meta(model.de.de).fun_syms
     de_dyn = sort!(collect(intersect(Set(cov.dynamic), Set(de_fun_syms))))
     off_min = isempty(time_offsets) ? 0.0 : minimum(time_offsets)
+    off_max = isempty(time_offsets) ? 0.0 : maximum(time_offsets)
     keys_sorted, groups = _group_indices(df, primary_id)
     individuals = Vector{Individual}(undef, length(groups))
     obs_groups = Vector{Vector{Int}}(undef, length(groups))
@@ -1653,10 +1681,17 @@ function DataModel(
         if !isempty(de_dyn) && tspan[1] < minimum(tvals)
             error("Formulas request times earlier than the dynamic covariate support for individual $(keys_sorted[i]): the integration span starts at t=$(tspan[1]) (smallest formula time offset $(off_min)), but the dynamic covariate(s) $(join(de_dyn, ", ")) used in @DifferentialEquation are only supported on [$(minimum(tvals)), $(maximum(tvals))] and cannot be extrapolated. Add covariate rows covering t=$(tspan[1]), or change the formula offset (or t0) so that the integration starts at or after $(minimum(tvals)).")
         end
+        if !isempty(de_dyn) && tspan[2] > maximum(tvals)
+            error("Formulas request times later than the dynamic covariate support for individual $(keys_sorted[i]): the integration span ends at t=$(tspan[2]) (largest formula time offset $(off_max)), but the dynamic covariate(s) $(join(de_dyn, ", ")) used in @DifferentialEquation are only supported on [$(minimum(tvals)), $(maximum(tvals))] and cannot be extrapolated. Add covariate rows covering t=$(tspan[2]), or change the formula offset so that the integration ends at or before $(maximum(tvals)).")
+        end
+        # Every dynamic-covariate knot is a kink (linear) or jump (constant) in the DE
+        # right-hand side; the adaptive controller only respects it if told (#309).
+        tstops = isempty(de_dyn) ? Float64[] :
+            Float64[x for x in sort(unique(tvals)) if tspan[1] <= x <= tspan[2]]
         re_groups = _build_re_groups(model, df, rows)
         cb_times = callbacks !== nothing ? callbacks.all_times : Float64[]
         saveat = _build_saveat(df, rows, obs_rows, time_col, config, time_offsets, cb_times)
-        individuals[i] = Individual(series, const_cov, callbacks, tspan, re_groups, saveat)
+        individuals[i] = Individual(series, const_cov, callbacks, tspan, re_groups, saveat, tstops)
     end
 
     if !isempty(bad_ids)
@@ -1851,6 +1886,8 @@ Return the individual's integration time span `(t_min, t_max)`.
 Return the individual's `saveat` grid, or `nothing` for dense saving.
 """
 @inline get_saveat(ind::Individual) = ind.saveat
+
+@inline get_tstops(ind::Individual) = ind.tstops
 
 # Per-individual random-effect grouping levels (distinct from
 # `get_re_groups(re::RandomEffects)`, which maps RE names to grouping columns).

--- a/src/data_model/DataModel.jl
+++ b/src/data_model/DataModel.jl
@@ -302,12 +302,16 @@ end
 function _warn_time_layout(df, config::DataModelConfig)
     ids = _get_col(df, config.primary_id)
     tvals = _get_col(df, config.time_col)
+    # Only observation rows can be double-counted; event rows carry no likelihood term.
+    evid = (config.evid_col !== nothing && hasproperty(df, config.evid_col)) ?
+        _get_col(df, config.evid_col) : nothing
     unsorted = String[]
     dups = String[]
     for (id, rows) in pairs(_group_row_indices(ids))
         ts = tvals[rows]
         issorted(ts) || push!(unsorted, string(id))
-        length(unique(ts)) == length(ts) || push!(dups, string(id))
+        tobs = evid === nothing ? ts : tvals[filter(r -> isequal(evid[r], 0), rows)]
+        length(unique(tobs)) == length(tobs) || push!(dups, string(id))
     end
     isempty(unsorted) ||
         @warn "Rows are not sorted by $(config.time_col) within $(config.primary_id) $(join(string.(unsorted[1:min(end, 5)]), ", ")). Sequential outcomes (HMMs) and dynamic covariates are interpreted in row order."
@@ -375,6 +379,29 @@ function _validate_schema(model, df, config::DataModelConfig)
             _check_missing(_get_col(df, config.amt_col)[evt_idx], config.amt_col)
             _check_missing(_get_col(df, config.rate_col)[evt_idx], config.rate_col)
             _check_missing(_get_col(df, config.cmt_col)[evt_idx], config.cmt_col)
+            _check_finite(_get_col(df, config.amt_col), config.amt_col)
+            _check_finite(_get_col(df, config.rate_col), config.rate_col)
+            # A zero-amount infusion has zero duration: the numerical path stops the rate
+            # at once while the closed-form path leaves it running forever (#308).
+            # Event-only individuals stay legal without a DE (#237.29); with one, every
+            # solve path indexes the individual's first observation time.
+            if model.de.de !== nothing
+                amt_all = _get_col(df, config.amt_col)
+                rate_all = _get_col(df, config.rate_col)
+                tvals_all = _get_col(df, config.time_col)
+                ids_all = _get_col(df, config.primary_id)
+                for i in evt_idx
+                    if evid[i] == 1 && rate_all[i] != 0 && amt_all[i] == 0
+                        error("Infusion event for $(config.primary_id) $(ids_all[i]) at time $(tvals_all[i]) has $(config.amt_col)=0 and $(config.rate_col)=$(rate_all[i]). A zero-amount infusion has no defined duration; use $(config.rate_col)=0 for a bolus or a nonzero $(config.amt_col).")
+                    end
+                end
+                dosing_only = [
+                    string(id) for (id, rws) in _group_row_indices(ids_all)
+                        if !any(r -> isequal(evid[r], 0), rws)
+                ]
+                isempty(dosing_only) ||
+                    error("$(config.primary_id) $(join(sort(dosing_only), ", ")) has only event rows ($(config.evid_col) != 0). With a @DifferentialEquation each individual needs at least one $(config.evid_col) == 0 row.")
+            end
             # Without a DE block, EVID only excludes rows from the observations -- the
             # dose amounts have nowhere to go (#174).
             if model.de.de === nothing &&

--- a/src/data_model/DataModel.jl
+++ b/src/data_model/DataModel.jl
@@ -1357,6 +1357,13 @@ end
     return u0
 end
 
+# The `affect!` closure mutates `infusion_rates` in place during integration, so two
+# concurrent solves of one individual corrupt each other (#308). Callers that may run
+# in parallel take a private copy; deepcopy keeps the struct field and the closure's
+# captured buffer pointing at the same new vector.
+@inline _private_event_callbacks(::Nothing) = nothing
+_private_event_callbacks(e::EventCallbacks) = deepcopy(e)
+
 function _build_re_groups(model, df, rows)
     groups = get_re_groups(model.random.random)
     re_names = get_re_names(model.random.random)

--- a/src/data_simulation/data_simulation.jl
+++ b/src/data_simulation/data_simulation.jl
@@ -92,10 +92,11 @@ function _simulate_sol_accessors(dm::DataModel, idx::Int, θ, η)
     u0 = calculate_initial_state(model, θ, η, const_cov)
     cb = nothing
     infusion_rates = nothing
-    if get_callbacks(ind) !== nothing
-        _apply_initial_events!(u0, get_callbacks(ind))
-        cb = get_callback(get_callbacks(ind))
-        infusion_rates = get_infusion_rates(get_callbacks(ind))
+    events = _private_event_callbacks(get_callbacks(ind))
+    if events !== nothing
+        _apply_initial_events!(u0, events)
+        cb = get_callback(events)
+        infusion_rates = get_infusion_rates(events)
     end
     plan = get_closed_form_plan(dm)
     if is_cf_eligible(plan) && (_cf_is_whole(plan) || cb === nothing)
@@ -103,7 +104,7 @@ function _simulate_sol_accessors(dm::DataModel, idx::Int, θ, η)
         cf_alg = _resolve_ode_alg(solver_cfg.alg)
         sol = _cf_dispatch_solve(
             model, compiled, u0, get_tspan(ind), get_saveat(ind), plan,
-            get_callbacks(ind), cf_alg, solver_cfg.args,
+            events, cf_alg, solver_cfg.args,
             _ode_solve_kwargs(solver_cfg.kwargs, NamedTuple(), NamedTuple())
         )
         sol !== nothing && return get_de_accessors_builder(get_de(model))(sol, compiled)

--- a/src/estimation/adaptive_mh.jl
+++ b/src/estimation/adaptive_mh.jl
@@ -141,8 +141,8 @@ end
 # η ∈ Δ^{d+1} (simplex), z ∈ ℝ^d (inner normal coords).
 # Forward: z_i = log(η_i / η_{d+1})  (ALR, last component as reference)
 # Inverse: η = softmax(vcat(z, 0))
-# log|J_{z→η}| = -sum(log η) = (d+1)log(1+sum(exp(z))) - sum(z)
-# MH correction = log|J(z_new→η_new)| - log|J(z_old→η_old)|
+# log|J_f(η)| = log|dz/dη| = -sum(log η) = (d+1)log(1+sum(exp(z))) - sum(z)
+# MH correction = log|J_f(η_old)| - log|J_f(η_new)|
 @inline function _amh_bij_forward(::Val{:MvLogitNormal}, η::AbstractVector)
     ηf = max.(Float64.(η), 1.0e-300)
     ref = ηf[end]
@@ -161,7 +161,7 @@ end
         S = 1.0 + sum(exp.(z))
         return (length(z) + 1) * log(S) - sum(z)
     end
-    return _log_jac_mlogit(z_new) - _log_jac_mlogit(z_old)
+    return _log_jac_mlogit(z_old) - _log_jac_mlogit(z_new)
 end
 
 # LogNormal: log bijection (η > 0)
@@ -269,10 +269,10 @@ end
 @inline _bij_log_jac_forward(::Val{:NormalizingPlanarFlow}, ::AbstractVector) = 0.0
 # MvLogNormal: z = log(η), log|dz/dη| = -sum(z_i)
 @inline _bij_log_jac_forward(::Val{:MvLogNormal}, z::AbstractVector) = -sum(z)
-# MvLogitNormal: z = alr(η) (ALR, d-dim), log|dz/dη| = sum(z) - (d+1)*log(1+sum(exp(z)))
+# MvLogitNormal: z = alr(η) (ALR, d-dim), log|dz/dη| = (d+1)*log(1+sum(exp(z))) - sum(z)
 @inline function _bij_log_jac_forward(::Val{:MvLogitNormal}, z::AbstractVector)
     S = 1.0 + sum(exp.(Float64.(z)))
-    return sum(z) - (length(z) + 1) * log(S)
+    return (length(z) + 1) * log(S) - sum(z)
 end
 
 # LogNormal: z = log(η), dz/dη = 1/η = exp(-z) → log|dz/dη| = -z
@@ -569,6 +569,9 @@ function _amh_init_state(
         )
         lp_offset += n_levels
     end
+
+    b_ok = _em_vet_init_b(dm, info, θ_re, b_current, const_cache, cache, rng, re_names, "AdaptiveMH")
+    b_ok === b_current || copyto!(b_current, b_ok)
 
     # Initialize per-individual and per-level caches
     ind_ll, re_lp, logp = _amh_compute_full_ll(

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -3330,14 +3330,17 @@ end
 # `ind.callbacks` come out of the abstractly-typed `Individual` storage, so the
 # kwargs NamedTuples must be built behind a dispatch boundary to stay concrete
 # (keeps the Bool method of `_ode_normalize_verbose` statically dead).
-@inline function _ll_prob_kwargs(cb, saveat_use)
-    base = saveat_use === nothing ? (dense = true,) :
-        (saveat = saveat_use, save_everystep = false, dense = false)
+# `tstops` always merged (empty vector when the DE reads no dynamic covariate): a
+# conditional merge would make the return a Union of two NamedTuple types, which is the
+# shape the comment above says breaks Enzyme.
+@inline function _ll_prob_kwargs(cb, saveat_use, tstops)
+    base = saveat_use === nothing ? (dense = true, tstops = tstops) :
+        (saveat = saveat_use, save_everystep = false, dense = false, tstops = tstops)
     return cb === nothing ? base : merge(base, (callback = cb,))
 end
 
-function _ll_build_prob_template(f!_use, u0, tspan, p_flat, cb, saveat_use)
-    kw = _ll_prob_kwargs(cb, saveat_use)
+function _ll_build_prob_template(f!_use, u0, tspan, p_flat, cb, saveat_use, tstops)
+    kw = _ll_prob_kwargs(cb, saveat_use, tstops)
     return ODEProblem{true, SciMLBase.FullSpecialize}(f!_use, u0, tspan, p_flat; kw...)
 end
 
@@ -3600,7 +3603,7 @@ function _ll_solve_de(dm::DataModel, idx::Int, θ, η_ind, cache::_LLCache, pre)
         if prob === nothing
             saveat_use = _ll_saveat(cache, idx, ind)
             prob = _ll_build_prob_template(
-                f!_use, u0, get_tspan(ind), p_flat, cb, saveat_use
+                f!_use, u0, get_tspan(ind), p_flat, cb, saveat_use, get_tstops(ind)
             )
             if cache.prob_templates !== nothing
                 cache.prob_templates[idx] = prob
@@ -3635,7 +3638,7 @@ function _ll_solve_de(dm::DataModel, idx::Int, θ, η_ind, cache::_LLCache, pre)
         )
         cbset = cb === nothing ? cbk : SciMLBase.CallbackSet(cb, cbk)
         prob = ODEProblem{true, SciMLBase.FullSpecialize}(
-            f!_use, u0_T, get_tspan(ind), p_flat; _ll_prob_kwargs(cbset, saveat_use)...
+            f!_use, u0_T, get_tspan(ind), p_flat; _ll_prob_kwargs(cbset, saveat_use, get_tstops(ind))...
         )
         sol = _ll_ode_solve_baked(cache, prob)
         SciMLBase.successful_retcode(sol) || return _ll_drop_solve(sol.retcode)
@@ -3680,7 +3683,7 @@ function _ll_solve_de(dm::DataModel, idx::Int, θ, η_ind, cache::_LLCache, pre)
         SciMLBase.CallbackSet(cb, cross_cbs...)
     end
     prob = ODEProblem{true, SciMLBase.FullSpecialize}(
-        f!_use, u0_T, get_tspan(ind), p_flat; _ll_prob_kwargs(cbset, saveat_use)...
+        f!_use, u0_T, get_tspan(ind), p_flat; _ll_prob_kwargs(cbset, saveat_use, get_tstops(ind))...
     )
     sol = _ll_ode_solve_baked(cache, prob)
     SciMLBase.successful_retcode(sol) || return _ll_drop_solve(sol.retcode)

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -3379,6 +3379,29 @@ function _warn_degenerate_soft_trees(dm::DataModel, θ_start)
     return nothing
 end
 
+# A fit whose objective never became finite (`Inf`, or the RE path's infeasibility wall)
+# leaves the optimizer on a flat surface, so the returned "estimates" are the starting
+# values. Name the individuals whose contribution is -Inf so the culprit is visible.
+function _warn_nonfinite_fit(dm::DataModel, θu, label::AbstractString)
+    ids = try
+        cache = build_ll_cache(dm; serialization = SciMLBase.EnsembleSerial())
+        cache1 = cache isa Vector ? first(cache) : cache
+        lp = get_laplace_cache(get_re_group_info(dm))
+        template = lp === nothing ? nothing : get_eta_template(lp)
+        η = template === nothing ? ComponentArray() : template
+        [
+            string(_individual_id(dm, i)) for i in eachindex(get_individuals(dm))
+                if !isfinite(_loglikelihood_individual(dm, i, θu, η, cache1))
+        ]
+    catch
+        String[]
+    end
+    culprit = isempty(ids) ? "" :
+        " Individual(s) with a -Inf log-likelihood contribution at the returned parameters ($(get_primary_id(dm))): $(join(ids, ", "))."
+    @warn "$(label): the objective never became finite, so the optimizer saw a constant value everywhere and stopped without moving. The returned parameters are the starting values, NOT estimates.$(culprit) Check for observations large enough to overflow the residual, and for out-of-domain `log`/`sqrt`/`^` in @formulas or @DifferentialEquation."
+    return nothing
+end
+
 @inline function _reset_numeric_warnings!()
     _WARNED_SOLVE_DROP[] = false
     _WARNED_NUMERIC_ERROR[] = false

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -3367,9 +3367,14 @@ function _warn_degenerate_soft_trees(dm::DataModel, θ_start)
         p isa SoftTreeParameters || continue
         v = θ_start === nothing ? p.value : getproperty(θ_start, name)
         n_leaf = p.n_output * 2^p.depth
-        leaves = @view v[(length(v) - n_leaf + 1):end]
-        all(isequal(first(leaves)), leaves) || continue
-        @warn "Soft tree $(name) starts with all $(n_leaf) leaf values equal to $(first(leaves)). The split parameters have exactly zero gradient there, so a gradient-based optimizer cannot train them and the tree stays a constant (absorbed into the surrounding model). Give the leaves a small zero-mean spread instead — e.g. `θ0.$(name)[(end - $(n_leaf) + 1):end] .= 0.05 .* [(-1.0)^i for i in 1:$(n_leaf)]` — which keeps the output at $(first(leaves)) while making the splits trainable." maxlog = 1
+        # Leaves are stored as `vec(leaf_values)` with shape (n_output, 2^depth), and the
+        # saddle is per output row: a row that is constant zeroes the split gradient even
+        # when other rows hold a different constant (#304).
+        leaves = reshape(
+            @view(v[(length(v) - n_leaf + 1):end]), p.n_output, 2^p.depth
+        )
+        any(o -> all(isequal(leaves[o, 1]), @view(leaves[o, :])), 1:p.n_output) || continue
+        @warn "Soft tree $(name) starts with constant leaf values within an output row (first leaf $(leaves[1, 1])). The split parameters have exactly zero gradient there, so a gradient-based optimizer cannot train them and the tree stays a constant (absorbed into the surrounding model). Give the leaves a small zero-mean spread instead — e.g. `θ0.$(name)[(end - $(n_leaf) + 1):end] .= 0.05 .* [(-1.0)^i for i in 1:$(n_leaf)]` — which keeps the output unchanged while making the splits trainable." maxlog = 1
     end
     return nothing
 end

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -3275,7 +3275,7 @@ function _row_random_effects_fill(
     return ComponentArray(vals, tmpl.axs)
 end
 
-mutable struct _LLCache{H, M, S, A, O, K, P, V, SA}
+mutable struct _LLCache{H, M, S, A, O, K, P, V, SA, EC}
     helpers::H
     model_funs::M
     solver_cfg::S
@@ -3285,6 +3285,7 @@ mutable struct _LLCache{H, M, S, A, O, K, P, V, SA}
     prob_templates::P
     vary_cache::V
     saveat_cache::SA
+    event_cbs::EC
     closed_form_plan::ClosedFormPlan
 end
 const LikelihoodCache = _LLCache
@@ -3298,6 +3299,7 @@ const LikelihoodCache = _LLCache
 @inline get_prob_templates(c::_LLCache) = c.prob_templates
 @inline get_vary_cache(c::_LLCache) = c.vary_cache
 @inline get_saveat_cache(c::_LLCache) = c.saveat_cache
+@inline get_event_cbs(c::_LLCache) = c.event_cbs
 @inline get_closed_form_plan(c::_LLCache) = c.closed_form_plan
 
 # `_is_hmm_dist` (the 7 HMM-family outcome types) is defined in
@@ -3534,7 +3536,7 @@ end
 # DE, forms u0 from `pre`, and extracts the event callback + infusion rates. The divergent
 # solve tails (flat-p templates + saveat + crossings vs dense) stay at each call site.
 @inline function _solve_preamble(
-        dm::DataModel, ind::Individual, θ, η_ind, pre, helpers, model_funs
+        dm::DataModel, ind::Individual, θ, η_ind, pre, helpers, model_funs, events
     )
     model = get_model(dm)
     const_cov = get_const_cov(ind)
@@ -3553,10 +3555,10 @@ end
     u0 = _initial_state_with_pre(model, θ, η_ind, const_cov, pre)
     cb = nothing
     infusion_rates = nothing
-    if get_callbacks(ind) !== nothing
-        _apply_initial_events!(u0, get_callbacks(ind))
-        cb = get_callback(get_callbacks(ind))
-        infusion_rates = get_infusion_rates(get_callbacks(ind))
+    if events !== nothing
+        _apply_initial_events!(u0, events)
+        cb = get_callback(events)
+        infusion_rates = get_infusion_rates(events)
     end
     return compiled, u0, cb, infusion_rates
 end
@@ -3564,8 +3566,9 @@ end
 function _ll_solve_de(dm::DataModel, idx::Int, θ, η_ind, cache::_LLCache, pre)
     model = get_model(dm)
     ind = get_individuals(dm)[idx]
+    events = cache.event_cbs === nothing ? nothing : cache.event_cbs[idx]
     compiled, u0, cb, infusion_rates = _solve_preamble(
-        dm, ind, θ, η_ind, pre, cache.helpers, cache.model_funs
+        dm, ind, θ, η_ind, pre, cache.helpers, cache.model_funs, events
     )
     # T must cover the vars eltype too (η/θ can enter the RHS without entering
     # u0) — pack once with the promoted type, reuse for template and remake.
@@ -3579,7 +3582,7 @@ function _ll_solve_de(dm::DataModel, idx::Int, θ, η_ind, cache::_LLCache, pre)
         saveat_use = _ll_saveat(cache, idx, ind)
         sol = _cf_dispatch_solve(
             model, compiled, u0_T, get_tspan(ind), saveat_use, plan,
-            get_callbacks(ind), cache.alg, cache.ode_args,
+            events, cache.alg, cache.ode_args,
             _ode_solve_kwargs(cache.solver_cfg.kwargs, cache.ode_kwargs, NamedTuple())
         )
         sol === nothing && return _ll_drop_solve(:closed_form_failed)
@@ -4144,6 +4147,15 @@ function _build_vary_cache_individual(
     return [_vary_row(vary, dyn_local, t_obs, j) for j in 1:n_rows]
 end
 
+# Each cache owns its event callbacks for the same reason it owns its interpolants:
+# `infusion_rates` is mutated in place during integration (#308). `nothing` when no
+# individual has events, so event-free models pay nothing.
+function _build_event_cache(dm::DataModel)
+    inds = get_individuals(dm)
+    any(ind -> get_callbacks(ind) !== nothing, inds) || return nothing
+    return [_private_event_callbacks(get_callbacks(ind)) for ind in inds]
+end
+
 function _build_vary_cache(dm::DataModel)
     return map(eachindex(get_individuals(dm))) do i
         ind = get_individuals(dm)[i]
@@ -4209,6 +4221,7 @@ function _build_ll_cache_single(
     end
     vary_cache = _build_vary_cache(dm)
     saveat_cache = _build_fit_saveat_cache(dm, force_saveat)
+    event_cbs = _build_event_cache(dm)
     return _LLCache(
         get_helper_funs(get_model(dm)),
         get_model_funs(get_model(dm)),
@@ -4219,6 +4232,7 @@ function _build_ll_cache_single(
         prob_templates,
         vary_cache,
         saveat_cache,
+        event_cbs,
         get_closed_form_plan(dm)
     )
 end

--- a/src/estimation/cv.jl
+++ b/src/estimation/cv.jl
@@ -150,6 +150,13 @@ function cross_validate(
     kind = _as_symbol(kind)
     n_folds >= 2 || error("n_folds must be ≥ 2, got $n_folds")
     kind ∈ (:id, :observation) || error("kind must be :id or :observation, got $kind")
+    # With `t0 = nothing` each DataModel resolves an individual's integration start from
+    # the rows it holds. An observation split can drop that individual's earliest row from
+    # the training fold but not from the scoring fold, so the initial condition would fire
+    # at different times in the fitted and the scored model (#304).
+    if kind == :observation && get_t0(dm) === nothing && get_de(get_model(dm)) !== nothing
+        error("cross_validate(kind = :observation) needs an explicit t0 on a model with a differential equation: with t0 = nothing each fold re-derives every individual's integration start from the rows it keeps, so the training and the scoring model would apply the initial conditions at different times. Rebuild the DataModel with t0 = <first observation time> (e.g. t0 = 0.0), or use kind = :id.")
+    end
     n = length(get_individuals(dm))
     if kind == :id
         n >= n_folds || error("n_folds ($n_folds) exceeds number of individuals ($n)")

--- a/src/estimation/focei.jl
+++ b/src/estimation/focei.jl
@@ -194,6 +194,12 @@ function _focei_paramcount(d::MvNormal)
     k = length(d)
     return k + k * (k + 1) ÷ 2
 end
+# The vech(Σ) block is the dispersion FOCE freezes; `_focei_params` orders the k mean
+# entries first, so the covariance coordinates start at k+1.
+function _focei_dispersion_indices(d::MvNormal)
+    k = length(d)
+    return collect((k + 1):(k + k * (k + 1) ÷ 2))
+end
 function _focei_expected_information(d::MvNormal)
     # Covariance block in closed form. With B_a = E_ij + E_ji (i<j) or E_ii (i==j),
     # tr(P E_rs P E_uv) = P[v,r]·P[s,u], so
@@ -612,6 +618,9 @@ function _focei_negH_batch_impl(
         if !interaction && any(d -> !isempty(_focei_dispersion_indices(d)), dists_b)
             m_b = _focei_prior_mean_b(dm, batch_info, θ_re, const_cache, cache)
             dists_m = _focei_obs_dists_batch(dm, batch_info, θ_re, m_b, const_cache, cache)
+            # An empty batch means the model failed to evaluate at the prior mean; the
+            # dispersion lookups below would index it out of bounds.
+            isempty(dists_m) && return fill(convert(T, NaN), nb, nb)
         end
         Hdata = _focei_data_term(J, dists_b, dists_m, interaction, T)
     end

--- a/src/estimation/ghquadrature.jl
+++ b/src/estimation/ghquadrature.jl
@@ -567,6 +567,8 @@ function _fit_model_scalar(
     )
 
     # ── Build result ─────────────────────────────────────────────────────────
+    isfinite(sol.objective) ||
+        _warn_nonfinite_fit(dm, θ_hat_u, string(nameof(typeof(method))))
     summary = FitSummary(
         sol.objective,
         sol.retcode == SciMLBase.ReturnCode.Success,

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -2894,10 +2894,13 @@ function _fit_laplace_family(
     # No feasible point was ever reached, so `sol.objective` is the infeasibility wall
     # and not a fit; the flat wall otherwise lets the optimizer report success (#247).
     infeasible_fit = wall_ref[] === nothing
+    fitted = resolve_fitted_parameters(layout, _θt_from_z(sol.u))
+    (infeasible_fit || !isfinite(sol.objective)) &&
+        _warn_nonfinite_fit(dm, fitted.untransformed, string(nameof(typeof(method))))
     summary = FitSummary(
         sol.objective,
         !infeasible_fit && sol.retcode == SciMLBase.ReturnCode.Success,
-        resolve_fitted_parameters(layout, _θt_from_z(sol.u)),
+        fitted,
         infeasible_fit ?
             "The Laplace objective was infeasible at every parameter tried; the reported value is an infeasibility wall, not a marginal likelihood. Check starting values, and whether a bounded-support random-effect distribution puts empirical Bayes estimates outside its support." :
             NamedTuple()

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -566,7 +566,7 @@ end
 function _em_seed_batch_b(
         dm::DataModel, info::REBatchInfo, θ0_u,
         const_cache::REConstantsCache, cache_init, rng::AbstractRNG,
-        re_names, bi::Int, method_label::String
+        re_names, bi, method_label::String
     )
     b_init = _re_prior_mean_b(dm, info, θ0_u, const_cache, cache_init, re_names)
     logf = _laplace_logf_batch(dm, info, θ0_u, b_init, const_cache, cache_init)
@@ -588,6 +588,25 @@ function _em_seed_batch_b(
         "$(method_label): Cannot find valid initial random effects for batch $bi after 10 tries. " *
             "Initial fixed-effect parameters likely produce -Inf log-likelihood. " *
             "Try different starting values."
+    )
+end
+
+# Guard for the native samplers' own initial draw. An unchecked prior draw with a
+# non-finite log-joint deadlocks the chain: the acceptance ratio becomes NaN, so no
+# proposal is ever accepted and the M-step is skipped every iteration. Returns `b`
+# unchanged (no extra RNG draws) whenever it is already finite.
+function _em_vet_init_b(
+        dm::DataModel, info::REBatchInfo, θ_re,
+        b::Vector{Float64}, const_cache::REConstantsCache, cache,
+        rng::AbstractRNG, re_names, method_label::String
+    )
+    isempty(b) && return b
+    isfinite(_laplace_logf_batch(dm, info, θ_re, b, const_cache, cache)) && return b
+    return Vector{Float64}(
+        _em_seed_batch_b(
+            dm, info, θ_re, const_cache, cache, rng, re_names,
+            "(sampler init)", method_label
+        )
     )
 end
 

--- a/src/estimation/mle.jl
+++ b/src/estimation/mle.jl
@@ -153,9 +153,12 @@ function _fit_no_re(
         OptimizationProblem(optf, z0)
     sol = Optimization.solve(prob, method.optimizer; method.optim_kwargs...)
 
+    fitted = resolve_fitted_parameters(layout, _θt_from_z(sol.u))
+    isfinite(sol.objective) ||
+        _warn_nonfinite_fit(dm, fitted.untransformed, string(nameof(typeof(method))))
     summary = FitSummary(
         sol.objective, sol.retcode == SciMLBase.ReturnCode.Success,
-        resolve_fitted_parameters(layout, _θt_from_z(sol.u)), NamedTuple()
+        fitted, NamedTuple()
     )
     diagnostics = FitDiagnostics(
         (;), (optimizer = method.optimizer,), (retcode = sol.retcode,), NamedTuple()

--- a/src/estimation/pooled.jl
+++ b/src/estimation/pooled.jl
@@ -1169,6 +1169,14 @@ function _fit_pooled(
             "refreeze_check=:refit or force_free."
     end
 
+    # The up-front gate only sees user `constants`; auto-freezing can demote the last
+    # prior-bearing parameter, leaving the MAP term a constant offset (a plain Pooled fit).
+    if method isa PooledMap && !_has_fixed_priors(fe, merged_constants)
+        @warn "PooledMap: every prior-bearing fixed effect was frozen, so the MAP " *
+            "penalty is constant and this fit is equivalent to Pooled(). Use " *
+            "force_free to keep a prior-bearing parameter free."
+    end
+
     η_hat = _compute_pooled_etas(dm, θ_hat_u, strategies)
 
     re_names = get_re_names(get_laplace_cache(get_re_group_info(dm)))
@@ -1401,6 +1409,7 @@ function _fit_model(
         "PooledMap() requires priors on free fixed effects. Define priors in " *
             "@fixedEffects (e.g. RealNumber(...; prior=Normal(...))) or use Pooled() instead."
     )
+    _warn_unbounded_prior_at_bounds(fe)
 
     return _fit_pooled(
         dm, method;

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -3939,7 +3939,15 @@ function _fit_model(
 
         # Var lb clamp (post M-step)
         if !isempty(var_lb_targets)
-            θu_new = _saem_apply_var_lb(θu_new, var_lb_targets, var_lb_eff)
+            θu_new_clamped = _saem_apply_var_lb(θu_new, var_lb_targets, var_lb_eff)
+            if θu_new_clamped !== θu_new
+                θu_new = θu_new_clamped
+                θt_full = transform(θu_new)
+                for name in base_free_names
+                    setproperty!(θt_free, name, getproperty(θt_full, name))
+                end
+                θ_prev_new = copy(θt_free)
+            end
         end
 
         θ_full_vec = θt_full

--- a/src/estimation/saemix_mh.jl
+++ b/src/estimation/saemix_mh.jl
@@ -345,6 +345,8 @@ function _saemixmh_init_state(
     levels = _saemixmh_build_levels(dm, batch_info, re_names)
     b = zeros(Float64, nb)
     _saemixmh_init_b!(b, levels, dm, θ, const_cache, cache, rng, re_names)
+    b_ok = _em_vet_init_b(dm, batch_info, θ_re, b, const_cache, cache, rng, re_names, "SaemixMH")
+    b_ok === b || copyto!(b, b_ok)
     indiv_ll = Vector{Float64}(undef, n_inds)
     _saemixmh_init_indiv_ll!(indiv_ll, dm, batch_info, θ_re, const_cache, cache, b)
     level_plp = Vector{Float64}(undef, length(levels))

--- a/src/model/Covariates.jl
+++ b/src/model/Covariates.jl
@@ -14,6 +14,10 @@ abstract type AbstractCovariate end
 function _check_covariate_columns(columns, what::AbstractString)
     isempty(columns) &&
         error("$(what) needs at least one column; got an empty vector.")
+    # Duplicates otherwise surface as a raw `duplicate field name in NamedTuple` when the
+    # per-row/per-individual value is built (#309).
+    allunique(columns) ||
+        error("$(what) needs distinct columns; got repeated column(s) $(join(unique([c for c in columns if count(==(c), columns) > 1]), ", ")).")
     return nothing
 end
 
@@ -161,6 +165,18 @@ const ALLOWED_INTERPOLATIONS = Set(
         ConstantInterpolation,
         SmoothedConstantInterpolation,
         LinearInterpolation,
+        QuadraticInterpolation,
+        LagrangeInterpolation,
+        QuadraticSpline,
+        CubicSpline,
+        AkimaInterpolation,
+    ]
+)
+
+# Repeated node times make these interpolants return NaN everywhere (or throw a
+# SingularException); the constant and linear ones tolerate them (#309).
+const _DUP_TIME_UNSAFE_INTERPOLATIONS = Set(
+    [
         QuadraticInterpolation,
         LagrangeInterpolation,
         QuadraticSpline,

--- a/src/model/PreDE.jl
+++ b/src/model/PreDE.jl
@@ -166,11 +166,18 @@ macro preDifferentialEquation(block)
     # function as `sym in Set([...])`, allocating a fresh Set on every builder
     # invocation; `calculate_prede` runs per individual per objective evaluation.
     # Mirrors the identical fix in RandomEffects.jl.)
+    # An unresolvable symbol used to fall through to a bare `UndefVarError` at the first
+    # objective evaluation (#309). Pre-DE variables assigned in this same block resolve
+    # from the generated assignments below, so they keep the fall-through.
+    _unknown_sym = sym -> sym in names ? :() :
+        :(error($("Unknown symbol $(sym) in preDifferentialEquation.")))
     binds_vars = [
         if sym in prop_syms
                 quote
                     if hasproperty(constant_features_i, $(QuoteNode(sym)))
                         $(sym) = getproperty(constant_features_i, $(QuoteNode(sym)))
+                else
+                        $(_unknown_sym(sym))
                 end
                 end
         else
@@ -181,6 +188,8 @@ macro preDifferentialEquation(block)
                         $(sym) = getproperty(random_effects, $(QuoteNode(sym)))
                 elseif hasproperty(fixed_effects, $(QuoteNode(sym)))
                         $(sym) = getproperty(fixed_effects, $(QuoteNode(sym)))
+                else
+                        $(_unknown_sym(sym))
                 end
                 end
         end

--- a/src/model/crossing.jl
+++ b/src/model/crossing.jl
@@ -105,6 +105,14 @@ end
     a = integrator.tprev
     b = integrator.t
     va = ForwardDiff.value(integrator(a; idxs = idx)) - cv
+    vb = ForwardDiff.value(integrator(b; idxs = idx)) - cv
+    # The step interpolant is smooth, so if it does not bracket the level the crossing is
+    # a jump (a coincident dose/reset) at `integrator.t` -- report it, no IFT correction.
+    if (vb < 0) == (va < 0)
+        ca.ref[] = oftype(ca.ref[], b)
+        ca.fired[] = true
+        return nothing
+    end
     @inbounds for _ in 1:40                                 # bisection on the step interpolant
         m = 0.5 * (a + b)
         vm = ForwardDiff.value(integrator(m; idxs = idx)) - cv
@@ -150,6 +158,12 @@ function _crossing_time_from_sol(sol, idx::Int, c, tmax)
     end
     found || return oftype(0.5 * (ts[1] + ts[1]) - cv, tmax)
     va = ForwardDiff.value(sol(a; idxs = idx)) - cv
+    vb = ForwardDiff.value(sol(b; idxs = idx)) - cv
+    # Same rule as `_CrossingAffect`: a sign change the smooth interpolant does not
+    # bracket (a duplicated `sol.t` entry) is a jump at `b`.
+    if b <= a || (vb < 0) == (va < 0)
+        return oftype(sol.u[1][idx] - c, b)
+    end
     @inbounds for _ in 1:40                                 # bisection on the step interpolant
         m = 0.5 * (a + b)
         vm = ForwardDiff.value(sol(m; idxs = idx)) - cv

--- a/src/plotting/plotting.jl
+++ b/src/plotting/plotting.jl
@@ -371,8 +371,9 @@ function _solve_dense_individual(
     )
     model = get_model(dm)
     pre = calculate_prede(model, θ, η_ind, get_const_cov(ind))
+    events = _private_event_callbacks(get_callbacks(ind))
     compiled, u0, cb, infusion_rates = _solve_preamble(
-        dm, ind, θ, η_ind, pre, get_helper_funs(model), get_model_funs(model)
+        dm, ind, θ, η_ind, pre, get_helper_funs(model), get_model_funs(model), events
     )
     f! = get_de_f!(get_de(model))
     infusion_rates === nothing || (f! = _plot_with_infusion(f!, infusion_rates))
@@ -382,7 +383,7 @@ function _solve_dense_individual(
         cf_alg = _resolve_ode_alg(solver_cfg.alg)
         sol = _cf_dispatch_solve(
             model, compiled, u0, get_tspan(ind), nothing, plan,
-            get_callbacks(ind), cf_alg, solver_cfg.args,
+            events, cf_alg, solver_cfg.args,
             _ode_solve_kwargs(solver_cfg.kwargs, ode_kwargs, NamedTuple())
         )
         sol !== nothing && return sol, compiled

--- a/src/uq/common.jl
+++ b/src/uq/common.jl
@@ -384,18 +384,29 @@ function _project_psd_covariance(cov_mat::Matrix{Float64})
     V = Matrix{Float64}(0.5 .* (V .+ V'))
     min_raw = isempty(vals_raw) ? 0.0 : minimum(vals_raw)
     min_used = isempty(vals) ? 0.0 : minimum(vals)
-    # Clipping a negative eigenvalue to zero shrinks the variance along that direction, so a
-    # weakly identified parameter can come out looking precise. Never do that silently
-    # (issue #173).
+    # Clipping shrinks the variance along that direction, so never do it silently (#173),
+    # and say so louder when the negative is far beyond roundoff relative to the matrix
+    # scale: that is numerical error, not a rounding repair (#306).
+    scale = isempty(vals_raw) ? 0.0 : maximum(abs, vals_raw)
+    min_rel = scale > 0.0 ? min_raw / scale : 0.0
     n_clipped > 0 &&
         @warn "Wald covariance was projected to the nearest PSD matrix: $(n_clipped) " *
-        "negative eigenvalue(s) clipped to zero (most negative $(min_raw)). Standard " *
-        "errors along those directions are shrunk toward zero and understate the true " *
-        "uncertainty; prefer method = :profile / :mcmc for those parameters." maxlog = 3
+        "negative eigenvalue(s) clipped to zero (most negative $(min_raw), " *
+        "$(abs(min_rel)) of the matrix scale). " *
+        (
+        min_rel < -1.0e-8 ?
+            "That is far beyond roundoff: the estimate is not at a local minimum, or the " *
+            "Hessian is (near-)singular, so this covariance is dominated by numerical " *
+            "error and its standard errors are not usable. " :
+            "Standard errors along those directions are shrunk toward zero and understate " *
+            "the true uncertainty. "
+    ) *
+        "Prefer method = :profile / :mcmc for those parameters." maxlog = 3
     diag = (;
         vcov_projected = n_clipped > 0,
         vcov_min_eig_raw = min_raw,
         vcov_min_eig_used = min_used,
+        vcov_min_eig_rel = min_rel,
         vcov_n_eigs_clipped = n_clipped,
     )
     return V, diag

--- a/src/uq/mcmc.jl
+++ b/src/uq/mcmc.jl
@@ -225,18 +225,46 @@ function _compute_uq_chain(
     intervals_n = _intervals_from_draws(draws_n, level)
     Vn = _cov_from_draws(draws_n)
 
+    # The chain is stored on the natural scale, so the transformed-scale summaries have to
+    # be built by pushing every draw forward (#306). Only the monotone scalar kinds have a
+    # per-coordinate forward map; a structured block (cholesky/expm/lie/stickbreak/
+    # lograterows) is reconstructed from its whole natural value, which the chain draws do
+    # not carry per coordinate, so those coordinates stay on the natural scale and are
+    # listed in the diagnostics.
+    active_kinds = _flat_transform_kinds_for_free(fe, free_names)[active_idx]
+    draws_t = copy(draws_n)
+    natural_only = Symbol[]
+    for j in eachindex(active_kinds)
+        if _is_monotone_scalar_kind(active_kinds[j])
+            @views draws_t[:, j] .= _scalar_forward.(active_kinds[j], draws_n[:, j])
+        else
+            push!(natural_only, active_names[j])
+        end
+    end
+    isempty(natural_only) ||
+        @warn "Chain UQ: these coordinates have no per-coordinate forward transform and are reported on the natural scale for scale = :transformed." parameters = unique(
+        natural_only
+    ) maxlog = 1
+    diag = merge(
+        diag, (; transformed_scale_natural_only = natural_only, coordinate_transforms = active_kinds)
+    )
+
+    est_t = vec(mean(draws_t; dims = 1))
+    intervals_t = _intervals_from_draws(draws_t, level)
+    Vt = _cov_from_draws(draws_t)
+
     return UQResult(
         :chain,
         _method_symbol(method),
         active_names,
         nothing,
-        copy(est_n),
-        copy(est_n),
+        est_t,
+        est_n,
+        intervals_t,
         intervals_n,
-        intervals_n,
-        copy(Vn),
-        copy(Vn),
-        copy(draws_n),
+        Vt,
+        Vn,
+        draws_t,
         copy(draws_n),
         diag
     )

--- a/src/uq/uq.jl
+++ b/src/uq/uq.jl
@@ -152,6 +152,16 @@ function compute_uq(
     if backend == :wald
         vcov in (:hessian, :sandwich) ||
             error("For Wald UQ, vcov must be :hessian or :sandwich.")
+        # A non-finite objective means the likelihood short-circuits to a constant, which
+        # gives ForwardDiff an exactly zero Hessian and hence zero standard errors (#306).
+        obj_src = get_objective(res)
+        isfinite(obj_src) ||
+            error(
+            "Wald UQ unavailable: the source fit's objective is $(obj_src), so the " *
+                "estimate is not at a finite local optimum and its Hessian carries no " *
+                "information. Fix the fit (check for non-finite likelihood contributions, " *
+                "e.g. out-of-range data) before quantifying its uncertainty."
+        )
     end
 
     if backend == :chain

--- a/src/uq/wald.jl
+++ b/src/uq/wald.jl
@@ -94,6 +94,43 @@ function _wald_meat_diag(B::Matrix{Float64}, H::AbstractMatrix, n_cluster::Int)
         "are unusable (too small). Use vcov = :hessian." n_cluster meat_rank
     return (; n_cluster = n_cluster, meat_rank = meat_rank, meat_degenerate = degenerate)
 end
+
+# Coordinate transforms that are monotone increasing scalar maps, so `_scalar_forward` /
+# `_scalar_inverse` apply per coordinate. `:elementwise` masks are already expanded into
+# these by `_flat_transform_kinds_for_free`.
+@inline function _is_monotone_scalar_kind(kind::Symbol)
+    return kind === :identity || kind === :log || kind === :logit
+end
+
+# Exact natural-scale variances where they exist: identity copies the transformed one,
+# `:log` uses the lognormal closed form. Rows/columns are rescaled by the same factor so
+# the drawn correlations - and with them PSD-ness - are preserved.
+function _wald_closed_form_natural_vcov(
+        Vn::Matrix{Float64}, est_t::Vector{Float64}, Vt::Matrix{Float64},
+        active_kinds::Vector{Symbol}
+    )
+    p = size(Vn, 1)
+    r = ones(Float64, p)
+    for j in eachindex(active_kinds)
+        j <= p || break
+        kind = active_kinds[j]
+        s2 = Vt[j, j]
+        v_new = if kind === :identity
+            s2
+        elseif kind === :log
+            expm1(s2) * exp(2 * est_t[j] + s2)
+        else
+            continue
+        end
+        v_old = Vn[j, j]
+        (isfinite(v_new) && v_new >= 0 && v_old > 0) || continue
+        r[j] = sqrt(v_new / v_old)
+    end
+    all(isone, r) && return Vn
+    Vn2 = Diagonal(r) * Vn * Diagonal(r)
+    return Matrix{Float64}(0.5 .* (Vn2 .+ Vn2'))
+end
+
 # Shared Wald finalize tail: project the raw covariance to PSD, draw from the Gaussian
 # approximation, map draws back to the natural scale, extend any stickbreak coordinates,
 # and assemble the UQResult. `extra_diag` carries method-specific diagnostics (e.g.
@@ -145,8 +182,21 @@ function _finalize_wald_uqresult(
     # inspecting the draws should see the overflow rather than find rows silently missing.
     draws_n_fin = n_nonfinite > 0 ? draws_n[finite_rows, :] : draws_n
 
-    intervals_t = _intervals_from_draws(draws_t, level)
+    # Closed forms replace the draw quantiles wherever they exist (#306): the transformed
+    # interval is exactly `est ± z*SE`, and a monotone scalar transform carries those
+    # endpoints to the natural scale exactly (quantiles are equivariant). `:identity`,
+    # `:log` and `:logit` are all increasing, so the endpoints keep their order. Structured
+    # blocks (cholesky/expm/lie/stickbreak/lograterows) have no per-coordinate map and stay
+    # draw-based.
+    z = quantile(Normal(), 1.0 - (1.0 - level) / 2)
+    se_t = [sqrt(max(Vt[i, i], 0.0)) for i in axes(Vt, 1)]
+    intervals_t = UQIntervals(level, est_t .- z .* se_t, est_t .+ z .* se_t)
     intervals_n = _intervals_from_draws(draws_n_fin, level)
+    for j in eachindex(active_kinds)
+        _is_monotone_scalar_kind(active_kinds[j]) || continue
+        intervals_n.lower[j] = _scalar_inverse(active_kinds[j], intervals_t.lower[j])
+        intervals_n.upper[j] = _scalar_inverse(active_kinds[j], intervals_t.upper[j])
+    end
 
     ext = _extend_natural_stickbreak(
         fe, free_names, active_names, active_kinds,
@@ -163,6 +213,7 @@ function _finalize_wald_uqresult(
             for i in 1:size(Vn_src, 1)
     ]
     Vn_use = _cov_from_draws(all(Vn_rows) ? Vn_src : Vn_src[Vn_rows, :])
+    Vn_use = _wald_closed_form_natural_vcov(Vn_use, est_t, Vt, active_kinds)
 
     diag = merge(
         (;

--- a/src/uq/wald.jl
+++ b/src/uq/wald.jl
@@ -1,34 +1,69 @@
 using LinearAlgebra
 using Random
 
+# Above this condition number `inv(H)` keeps fewer than ~4 significant digits and can
+# return a roundoff-SIGNED enormous eigenvalue that the PSD projection clips (#306).
+const _WALD_INV_MAX_COND = 1.0e-4 / eps(Float64)
+
+# Parameters loading most on the given (near-)null directions - the ones that are not
+# identified by the data.
+function _wald_weak_names(F::SVD, weak::AbstractVector{Int}, active_names)
+    length(active_names) == length(F.S) || return collect(active_names)
+    return unique([active_names[argmax(abs.(view(F.V, :, j)))] for j in weak])
+end
+
 # Pseudo-inverse of the objective Hessian for the Wald "bread" matrix.
 #
 # `pinv`'s default rank tolerance maps a near-zero singular value to 0 rather than to a
 # large reciprocal, so a weakly identified direction came out with near-zero variance -
 # falsely precise, the exact opposite of what a standard error must convey (issue #173).
-# Keep every nonzero singular value so such a direction yields a LARGE variance, and only
-# drop the exactly singular ones (which is what makes this usable where `inv` throws).
+# Keep every nonzero singular value so such a direction yields a LARGE variance, and floor
+# the reciprocal of the (near-)singular ones at the conditioning tolerance.
 function _wald_pinv(H::AbstractMatrix, active_names)
     F = svd(H)
     n = length(F.S)
     smax = n == 0 ? 0.0 : maximum(F.S)
-    tol = eps(Float64) * smax * maximum(size(H))
-    weak = findall(<(tol), F.S)
+    tol_raw = eps(Float64) * smax * maximum(size(H))
+    tol = tol_raw > 0 ? tol_raw : eps(Float64)
+    weak = findall(<=(tol), F.S)
     if !isempty(weak)
-        # Name the parameters loading most on the (near-)null directions - those are the
-        # ones whose reported SE is now large because they are not identified by the data.
-        loads = length(active_names) == n ?
-            [active_names[argmax(abs.(view(F.V, :, j)))] for j in weak] : active_names
         @warn "Wald covariance: the objective Hessian is (near-)singular in " *
             "$(length(weak)) direction(s); the standard errors for these parameters are " *
             "large because they are only weakly identified. Consider reparameterizing or " *
-            "fixing them via `constants=`." parameters = unique(loads) smallest_singular_value = minimum(F.S)
+            "fixing them via `constants=`." parameters = _wald_weak_names(F, weak, active_names) smallest_singular_value = minimum(F.S)
     end
-    Sinv = [s > 0 ? inv(s) : zero(s) for s in F.S]
+    # An exactly zero singular value is the limit of the near-zero case: flooring at `tol`
+    # keeps its variance large instead of zero, as the warning above promises (#306).
+    Sinv = [s > tol ? inv(s) : inv(tol) for s in F.S]
     return F.V * Diagonal(Sinv) * F.U'
 end
 
 function _wald_bread(H::AbstractMatrix, pseudo_inverse::Bool, active_names)
+    F = svd(H)
+    smax = isempty(F.S) ? 0.0 : maximum(F.S)
+    # Zero curvature is no information, not infinite precision. ForwardDiff returns an
+    # exactly zero Hessian whenever the objective short-circuits to `Inf`, and that passes
+    # every finiteness guard while inverting to zero standard errors (issue #306).
+    smax > 0 ||
+        error(
+        "Wald covariance unavailable: the objective Hessian at the estimate is zero, so " *
+            "the objective carries no curvature (typically a non-finite likelihood that " *
+            "short-circuits to a constant). Check the fit converged to a finite objective."
+    )
+    if !pseudo_inverse
+        # `inv` does not throw for a Hessian that is singular only to machine precision; it
+        # returns a covariance whose enormous eigenvalue has a roundoff-decided sign. Refuse
+        # instead, on the same conditioning test the pseudo-inverse branch uses (#306).
+        smin = minimum(F.S)
+        smin <= smax / _WALD_INV_MAX_COND &&
+            error(
+            "Failed to invert Hessian for Wald covariance: it is numerically singular " *
+                "(condition number $(smax / smin)), so the covariance would be dominated by " *
+                "roundoff. Parameter(s) $(join(_wald_weak_names(F, findall(<=(smax / _WALD_INV_MAX_COND), F.S), active_names), ", ")) are only weakly " *
+                "identified. Consider pseudo_inverse=true, reparameterizing, or fixing them " *
+                "via constants."
+        )
+    end
     bread = try
         pseudo_inverse ? _wald_pinv(H, active_names) : inv(H)
     catch err
@@ -42,6 +77,23 @@ function _wald_bread(H::AbstractMatrix, pseudo_inverse::Bool, active_names)
     return Matrix{Float64}(0.5 .* (bread .+ bread'))
 end
 
+# Cluster-robust sandwich meat diagnostics. At a converged optimum the per-cluster scores
+# sum to zero, so with one cluster - or near-duplicate clusters - the meat collapses to
+# (numerically) zero and the sandwich reports standard errors far TIGHTER than the Hessian
+# ones, with nothing in the output to show it (issue #306).
+function _wald_meat_diag(B::Matrix{Float64}, H::AbstractMatrix, n_cluster::Int)
+    n_active = size(B, 1)
+    meat_rank = rank(B)
+    meat_scale = opnorm(B)
+    degenerate = meat_rank < n_active || meat_scale <= 1.0e-8 * opnorm(H)
+    degenerate &&
+        @warn "Sandwich covariance is degenerate for this fit: the cluster-robust meat " *
+        "has rank $(meat_rank) for $(n_active) parameter(s) over $(n_cluster) " *
+        "cluster(s). Per-cluster scores sum to zero at the optimum, so few or " *
+        "near-duplicate clusters collapse the meat and the resulting standard errors " *
+        "are unusable (too small). Use vcov = :hessian." n_cluster meat_rank
+    return (; n_cluster = n_cluster, meat_rank = meat_rank, meat_degenerate = degenerate)
+end
 # Shared Wald finalize tail: project the raw covariance to PSD, draw from the Gaussian
 # approximation, map draws back to the natural scale, extend any stickbreak coordinates,
 # and assemble the UQResult. `extra_diag` carries method-specific diagnostics (e.g.
@@ -322,6 +374,7 @@ function _compute_uq_wald_no_re(
 
     bread = _wald_bread(H_active, pseudo_inverse, active_names)
 
+    meat_diag = NamedTuple()
     Vt_raw = if vcov == :hessian
         copy(bread)
     elseif vcov == :sandwich
@@ -353,6 +406,7 @@ function _compute_uq_wald_no_re(
             B .+= g * g'
         end
         B = 0.5 .* (B .+ B')
+        meat_diag = _wald_meat_diag(B, H_active, length(get_individuals(dm)))
         M = bread * B * bread'
         Matrix{Float64}(0.5 .* (M .+ M'))
     else
@@ -362,7 +416,7 @@ function _compute_uq_wald_no_re(
     return _finalize_wald_uqresult(
         fe, θ_hat_t, θ_hat_u, free_names, active_idx,
         active_names, active_kinds, _θu_from_active, Vt_raw, backend_used, vcov,
-        pseudo_inverse, n_draws, level, rng, _method_symbol(method), NamedTuple()
+        pseudo_inverse, n_draws, level, rng, _method_symbol(method), meat_diag
     )
 end
 
@@ -512,6 +566,7 @@ function _compute_uq_wald_re(
 
     bread = _wald_bread(H_active, pseudo_inverse, active_names)
 
+    meat_diag = NamedTuple()
     Vt_raw = if vcov == :hessian
         copy(bread)
     elseif vcov == :sandwich
@@ -553,6 +608,7 @@ function _compute_uq_wald_re(
             B .+= g * g'
         end
         B = 0.5 .* (B .+ B')
+        meat_diag = _wald_meat_diag(B, H_active, length(batch_infos))
         M = bread * B * bread'
         Matrix{Float64}(0.5 .* (M .+ M'))
     else
@@ -563,6 +619,6 @@ function _compute_uq_wald_re(
         fe, θ_hat_t, θ_hat_u, free_names, active_idx,
         active_names, active_kinds, _θu_from_active, Vt_raw, backend_used, vcov,
         pseudo_inverse, n_draws, level, rng, _method_symbol(source_method),
-        (; approximation_method = _method_symbol(approx_method))
+        merge((; approximation_method = _method_symbol(approx_method)), meat_diag)
     )
 end

--- a/src/utils/GeneralUtils.jl
+++ b/src/utils/GeneralUtils.jl
@@ -6,6 +6,7 @@ using ForwardDiff
 import DiffEqBase
 import Roots
 import DataFrames
+import DataInterpolations
 
 # Public symbol-valued options also accept the string spelling, so the Python/R
 # bindings (and serialized federated options) can pass them through unchanged.
@@ -126,5 +127,7 @@ end
     return err isa LinearAlgebra.PosDefException ||
         err isa LinearAlgebra.SingularException ||
         err isa DomainError || err isa ArgumentError ||
-        err isa Roots.ConvergenceFailed
+        err isa Roots.ConvergenceFailed ||
+        err isa DataInterpolations.LeftExtrapolationError ||
+        err isa DataInterpolations.RightExtrapolationError
 end

--- a/src/utils/Splines.jl
+++ b/src/utils/Splines.jl
@@ -59,7 +59,10 @@ end
 # ForwardDiff/Enzyme compatible.
 function _bspline_nonzero(x::Real, knots::AbstractVector{<:Real}, degree::Int)
     m = length(knots)
-    mu = x == knots[end] ? m - 1 : searchsortedlast(knots, x)
+    # Clamp to the last existing span: at `x == knots[end]` (and inside a repeated
+    # right boundary) `searchsortedlast` runs past the last basis function, which made
+    # every basis value zero there (#304).
+    mu = min(searchsortedlast(knots, x), m - degree - 1)
     T = float(promote_type(typeof(x), eltype(knots)))
     prev = zeros(T, degree + 1)   # level k-1: prev[r] = N_{mu-(k-1)+r-1, k-1}
     cur = zeros(T, degree + 1)    # level k:   cur[r]  = N_{mu-k+r-1, k}

--- a/test/covariates_tests.jl
+++ b/test/covariates_tests.jl
@@ -117,6 +117,11 @@ end
         z = CovariateVector([:a, :b, :c])
     end
     @test !haskey(cov3.interpolations, :z)
+
+    # Duplicate columns used to surface as a raw NamedTuple error at build time (#309).
+    @test_throws ErrorException CovariateVector([:z1, :z1])
+    @test_throws ErrorException ConstantCovariateVector([:z1, :z1])
+    @test_throws ErrorException DynamicCovariateVector([:z1, :z1])
 end
 
 @testset "Covariates macro rewriting" begin

--- a/test/crossing_tests.jl
+++ b/test/crossing_tests.jl
@@ -69,6 +69,39 @@ end
     @test isapprox(accs[2].rv, -0.5; atol = 1.0e-6)
 end
 
+# A bolus at t = 0.5 jumps x from 0.5 to 1.5 across the level: the crossing IS the jump,
+# so both paths must report the dose time itself and not extrapolate off the smooth
+# pre-jump interpolant (#308).
+@testset "crossing at a coincident dose" begin
+    df = DataFrame(
+        ID = [1, 1, 1, 1],
+        t = [0.0, 0.5, 1.0, 2.0],
+        y = [0.0, missing, 1.5, 2.5],
+        zt = [missing, missing, missing, 0.5],
+        rz = [missing, missing, missing, 0.0],
+        EVID = [0, 1, 0, 0],
+        AMT = [0.0, 1.0, 0.0, 0.0],
+        RATE = zeros(4),
+        CMT = [1, 1, 1, 1]
+    )
+    dm = DataModel(
+        _crossing_model(), df; primary_id = :ID, time_col = :t, evid_col = :EVID,
+        amt_col = :AMT, rate_col = :RATE, cmt_col = :CMT
+    )
+    θ = get_θ0_untransformed(dm.model.fixed.fixed)
+    ηz = NoLimits._default_random_effects_from_dm(dm, NamedTuple(), θ)
+    ind = dm.individuals[1]
+    pre = NoLimits.calculate_prede(dm.model, θ, ηz[1], ind.const_cov)
+    cache = NoLimits._build_ll_cache_single(dm)
+    acc_ll = NoLimits._ll_solve_de(dm, 1, θ, ηz[1], cache, pre)
+    sol, comp = NoLimits._solve_dense_individual(dm, ind, θ, ηz[1])
+    acc_pl = NoLimits._sol_accessors_with_crossings(
+        dm.model, sol, comp, θ, ηz[1], ind.const_cov
+    )
+    @test isapprox(acc_ll.tc, 0.5; atol = 1.0e-6)
+    @test isapprox(acc_pl.tc, 0.5; atol = 1.0e-6)
+end
+
 @testset "crossing_rootval likelihood is finite and AD-differentiable" begin
     dm = _crossing_dm()
     θ = get_θ0_untransformed(dm.model.fixed.fixed)

--- a/test/data_model_ode_tests.jl
+++ b/test/data_model_ode_tests.jl
@@ -207,6 +207,8 @@ end
     dm = DataModel(model_saveat, df; primary_id = :ID, time_col = :t)
 
     ind = get_individual(dm, 1)
+    # The covariate knots are kinks in the RHS and are handed to the solver (#309).
+    @test NoLimits.get_tstops(ind) == [0.0, 0.5, 1.0]
     θ = get_θ0_untransformed(model_saveat.fixed.fixed)
     η = ComponentArray()
     const_covariates_i = NamedTuple()
@@ -389,6 +391,33 @@ end
 
     model_saveat = set_solver_config(model; saveat_mode = :saveat)
     dm = DataModel(model_saveat, df; primary_id = :ID, time_col = :t)
+
+    # NaN in a *vector* covariate column used to slip past the finiteness guard, which
+    # iterated the synthetic `x_1`/`x_2` flat names instead of Age/BMI (#309).
+    df_nan = copy(df)
+    df_nan.Age = [NaN, NaN, NaN, 45.0, 45.0, 45.0]
+    err_nan = try
+        DataModel(model_saveat, df_nan; primary_id = :ID, time_col = :t)
+        nothing
+    catch e
+        e
+    end
+    @test err_nan isa ErrorException
+    @test occursin("Column Age contains the non-finite value", err_nan.msg)
+
+    # A repeated row time NaN-poisons the CubicSpline interpolant over its whole
+    # support, so it is rejected at construction naming the covariate (#309).
+    df_dup = copy(df)
+    df_dup.t = [0.0, 0.5, 0.5, 0.0, 0.5, 1.0]
+    err_dup = try
+        DataModel(model_saveat, df_dup; primary_id = :ID, time_col = :t)
+        nothing
+    catch e
+        e
+    end
+    @test err_dup isa ErrorException
+    @test occursin("repeated time", err_dup.msg)
+    @test occursin("Dynamic covariate w", err_dup.msg)
 
     ind = get_individual(dm, 1)
     θ = get_θ0_untransformed(model_saveat.fixed.fixed)

--- a/test/data_model_tests.jl
+++ b/test/data_model_tests.jl
@@ -1316,7 +1316,7 @@ end
         end
 
         @formulas begin
-            y ~ Normal(x1(t - 0.5), σ)
+            y ~ Normal(x1(t - 0.5) + x1(t + 0.5), σ)
         end
     end
 
@@ -1340,6 +1340,24 @@ end
     @test occursin("dynamic covariate support", err.msg)
     @test occursin("-0.5", err.msg)
     @test occursin("[0.5, 2.0]", err.msg)
+
+    # The mirrored upper-bound guard: the +0.5 offset pushes the integration past the
+    # covariate support, which used to escape as a raw extrapolation error (#309).
+    df_up = DataFrame(
+        ID = [1, 1, 1],
+        t = [0.0, 1.0, 2.0],
+        w1 = [1.0, 1.2, 1.4],
+        y = [1.0, 1.1, 1.2]
+    )
+    err_up = try
+        DataModel(model_saveat, df_up; primary_id = :ID, time_col = :t)
+        nothing
+    catch e
+        e
+    end
+    @test err_up isa ErrorException
+    @test occursin("later than the dynamic covariate support", err_up.msg)
+    @test occursin("2.5", err_up.msg)
 end
 
 @testset "DataModel pairing creates multiple batches" begin

--- a/test/data_model_tests.jl
+++ b/test/data_model_tests.jl
@@ -317,6 +317,27 @@ end
         primary_id = :ID, time_col = :t, evid_col = :EVID,
         amt_col = :AMT, rate_col = :RATE, cmt_col = :CMT
     )
+
+    # A dose row sharing t with a baseline observation is not a duplicate observation (#308).
+    df_dose_at_t0 = DataFrame(
+        ID = [1, 1, 1], t = [0.0, 0.0, 1.0], EVID = [1, 0, 0],
+        AMT = [0.0, 0.0, 0.0], RATE = zeros(3), CMT = [1, 1, 1],
+        Age = [30.0, 30.0, 30.0], y = [missing, 1.1, 1.2]
+    )
+    @test_logs DataModel(
+        model, df_dose_at_t0;
+        primary_id = :ID, time_col = :t, evid_col = :EVID,
+        amt_col = :AMT, rate_col = :RATE, cmt_col = :CMT
+    )
+    # Two genuine observations at one time still warn.
+    df_dup_obs = copy(df_dose_at_t0)
+    df_dup_obs.EVID[1] = 0
+    df_dup_obs.y[1] = 1.0
+    @test_logs (:warn, r"Duplicate") match_mode = :any DataModel(
+        model, df_dup_obs;
+        primary_id = :ID, time_col = :t, evid_col = :EVID,
+        amt_col = :AMT, rate_col = :RATE, cmt_col = :CMT
+    )
 end
 
 # Shared valid model + df; only the DataModel(...) kwargs differ across the
@@ -1699,6 +1720,24 @@ end
         evid_col = :EVID, amt_col = :AMT, rate_col = :RATE, cmt_col = :CMT
     )
     @test isconcretetype(eltype(get_individuals(dm1)))
+
+    # AMT=0 with RATE!=0 is a zero-duration infusion the two solve paths disagree on (#308).
+    df_zero_amt = copy(df)
+    df_zero_amt.AMT[1] = 0.0
+    df_zero_amt.RATE[1] = 5.0
+    @test_throws ErrorException DataModel(
+        model, df_zero_amt; primary_id = :ID, time_col = :t, evid_col = :EVID,
+        amt_col = :AMT, rate_col = :RATE, cmt_col = :CMT
+    )
+
+    # With a DE, an individual with only event rows has no observation time to solve
+    # from -- rejected instead of a BoundsError during the solve (#308).
+    df_dosing_only = copy(df)
+    df_dosing_only.EVID[7:8] .= 1
+    @test_throws ErrorException DataModel(
+        model, df_dosing_only; primary_id = :ID, time_col = :t, evid_col = :EVID,
+        amt_col = :AMT, rate_col = :RATE, cmt_col = :CMT
+    )
 end
 
 @testset "chunked (ChainedVector) columns from CSV" begin

--- a/test/enzyme_compat_proxy_tests.jl
+++ b/test/enzyme_compat_proxy_tests.jl
@@ -196,7 +196,8 @@ end
         serialization = NoLimits.EnsembleSerial()
     )
     prob_d = cache_d.prob_templates[1]
-    @test keys(prob_d.kwargs) == (:dense,)
+    @test keys(prob_d.kwargs) == (:dense, :tstops)
+    @test isempty(prob_d.kwargs[:tstops])
     @test prob_d.kwargs[:dense] === true
     # FD gradient through the flat-p path stays finite and matches finite reality
     axs = getaxes(θu)

--- a/test/estimation_cv_tests.jl
+++ b/test/estimation_cv_tests.jl
@@ -354,3 +354,13 @@ end
     @test res.mean_obs_loglikelihood == -Inf
     @test any(==(-Inf), [fr.test_loglikelihood for fr in res.fold_results])
 end
+
+# t0 = nothing lets every fold re-derive the integration start from its own rows, so an
+# observation split would fit and score with different initial-condition times (#304).
+@testset "cross_validate observation-wise: ODE with t0 = nothing is refused" begin
+    dm = DataModel(
+        fx_ode_model(), fx_ode_df(); primary_id = :ID, time_col = :t, t0 = nothing
+    )
+    @test_throws ErrorException cross_validate(dm, 2; kind = :observation)
+    @test cross_validate(dm, 2; kind = :id) isa CVSpec
+end

--- a/test/estimation_focei_tests.jl
+++ b/test/estimation_focei_tests.jl
@@ -46,6 +46,8 @@ const NL = NoLimits
     @test NL._focei_dispersion_indices(LogNormal(0.0, 1.0)) == [2]
     @test NL._focei_dispersion_indices(Poisson(1.0)) == Int[]
     @test NL._focei_dispersion_indices(Gamma(2.0, 1.0)) == Int[]
+    # MvNormal: the vech(Σ) coordinates, after the k mean entries (#284).
+    @test NL._focei_dispersion_indices(MvNormal(zeros(2), [1.0 0.0; 0.0 1.0])) == [3, 4, 5]
 
     # Support flags.
     @test NL._focei_is_supported(Normal(0.0, 1.0))
@@ -162,6 +164,39 @@ end
     @test !isapprox(Hfoce[1, 1], Hfoci[1, 1]; atol = 1.0e-3)
     # Crucially, FOCE froze the dispersion at η = μη, NOT at η = 0.
     @test !isapprox(Hfoce[1, 1], 2 * exp(-2 * c0) + Λ; atol = 1.0e-3)
+
+    # MvNormal outcome: `interaction=false` must freeze the covariance block too, so
+    # the two Hessians differ (they were byte-identical before #284).
+    model_mv = @Model begin
+        @fixedEffects begin
+            a = RealNumber(1.0)
+            c = RealNumber(-0.3)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η = RandomEffect(Normal(0.3, 0.6); column = :ID)
+        end
+        @formulas begin
+            y ~ MvNormal([a + η, a - η], exp(c + 0.8 * η) * LinearAlgebra.I(2))
+        end
+    end
+    df_mv = DataFrame(
+        ID = [1, 1], t = [0.0, 1.0], y = [[1.3, 0.9], [1.1, 1.0]]
+    )
+    dm_mv = DataModel(model_mv, df_mv; primary_id = :ID, time_col = :t)
+    _, infos_mv, cc_mv = NL._build_re_batch_infos(dm_mv, NamedTuple())
+    cache_mv = NL.build_ll_cache(dm_mv; force_saveat = true)
+    θu_mv = NL.get_θ0_untransformed(dm_mv.model.fixed.fixed)
+    Hmv_foce = NL._focei_negH_batch(
+        dm_mv, infos_mv[1], θu_mv, b, cc_mv, cache_mv; interaction = false
+    )
+    Hmv_foci = NL._focei_negH_batch(
+        dm_mv, infos_mv[1], θu_mv, b, cc_mv, cache_mv; interaction = true
+    )
+    @test all(isfinite, Hmv_foce) && all(isfinite, Hmv_foci)
+    @test !isapprox(Hmv_foce[1, 1], Hmv_foci[1, 1]; rtol = 1.0e-6)
 
     # FOCE end-to-end fit runs.
     rf = fit_model(

--- a/test/estimation_mle_tests.jl
+++ b/test/estimation_mle_tests.jl
@@ -40,6 +40,15 @@ end
     res = fx_mle()                        # shared no-RE MLE fit
     @test res isa FitResult
     @test NoLimits.get_params(res; scale = :untransformed) isa ComponentArray
+
+    # #310: a finite but overflowing observation makes the objective constant, so the fit
+    # returns the starting values; it must say so and name the individual.
+    df_bad = copy(fx_nore_df())
+    df_bad.y[8] = 1.0e200
+    dm_bad = DataModel(fx_nore_model(), df_bad; primary_id = :ID, time_col = :t)
+    @test_logs (:warn, r"never became finite.*ID\): 4") match_mode = :any fit_model(
+        dm_bad, NoLimits.MLE(); serialization = NoLimits.EnsembleSerial()
+    )
 end
 
 let

--- a/test/estimation_pooled_tests.jl
+++ b/test/estimation_pooled_tests.jl
@@ -524,6 +524,15 @@ end
 
 # ─── 14. PooledMap: priors active on free params, frozen priors constant ──────────
 
+# True when the PooledMap fit reports that every prior-bearing parameter was frozen.
+function _pooledmap_warned(dm)
+    logger = Test.TestLogger()
+    Base.CoreLogging.with_logger(logger) do
+        fit_model(dm, NoLimits.PooledMap(); serialization = NoLimits.EnsembleSerial())
+    end
+    return any(r -> occursin("every prior-bearing", string(r.message)), logger.logs)
+end
+
 @testset "PooledMap with RE-only mean" begin
     model = @Model begin
         @fixedEffects begin
@@ -550,6 +559,30 @@ end
     θ̂ = NoLimits.get_params(res; scale = :untransformed)
     # prior Normal(0,1) shrinks μ̂ slightly below the data mean
     @test 0.5 < θ̂.μ < mean(df.y)
+
+    # A live prior survives the auto-freeze here, so no degeneracy warning.
+    @test !_pooledmap_warned(dm)
+
+    # Same model with the only prior on the auto-frozen ω: the MAP term degenerates
+    # into a constant offset, which must be reported (#284).
+    model_deg = @Model begin
+        @fixedEffects begin
+            μ = RealNumber(0.0)
+            ω = RealNumber(0.5, scale = :log, prior = LogNormal(0.0, 0.5))
+            σ = RealNumber(0.4, scale = :log)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η = RandomEffect(Normal(μ, ω); column = :ID)
+        end
+        @formulas begin
+            y ~ Normal(η, σ)
+        end
+    end
+    dm_deg = DataModel(model_deg, df; primary_id = :ID, time_col = :t)
+    @test _pooledmap_warned(dm_deg)
 end
 
 # ─── 15. method option validation ─────────────────────────────────────────────────

--- a/test/ode_callbacks_tests.jl
+++ b/test/ode_callbacks_tests.jl
@@ -559,3 +559,54 @@ end
         @test isapprox(_fitted(_dm(df; t0 = nothing)), expected; rtol = 1.0e-5)
     end
 end
+
+@testset "ODE callbacks: infusion rate state is per-solve (#308)" begin
+    # A linear RHS would take the closed-form path (which copies the rates) and hide
+    # the shared-buffer race, so the RHS here is deliberately nonlinear.
+    model = @Model begin
+        @covariates begin
+            t = Covariate()
+        end
+
+        @fixedEffects begin
+            k = RealNumber(0.3, scale = :log)
+            σ = RealNumber(1.0, scale = :log)
+        end
+
+        @DifferentialEquation begin
+            D(x1) ~ -k * x1 * x1 / (1 + x1)
+        end
+
+        @initialDE begin
+            x1 = 0.0
+        end
+
+        @formulas begin
+            y ~ Normal(x1(t), σ)
+        end
+    end
+
+    df = DataFrame(
+        ID = [1, 1, 1, 2, 2, 2],
+        t = [1.0, 2.0, 4.0, 1.0, 2.0, 4.0],
+        EVID = [1, 0, 0, 1, 0, 0],
+        AMT = [10.0, 0.0, 0.0, 10.0, 0.0, 0.0],
+        RATE = [5.0, 0.0, 0.0, 5.0, 0.0, 0.0],
+        CMT = [1, 1, 1, 1, 1, 1],
+        y = [missing, 3.0, 2.0, missing, 2.5, 1.8]
+    )
+    dm = DataModel(
+        model, df; primary_id = :ID, time_col = :t, evid_col = :EVID,
+        amt_col = :AMT, rate_col = :RATE, cmt_col = :CMT
+    )
+    θ = get_θ0_untransformed(model.fixed.fixed)
+    ref = NoLimits.loglikelihood(dm, θ, ComponentArray())
+    @test isfinite(ref)
+
+    n = 200
+    out = fill(NaN, n)
+    Threads.@threads for i in 1:n
+        out[i] = NoLimits.loglikelihood(dm, θ, ComponentArray())
+    end
+    @test all(==(ref), out)
+end

--- a/test/ode_callbacks_tests.jl
+++ b/test/ode_callbacks_tests.jl
@@ -262,13 +262,13 @@ end
 
     @testset "CMT name mapping works" begin
         df = DataFrame(
-            ID = [1, 1],
-            t = [0.0, 0.0],
-            EVID = [1, 1],
-            AMT = [2.0, 3.0],
-            RATE = [0.0, 0.0],
-            CMT = ["x1", "central"],
-            y = [missing, missing]
+            ID = [1, 1, 1],
+            t = [0.0, 0.0, 1.0],
+            EVID = [1, 1, 0],
+            AMT = [2.0, 3.0, 0.0],
+            RATE = [0.0, 0.0, 0.0],
+            CMT = ["x1", "central", "x1"],
+            y = [missing, missing, 1.0]
         )
         dm = DataModel(
             model, df;
@@ -285,13 +285,13 @@ end
 
     @testset "CMT mixed styles error" begin
         df = DataFrame(
-            ID = [1, 1],
-            t = [0.0, 0.0],
-            EVID = [1, 1],
-            AMT = [2.0, 3.0],
-            RATE = [0.0, 0.0],
-            CMT = Any["x1", 2],
-            y = [missing, missing]
+            ID = [1, 1, 1],
+            t = [0.0, 0.0, 1.0],
+            EVID = [1, 1, 0],
+            AMT = [2.0, 3.0, 0.0],
+            RATE = [0.0, 0.0, 0.0],
+            CMT = Any["x1", 2, "x1"],
+            y = [missing, missing, 1.0]
         )
         @test_throws ErrorException DataModel(
             model, df;
@@ -306,13 +306,13 @@ end
 
     @testset "CMT closest-match suggestion" begin
         df = DataFrame(
-            ID = [1],
-            t = [0.0],
-            EVID = [1],
-            AMT = [2.0],
-            RATE = [0.0],
-            CMT = ["x2"],
-            y = [missing]
+            ID = [1, 1],
+            t = [0.0, 1.0],
+            EVID = [1, 0],
+            AMT = [2.0, 0.0],
+            RATE = [0.0, 0.0],
+            CMT = ["x2", "x1"],
+            y = [missing, 1.0]
         )
         err = try
             DataModel(

--- a/test/prede_tests.jl
+++ b/test/prede_tests.jl
@@ -40,6 +40,15 @@ end
     @test_throws LoadError @eval @preDifferentialEquation begin
         bad = t + 1
     end
+
+    # An unresolvable symbol used to fall through as a bare UndefVarError (#309).
+    prede_unknown = @preDifferentialEquation begin
+        v = w + 1
+    end
+    build_unknown = get_prede_builder(prede_unknown)
+    @test_throws ErrorException build_unknown(
+        ComponentArray(), ComponentArray(), NamedTuple(), NamedTuple(), NamedTuple()
+    )
 end
 
 @testset "PreDifferentialEquation mutation warnings" begin

--- a/test/saem_mh_kernel_tests.jl
+++ b/test/saem_mh_kernel_tests.jl
@@ -600,3 +600,20 @@ end
         @test s.saem.retry_mcmc_steps == 2
     end
 end
+
+# ---------------------------------------------------------------------------
+# Bijection log-Jacobians (#283)
+# ---------------------------------------------------------------------------
+
+@testset "AdaptiveNoLimitsMH bijection log-Jacobians: ALR reduces to logit at d=1" begin
+    # At d = 1 the ALR map is exactly the logit map, so MvLogitNormal must agree
+    # numerically with the scalar Beta implementation.
+    for z_new in (-1.3, 0.0, 0.7), z_old in (-0.4, 0.0, 2.1)
+        @test NoLimits._amh_bij_log_jac(Val(:MvLogitNormal), [z_new], [z_old]) ≈
+            NoLimits._amh_bij_log_jac(Val(:Beta), z_new, z_old)
+    end
+    for z in (-2.0, -0.5, 0.0, 1.1, 3.0)
+        @test NoLimits._bij_log_jac_forward(Val(:MvLogitNormal), [z]) ≈
+            NoLimits._bij_log_jac_forward(Val(:Beta), z)
+    end
+end

--- a/test/saem_var_lb_tests.jl
+++ b/test/saem_var_lb_tests.jl
@@ -723,3 +723,30 @@ end
     )
     @test get_params(res; scale = :untransformed).ω ≈ 0.55
 end
+
+@testset "var lb integration: numeric M-step — clamp survives to the result" begin
+    # Regression for #283: the post-M-step var-lb clamp used to be dropped because
+    # θt_free / θ_prev_new were never resynced from the clamped θu_new.
+    # builtin_stats = :none forces the numeric M-step, sa_anneal_alpha = 0 keeps the
+    # (already correct) anneal clamp from masking it, and the effective floor is
+    # min(anneal_min_sd, var_lb_value), so both are raised above the fixture's
+    # σ = 0.3. Without the resync σ comes back at its unclamped 0.3.
+    Random.seed!(1234)
+    dm = _make_normal_re_dm()
+    res = fit_model(
+        dm,
+        NoLimits.SAEM(;
+            sampler = MH(),
+            turing_kwargs = (n_samples = 2, n_adapt = 2, progress = false),
+            maxiters = 2,
+            builtin_stats = :none,
+            sa_anneal_alpha = 0.0,
+            auto_var_lb = true,
+            anneal_min_sd = 0.5,
+            var_lb_value = 0.5
+        )
+    )
+    θ = NoLimits.get_params(res; scale = :untransformed)
+    @test Float64(θ.σ) >= 0.5
+    @test Float64(θ.ω) >= 0.5
+end

--- a/test/softtrees_tests.jl
+++ b/test/softtrees_tests.jl
@@ -92,6 +92,34 @@ end
     @test !warned(() -> fit_model(dm, method; theta_0_untransformed = θ_ok))
 end
 
+# Multi-output trees sit at the same saddle when the leaves are constant within a row,
+# even if the rows differ from each other (#304).
+@testset "SoftTree degenerate multi-output start warns" begin
+    df = DataFrame(ID = [1, 1, 2, 2], t = [0.0, 1.0, 0.0, 1.0], y = [1.0, 1.1, 0.9, 1.0])
+    model = @Model begin
+        @fixedEffects begin
+            σ = RealNumber(0.5, scale = :log)
+            Γ = SoftTreeParameters(
+                1, 2; n_output = 2, function_name = :ST2, calculate_se = false
+            )
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @formulas begin
+            y ~ Normal(ST2([t], Γ)[1], σ)
+        end
+    end
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+    θ = deepcopy(get_θ0_untransformed(model.fixed.fixed))
+    # Leaves are vec of a (2, 4) matrix: row 1 all 0.3, row 2 all 0.7.
+    θ.Γ[(end - 7):end] .= repeat([0.3, 0.7], 4)
+    logs = first(
+        Test.collect_test_logs(() -> NoLimits._warn_degenerate_soft_trees(dm, θ))
+    )
+    @test any(l -> occursin("Soft tree", string(l.message)), logs)
+end
+
 function _softtree_scalar(x, tree, params)
     return sum(tree(x, params))
 end

--- a/test/splines_tests.jl
+++ b/test/splines_tests.jl
@@ -24,6 +24,10 @@ using ForwardDiff
     @test_throws ErrorException bspline_eval(-0.1, coeffs, knots, degree)
     @test_throws ErrorException bspline_eval(1.1, coeffs, knots, degree)
 
+    # Right boundary knot: the basis used to collapse to all-zero there (#304).
+    @test isapprox(sum(bspline_basis(knots[end], knots, degree)), 1.0; atol = 1.0e-10)
+    @test isapprox(bspline_eval(knots[end], coeffs, knots, degree), coeffs[end]; atol = 1.0e-10)
+
     knots_bad = [0.0, 0.5, 0.4, 1.0]
     @test_throws ErrorException bspline_basis(0.5, knots_bad, 1)
 end

--- a/test/uq_tests.jl
+++ b/test/uq_tests.jl
@@ -702,6 +702,45 @@ end
     B = NoLimits._wald_pinv(H, [:a, :b])
     @test diag(B)[2] > 1.0e8
     @test isapprox(B, inv(H); rtol = 1.0e-3)
+
+    # #306 finding 1: an EXACTLY zero singular value is the limit of the near-zero case,
+    # not a perfectly determined direction - it must not come back with zero variance.
+    B0 = @test_logs match_mode = :any (:warn, r"weakly identified") NoLimits._wald_pinv(
+        diagm([10.0, 0.0, 5.0]), [:a, :b, :c]
+    )
+    @test diag(B0)[2] > 1.0e8
+    @test isapprox(diag(B0)[1], 0.1)
+
+    # #306 finding 2: the default (`inv`) branch must refuse a machine-singular Hessian
+    # instead of returning a roundoff-signed covariance.
+    @test_throws ErrorException NoLimits._wald_bread(
+        [1.0 1.0; 1.0 1.0 + 1.0e-12], false, [:a, :b]
+    )
+    @test NoLimits._wald_bread(H, false, [:a, :b]) isa Matrix{Float64}
+
+    # #306 finding 5: a zero Hessian is no information, not infinite precision.
+    @test_throws ErrorException NoLimits._wald_bread(zeros(2, 2), true, [:a, :b])
+    @test_throws ErrorException NoLimits._wald_bread(zeros(2, 2), false, [:a, :b])
+
+    # #306 finding 2: a clipped eigenvalue of the matrix's own scale is not a rounding
+    # repair, and the warning must say so instead of "shrunk toward zero".
+    @test_logs (:warn, r"far beyond roundoff") NoLimits._project_psd_covariance(
+        [-1.0 0.0; 0.0 1.0]
+    )
+    Vp, dp = @test_logs (:warn, r"shrunk toward zero") NoLimits._project_psd_covariance(
+        [1.0 0.0; 0.0 -1.0e-20]
+    )
+    @test dp.vcov_n_eigs_clipped == 1
+    @test dp.vcov_min_eig_rel > -1.0e-8
+    @test isapprox(Vp, [1.0 0.0; 0.0 0.0]; atol = 1.0e-18)
+
+    # #306 finding 7: a collapsed sandwich meat must say so and be visible in the diags.
+    md = @test_logs (:warn, r"degenerate") NoLimits._wald_meat_diag(
+        zeros(3, 3), Matrix(1.0I, 3, 3), 1
+    )
+    @test md.n_cluster == 1
+    @test md.meat_rank == 0
+    @test md.meat_degenerate
 end
 
 # Issue #250 finding 7: non-finite Wald moments must not reach range/quantile/Makie.

--- a/test/uq_tests.jl
+++ b/test/uq_tests.jl
@@ -147,6 +147,22 @@ end
     @test d.inactive_fixed_effects_held_constant
     @test d.vcov_min_eig_used >= -1.0e-10
 
+    # #306 finding 6: intervals and monotone natural SEs are closed form, not draw quantiles.
+    est_t = get_uq_estimates(uq; scale = :transformed, as_component = false)
+    ints_t = get_uq_intervals(uq; scale = :transformed, as_component = false)
+    se_t = sqrt.(diag(get_uq_vcov(uq; scale = :transformed)))
+    z = quantile(Normal(), 0.975)
+    @test ints_t.lower ≈ est_t .- z .* se_t atol = 1.0e-12
+    @test ints_t.upper ≈ est_t .+ z .* se_t atol = 1.0e-12
+    ints_n = get_uq_intervals(uq; scale = :natural, as_component = false)
+    # σ is the :log coordinate (index 2), a is :identity (index 1).
+    @test ints_n.lower[2] == exp(ints_t.lower[2])
+    @test ints_n.upper[2] == exp(ints_t.upper[2])
+    @test ints_n.lower[1] == ints_t.lower[1]
+    se_n = sqrt.(diag(get_uq_vcov(uq; scale = :natural)))
+    @test se_n[1] ≈ se_t[1] rtol = 1.0e-12
+    @test se_n[2] ≈ sqrt(expm1(se_t[2]^2) * exp(2 * est_t[2] + se_t[2]^2)) rtol = 1.0e-12
+
     uq_const = compute_uq(
         res; method = :wald, constants = (a = 0.2,), n_draws = 30, rng = Random.Xoshiro(2)
     )
@@ -194,6 +210,22 @@ end
     @test d.requested_draws == 15
     @test d.used_draws == 15
     @test d.available_draws >= d.used_draws
+
+    # #306 finding 3: the transformed scale must be the forward transform of the chain,
+    # not a copy of the natural-scale numbers.
+    est_n = get_uq_estimates(uq; scale = :natural, as_component = false)
+    est_t = get_uq_estimates(uq; scale = :transformed, as_component = false)
+    draws_n = get_uq_draws(uq; scale = :natural)
+    draws_t = get_uq_draws(uq; scale = :transformed)
+    @test draws_t[:, 2] ≈ log.(draws_n[:, 2])
+    @test draws_t != draws_n
+    @test est_t[2] ≈ mean(log.(draws_n[:, 2]))
+    @test est_t[1] == est_n[1]
+    ints_t = get_uq_intervals(uq; scale = :transformed, as_component = false)
+    ints_n = get_uq_intervals(uq; scale = :natural, as_component = false)
+    # Interpolated draw quantiles are only approximately equivariant, so compare loosely.
+    @test ints_t.lower[2] ≈ log(ints_n.lower[2]) rtol = 0.05
+    @test ints_t.upper[2] < ints_n.upper[2]
 end
 
 @testset "UQ chain for VI" begin


### PR DESCRIPTION
Bug-fix batch for the open bug issues. Every fix is the smallest change at the root cause, one commit per issue (two for #306, two for #308), each with a regression assertion inside an existing testset. No enhancement or feature work is included.

Closes #283, closes #284, closes #304, closes #310.
Addresses #306, #308, #309 (all HIGH and MEDIUM findings fixed; the remaining LOW items are listed at the end so the issues can be closed or trimmed).

## #283 SAEM/MCEM samplers
- `MvLogitNormal` bijection log-Jacobians in `adaptive_mh.jl` now follow the documented convention (checked numerically against the `:Beta` branch at d = 1).
- The SAEM post-M-step `auto_var_lb` clamp re-syncs `θt_full` / `θt_free` / `θ_prev_new` exactly like the SA-anneal clamp above it, so the floor is no longer discarded.
- Both native samplers (`SaemixMH`, `AdaptiveNoLimitsMH`) vet their initial draw with the existing finite-likelihood seeding (`_em_vet_init_b`), so a chain can no longer start at `-Inf` and deadlock.

## #284 FOCEI / Pooled
- FOCE returns the all-NaN Hessian (optimizer backtracks) instead of a `BoundsError` when the model fails only at the RE prior mean.
- `_focei_dispersion_indices(::MvNormal)` registers the vech(Σ) block, so `FOCEI(interaction = false)` actually freezes the covariance for multivariate-normal outcomes.
- `PooledMap` warns when auto-freezing removed every prior-bearing parameter (the fit is then a plain `Pooled()`), and now calls `_warn_unbounded_prior_at_bounds` like `MAP()`.

## #304 splines / CV / soft trees
- `bspline_basis` / `bspline_eval` are correct at `x == knots[end]` (span index clamped to the last basis function; interior values bit-identical).
- `cross_validate(kind = :observation)` errors clearly on an ODE model built with `t0 = nothing`, instead of fitting and scoring with different initial-condition times. Making folds inherit per-individual start times would require a new per-individual `t0` option across constructor, serialization and simulation, so the loud fix was chosen.
- The degenerate soft-tree guard checks leaf constancy per output row.

## #306 UQ
- `_wald_pinv`: an exactly zero singular value gets a large variance (floored at the conditioning tolerance), consistent with the warning it emits.
- `_wald_bread` default path (`pseudo_inverse = false`) refuses a numerically singular Hessian (condition number above `1e-4 / eps`) and names the weakly identified parameters, instead of returning roundoff-signed covariances.
- `_wald_bread` rejects an exactly-zero Hessian, and `compute_uq(method = :wald)` refuses a source fit whose objective is not finite (no more SE = 0 for every parameter).
- Sandwich: `n_cluster`, `meat_rank`, `meat_degenerate` are recorded in the diagnostics and a warning fires when the meat is rank-deficient or negligible against the bread.
- `_project_psd_covariance` still clips, but escalates its warning and records `vcov_min_eig_rel` when the negative eigenvalue is far beyond roundoff. A hard error was tried and broke UQ on every unconverged fit (the suite's `maxiters = 2` fixtures included), so it was not kept.
- Wald intervals are now closed form: `est ± z·SE` on the transformed scale, exactly back-transformed for `:identity`, `:log`, `:logit` coordinates; natural-scale variances are exact for `:identity` and `:log` (lognormal closed form), with rows/columns rescaled so the drawn correlations and PSD-ness are preserved. Structured blocks and off-diagonals stay draw-based.
- Chain UQ builds genuine transformed-scale draws/estimates/intervals/vcov for scalar-transform coordinates. Structured-block coordinates have no per-coordinate forward map and stay natural in the transformed slots; they are warned about once and listed in `get_uq_diagnostics(uq).transformed_scale_natural_only`.

## #308 events
- `infusion_rates` is no longer a shared mutable buffer: every likelihood cache owns a `deepcopy` of each individual's `EventCallbacks` (same precedent as the per-cache interpolant copies), and plotting/simulation take private copies. Threaded `loglikelihood` calls on the same `dm` are bit-identical to serial (0/400 mismatches, previously 68/400).
- A dose coincident with a `crossing_time` reports the jump time when the smooth step interpolant does not bracket the level (both the estimation and the plotting path). For the issue's repro this gives `tc = 1.0`, the first passage, rather than `-11.59`; the issue's `1.729` is the later downward crossing, but `crossing_time` is documented as the first crossing in either direction.
- `AMT = 0` with `RATE != 0` is rejected at `DataModel` construction; `AMT`/`RATE` join the `_check_finite` sweep.
- Dosing-only individuals are rejected at construction, naming the ids, for models with a differential equation. Non-DE models keep the existing event-only behaviour that `estimation_common_tests.jl` documents.
- The duplicate-timepoint warning only looks at observation rows, so a dose and a baseline observation at the same time no longer trigger it.

## #309 covariates
- `_check_finite` now walks the real data columns of vector covariate types.
- Duplicate row times error with covariate, individual and time for the interpolations that NaN-poison (Quadratic, Lagrange, QuadraticSpline, CubicSpline, Akima). Constant/Linear keep working. Note: a dose row and an observation row at the same time now also trigger this error under those five interpolations, which is the correct outcome of a layout that previously produced silent NaN.
- The `tspan` upper bound is checked against dynamic-covariate support, mirroring the lower-bound guard; `DataInterpolations` extrapolation errors are classified as numeric errors.
- Dynamic-covariate knot times are passed as `tstops` (precomputed once per individual, empty when the DE reads no dynamic covariate). No golden value moved.
- `@preDifferentialEquation` errors on an unresolvable symbol like `@initialDE` does; duplicate columns in a `*CovariateVector` get a NoLimits error.

## #310 estimation
- MLE/MAP, Laplace/FOCEI and GHQuadrature fits whose objective never became finite (or sat on the infeasibility wall) emit one warning saying the returned parameters are the starting values and naming the individuals with a `-Inf` contribution. SAEM/MCEM/Pooled have no equivalent single finish signal and are not covered.

## Not done (deliberately)
- #306 finding 4 (`RealPSDMatrix` coordinate names under `:expm` / `:lie`) is a labelling change to public names; left for a separate decision.
- #308 finding 6 (pre-dose scoring convention) is documentation; the remaining #308 LOW bullets (truncated infusion, `EVID = 2` overwriting `@initialDE`, row-order dependence of duplicated dynamic-covariate rows) are unchanged.
- #309 findings 5 (missing-value validation for covariates used only outside `@formulas`) and 7 (`summarize` weighting) are unchanged.

## Validation
Targeted runs through the Pkg sandbox on this branch: splines, softtrees, estimation_cv, estimation_mle, estimation_laplace, saem_mh_kernel, saem_var_lb, estimation_focei, estimation_pooled, covariates, data_model, data_model_ode, prede, crossing, ode_callbacks, data_simulation, closed_form_ode, estimation_common, estimation_multistart, uq, uq_edge_cases, stickbreak_uq_natural_extension, uq_plotting, estimation_ghquadrature, api_primitives, aqua. Runic check clean on `src test docs ext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
