### PR TITLE
docs: cite the arXiv paper (2606.24427)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-message: "If you use NoLimits.jl in your research, please cite it as below."
+message: "If you use NoLimits.jl in your research, please cite the paper below."
 title: "NoLimits.jl"
 abstract: >-
   A Julia framework for nonlinear mixed-effects modeling of longitudinal data,
@@ -14,19 +14,22 @@ authors:
   - family-names: "Arruda"
     given-names: "Jonas"
     affiliation: "Bonn Center for Mathematical Life Sciences, University of Bonn"
-  - family-names: "Peiter"
-    given-names: "Clemens"
+  - family-names: "Schmid"
+    given-names: "Nina"
     affiliation: "Bonn Center for Mathematical Life Sciences, University of Bonn"
   - family-names: "Gusinow"
     given-names: "Roy"
     affiliation: "Bonn Center for Mathematical Life Sciences, University of Bonn"
-  - family-names: "Schmid"
-    given-names: "Nina"
+  - family-names: "Wieland"
+    given-names: "Vincent"
+    affiliation: "Bonn Center for Mathematical Life Sciences, University of Bonn"
+  - family-names: "Peiter"
+    given-names: "Clemens"
     affiliation: "Bonn Center for Mathematical Life Sciences, University of Bonn"
   - family-names: "Hasenauer"
     given-names: "Jan"
     affiliation: "Bonn Center for Mathematical Life Sciences, University of Bonn"
-version: "0.2.0"
+version: "0.2.7"
 license: MIT
 repository-code: "https://github.com/manuhuth/NoLimits.jl"
 url: "https://manuhuth.github.io/NoLimits.jl/"
@@ -37,3 +40,36 @@ keywords:
   - "scientific machine learning"
   - "Bayesian inference"
   - "Julia"
+preferred-citation:
+  type: article
+  title: "NoLimits.jl: Flexible and Composable Nonlinear Mixed-Effects Modeling in Julia"
+  journal: "arXiv"
+  year: 2026
+  month: 6
+  url: "https://arxiv.org/abs/2606.24427"
+  doi: "10.48550/arXiv.2606.24427"
+  identifiers:
+    - type: other
+      value: "arXiv:2606.24427"
+  authors:
+    - family-names: "Huth"
+      given-names: "Manuel"
+      affiliation: "Bonn Center for Mathematical Life Sciences, University of Bonn"
+    - family-names: "Arruda"
+      given-names: "Jonas"
+      affiliation: "Bonn Center for Mathematical Life Sciences, University of Bonn"
+    - family-names: "Schmid"
+      given-names: "Nina"
+      affiliation: "Bonn Center for Mathematical Life Sciences, University of Bonn"
+    - family-names: "Gusinow"
+      given-names: "Roy"
+      affiliation: "Bonn Center for Mathematical Life Sciences, University of Bonn"
+    - family-names: "Wieland"
+      given-names: "Vincent"
+      affiliation: "Bonn Center for Mathematical Life Sciences, University of Bonn"
+    - family-names: "Peiter"
+      given-names: "Clemens"
+      affiliation: "Bonn Center for Mathematical Life Sciences, University of Bonn"
+    - family-names: "Hasenauer"
+      given-names: "Jan"
+      affiliation: "Bonn Center for Mathematical Life Sciences, University of Bonn"

--- a/README.md
+++ b/README.md
@@ -279,15 +279,18 @@ Full documentation is hosted at **[manuhuth.github.io/NoLimits.jl](https://manuh
 
 ## Citation
 
-If you use NoLimits.jl in published work, please cite it — GitHub's **"Cite this repository"**
+If you use NoLimits.jl in published work, please cite the paper. GitHub's **"Cite this repository"**
 button (from [`CITATION.cff`](CITATION.cff)) provides APA and BibTeX exports:
 
 ```bibtex
-@software{NoLimits_jl_2026,
-  title  = {{NoLimits.jl}: Flexible and composable nonlinear mixed-effects modeling in Julia},
-  author = {Huth, Manuel and Arruda, Jonas and Peiter, Clemens and Gusinow, Roy and Schmid, Nina and Hasenauer, Jan},
-  year   = {2026},
-  url    = {https://github.com/manuhuth/NoLimits.jl}
+@misc{huth2026nolimits,
+  title         = {{NoLimits.jl}: Flexible and Composable Nonlinear Mixed-Effects Modeling in Julia},
+  author        = {Huth, Manuel and Arruda, Jonas and Schmid, Nina and Gusinow, Roy and Wieland, Vincent and Peiter, Clemens and Hasenauer, Jan},
+  year          = {2026},
+  eprint        = {2606.24427},
+  archivePrefix = {arXiv},
+  primaryClass  = {stat.CO},
+  url           = {https://arxiv.org/abs/2606.24427}
 }
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -96,13 +96,16 @@ NoLimits exposes the per-site objective and gradient primitives for federated es
 
 ## How to Cite
 
-If you use NoLimits.jl in your research, please cite the software:
+If you use NoLimits.jl in your research, please cite the paper:
 
 ```bibtex
-@software{NoLimits_jl_2026,
-  title  = {{NoLimits.jl}},
-  author = {Huth, Manuel and Arruda, Jonas and Peiter, Clemens and Gusinow, Roy and Schmid, Nina and Hasenauer, Jan},
-  year   = {2026},
-  url    = {https://github.com/manuhuth/NoLimits.jl}
+@misc{huth2026nolimits,
+  title         = {{NoLimits.jl}: Flexible and Composable Nonlinear Mixed-Effects Modeling in Julia},
+  author        = {Huth, Manuel and Arruda, Jonas and Schmid, Nina and Gusinow, Roy and Wieland, Vincent and Peiter, Clemens and Hasenauer, Jan},
+  year          = {2026},
+  eprint        = {2606.24427},
+  archivePrefix = {arXiv},
+  primaryClass  = {stat.CO},
+  url           = {https://arxiv.org/abs/2606.24427}
 }
 ```


### PR DESCRIPTION
Point the citation metadata at the arXiv paper https://arxiv.org/abs/2606.24427.

- CITATION.cff: paper author list and order, version 0.2.7, new preferred-citation (article, DOI 10.48550/arXiv.2606.24427).
- README.md and docs/src/index.md: the duplicated @software BibTeX blocks replaced by the @misc arXiv entry.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)