### PR TITLE
fix: bug batch round 2 for #290 #306 #308 #309 #311-#316

### DIFF
--- a/docs/scripts/make_tutorial_assets.jl
+++ b/docs/scripts/make_tutorial_assets.jl
@@ -1206,10 +1206,11 @@ function NoLimits.fit_method(
     )
     ctx = build_fit_context(dm)
     θ = something(theta_0_untransformed, initial_parameters(ctx))
+    sol = nothing
     for _ in 1:(m.n_iter)
         modes = empirical_bayes(ctx, θ)                    # E-step: posterior modes b* ...
         covs = empirical_bayes_covariance(ctx, θ, modes)   # ... and covariance Σ = (−H)⁻¹
-        θ, _ = optimize_parameters(ctx; θ_start = θ) do θn  # M-step, natural scale
+        θ, sol = optimize_parameters(ctx; θ_start = θ) do θn  # M-step, natural scale
             -sum(
                 complete_data_loglikelihood(ctx, bi, θn, modes[bi]) +
                     0.5 * tr(
@@ -1222,7 +1223,8 @@ function NoLimits.fit_method(
     end
     return build_fit_result(
         ctx, m, θ; kind = :frequentist_re,
-        objective = -laplace_marginal(ctx, θ), iterations = m.n_iter
+        objective = -laplace_marginal(ctx, θ), iterations = m.n_iter,
+        converged = SciMLBase.successful_retcode(sol)
     )
 end
 

--- a/docs/src/data-model-construction.md
+++ b/docs/src/data-model-construction.md
@@ -183,6 +183,14 @@ dm = DataModel(
 
 The `CMT` column can contain either integer indices or state names (`String`/`Symbol`), but the format must be consistent within the DataFrame.
 
+### Event Timing Conventions
+
+An observation recorded at the same time as a dose is always scored against the **pre-dose** state, regardless of the order of the rows in the DataFrame. This differs from NONMEM, where the record order decides. The convention is the right one for the common pre-dose trough sample; if a sample is drawn just after the dose, give it a slightly later time (for example `t = 1.0 + 1e-6`) so that it is scored against the post-dose state.
+
+A reset event (`EVID = 2`) recorded at the integration start time replaces the `@initialDE` value for that compartment rather than being added to it, following NONMEM reset semantics.
+
+An infusion whose stop time (`t + AMT / RATE`) falls after the end of an individual's integration span is truncated at the end of the span, so less than `AMT` is delivered. `DataModel` warns when this happens.
+
 ## Dynamic Covariates and Interpolation
 
 When using `DynamicCovariate` or `DynamicCovariateVector`, the `DataInterpolations` package must be loaded in the user environment:

--- a/docs/src/estimation/cv.md
+++ b/docs/src/estimation/cv.md
@@ -25,12 +25,12 @@ For models with random effects, two separate modes control prediction for seen a
 **`seen_re_mode`** - individuals who appear in the training set:
 
 - `:ebe` (default) - plug in the empirical Bayes estimate (EBE, MAP of the conditional posterior) obtained from the training fit. Fast and the standard approach in pharmacometrics.
-- `:conditional` - draw `n_mc_samples` samples from the training conditional posterior `p(b | y_train, θ̂)` using the Laplace approximation (for `Laplace`) or MCMC sweeps (for `MCEM`/`SAEM`), then average per-observation log-likelihoods via `logsumexp` and predicted means arithmetically.
+- `:conditional` - draw `n_mc_samples` samples from the training conditional posterior `p(b | y_train, θ̂)` using the Laplace approximation (for `Laplace`) or MCMC sweeps (for `MCEM`/`SAEM`), then score each individual by its joint predictive marginal `log( (1/S) Σ_s Π_r p(y_r | b_s) )`, that is the sum of the individual's observation log-likelihoods within a draw followed by a `logsumexp` across draws. Predicted means are averaged arithmetically. Because the score is a per-individual quantity, `obs_scores` carries it on the individual's first row with `0.0` on the remaining rows, so sums and per-fold totals stay correct while single rows are no longer per-observation densities.
 
 **`unseen_re_mode`** - individuals absent from training (only possible with `kind=:id`):
 
 - `:mean` (default) - set the random effect to the prior mean (zero for zero-mean priors). This is the marginal population prediction.
-- `:montecarlo` - draw `n_mc_samples` samples from the RE prior `p(b | θ̂)` and average in the same way as `:conditional`.
+- `:montecarlo` - draw `n_mc_samples` samples from the RE prior `p(b | θ̂)` and aggregate them the same way as `:conditional`, giving the per-individual joint predictive marginal log-likelihood.
 
 ## Usage
 

--- a/docs/src/method-developer-api.md
+++ b/docs/src/method-developer-api.md
@@ -129,19 +129,25 @@ parameters (the transformed-scale round trip and PSD symmetrisation are handled)
 function NoLimits.fit_method(dm, m::MyEM, args...; theta_0_untransformed = nothing, kwargs...)
     ctx = build_fit_context(dm)
     θ = something(theta_0_untransformed, initial_parameters(ctx))
+    sol = nothing
     for _ in 1:m.n_iter
         modes = empirical_bayes(ctx, θ)                     # E-step: posterior modes ...
         covs = empirical_bayes_covariance(ctx, θ, modes)    # ... and their covariance
-        θ, _ = optimize_parameters(ctx; θ_start = θ) do θn  # M-step, natural scale
+        θ, sol = optimize_parameters(ctx; θ_start = θ) do θn  # M-step, natural scale
             -sum(complete_data_loglikelihood(ctx, bi, θn, modes[bi]) +
                  0.5 * tr(covs[bi] * complete_data_loglikelihood_hessian(ctx, bi, θn, modes[bi]))
                  for bi in eachindex(get_batch_infos(ctx)))
         end
     end
     return build_fit_result(ctx, m, θ; kind = :frequentist_re,
-        objective = -laplace_marginal(ctx, θ))
+        objective = -laplace_marginal(ctx, θ),
+        converged = SciMLBase.successful_retcode(sol))
 end
 ```
+
+`build_fit_result` defaults `converged` to `missing`, so an estimator that omits it reports
+"unknown" rather than claiming success; pass the retcode of the solution `optimize_parameters`
+returns, as above.
 
 Every context call is a thin cover forwarding to the corresponding cache-explicit primitive
 with the context's stored objects - results are identical, and the explicit layer below remains

--- a/docs/src/tutorials/building-custom-estimators.md
+++ b/docs/src/tutorials/building-custom-estimators.md
@@ -37,7 +37,7 @@ algorithm is derived in Part 3) as a `FittingMethod` that `fit_model` can drive.
 
 ```julia
 using NoLimits
-using Optimization, OptimizationOptimJL, LineSearches
+using Optimization, OptimizationOptimJL, LineSearches, SciMLBase
 using ComponentArrays, Distributions, DataFrames, Random, LinearAlgebra
 using Turing: MH
 using CairoMakie
@@ -83,17 +83,19 @@ NoLimits.uq_family(::MyEM) = :wald_re      # inherit random-effect Wald interval
 function NoLimits.fit_method(dm, m::MyEM, args...; theta_0_untransformed=nothing, kwargs...)
     ctx = build_fit_context(dm)
     θ = something(theta_0_untransformed, initial_parameters(ctx))
+    sol = nothing
     for _ in 1:m.n_iter
         modes = empirical_bayes(ctx, θ)                    # E-step: posterior modes b* ...
         covs = empirical_bayes_covariance(ctx, θ, modes)   # ... and covariance Σ = (−H)⁻¹
-        θ, _ = optimize_parameters(ctx; θ_start=θ) do θn   # M-step, natural scale
+        θ, sol = optimize_parameters(ctx; θ_start=θ) do θn   # M-step, natural scale
             -sum(complete_data_loglikelihood(ctx, bi, θn, modes[bi]) +
                  0.5 * tr(covs[bi] * complete_data_loglikelihood_hessian(ctx, bi, θn, modes[bi]))
                  for bi in eachindex(get_batch_infos(ctx)))
         end
     end
     return build_fit_result(ctx, m, θ; kind=:frequentist_re,
-        objective=-laplace_marginal(ctx, θ), iterations=m.n_iter)
+        objective=-laplace_marginal(ctx, θ), iterations=m.n_iter,
+        converged=SciMLBase.successful_retcode(sol))
 end
 
 res_quick = fit_model(dm, MyEM())

--- a/src/data_model/DataModel.jl
+++ b/src/data_model/DataModel.jl
@@ -346,6 +346,16 @@ function _validate_schema(model, df, config::DataModelConfig)
     nrow(df) == 0 &&
         error("DataModel received a DataFrame with 0 rows. At least one observation is required.")
 
+    # Every declared covariate needs its backing column: an absent one otherwise
+    # surfaces as a raw DataFrames error from whichever later `_get_col` hits it (#315).
+    for name in model.covariates.covariates.names
+        p = getfield(model.covariates.covariates.params, name)
+        for c in _covariate_data_columns(p)
+            hasproperty(df, c) ||
+                error("Covariate $(name) is declared as $(nameof(typeof(p))) with column $(c), but $(c) is not present in the DataFrame.")
+        end
+    end
+
     _check_missing(_get_col(df, config.time_col), config.time_col)
     _check_missing(_get_col(df, config.primary_id), config.primary_id)
     tcol = _get_col(df, config.time_col)
@@ -432,16 +442,8 @@ function _validate_schema(model, df, config::DataModelConfig)
         !isempty(missing_cols) &&
             error("Missing observation columns $(missing_cols) required by @formulas. Add them to the data.")
     end
-    _validate_formula_covariates_missing(model, df, config)
+    _validate_covariates_missing(model, df, config)
     return nothing
-end
-
-function _formula_used_covariates(model)
-    covariates = model.covariates.covariates
-    isempty(covariates.names) && return Symbol[]
-    ir = get_formulas_ir(model.formulas.formulas)
-    used = Set{Symbol}(vcat(ir.var_syms, ir.prop_syms))
-    return [name for name in covariates.names if name in used]
 end
 
 function _check_covariate_missing(
@@ -449,15 +451,16 @@ function _check_covariate_missing(
     )
     data = idx === nothing ? _get_col(df, col) : _get_col(df, col)[idx]
     if any(ismissing, data)
-        error("Covariate $(cov_name) uses column $(col) in @formulas, but $(col) contains missing values on $(scope). Remove/replace missings before constructing DataModel.")
+        error("Covariate $(cov_name) uses column $(col), but $(col) contains missing values on $(scope). Remove/replace missings before constructing DataModel.")
     end
     return nothing
 end
 
-function _validate_formula_covariates_missing(model, df, config::DataModelConfig)
-    used_covariates = _formula_used_covariates(model)
-    isempty(used_covariates) && return nothing
+# Missings are validated by declaration, not by formula usage: a covariate used only in
+# a RE distribution or the DE otherwise failed much later inside a distribution (#309.5).
+function _validate_covariates_missing(model, df, config::DataModelConfig)
     covariates = model.covariates.covariates
+    isempty(covariates.names) && return nothing
     params = covariates.params
     obs_idx = if config.evid_col === nothing
         nothing
@@ -466,7 +469,7 @@ function _validate_formula_covariates_missing(model, df, config::DataModelConfig
         findall(==(0), evid)
     end
     obs_scope = config.evid_col === nothing ? "all rows" : "observation rows"
-    for name in used_covariates
+    for name in covariates.names
         p = getfield(params, name)
         if p isa Covariate
             _check_covariate_missing(df, p.column, obs_idx, name, obs_scope)
@@ -1612,6 +1615,8 @@ function DataModel(
         t0::Union{Nothing, Real} = 0.0,
         serialization::SciMLBase.EnsembleAlgorithm = EnsembleSerial()
     )
+    model isa Model ||
+        error("DataModel expects a Model built with @Model as its first argument; got $(typeof(model)). Check the argument order: DataModel(model, df; ...).")
     df = _as_dataframe(df)
     primary_id = _as_symbol(primary_id)
     time_col = _as_symbol(time_col)

--- a/src/data_model/DataModel.jl
+++ b/src/data_model/DataModel.jl
@@ -1184,7 +1184,7 @@ end
 # `t0` is the individual's actual integration start (see the `tspan` construction in
 # `_data_model`): only events recorded exactly there are folded into u0 / the initial
 # infusion rates, every later event becomes a PresetTimeCallback at its own time.
-function _build_callbacks(model, df, rows, config::DataModelConfig, t0)
+function _build_callbacks(model, df, rows, config::DataModelConfig, t0, tend, id_val, truncated)
     config.evid_col === nothing && return nothing
     model.de.de === nothing && return nothing
     evid = _get_col(df, config.evid_col)[rows]
@@ -1262,6 +1262,7 @@ function _build_callbacks(model, df, rows, config::DataModelConfig, t0)
                     init_rate_starts[cmt_i] += rate_i
                     duration = abs(amt_i / rate_i)
                     stop_t = t + duration
+                    stop_t > tend && push!(truncated, (id_val, t, stop_t))
                     stop_delta = _get_or_init!(rate_delta_by_time, stop_t, n_states)
                     stop_delta[cmt_i] -= rate_i
                 end
@@ -1274,6 +1275,7 @@ function _build_callbacks(model, df, rows, config::DataModelConfig, t0)
                     start_delta = _get_or_init!(rate_delta_by_time, t, n_states)
                     start_delta[cmt_i] += rate_i
                     stop_t = t + duration
+                    stop_t > tend && push!(truncated, (id_val, t, stop_t))
                     stop_delta = _get_or_init!(rate_delta_by_time, stop_t, n_states)
                     stop_delta[cmt_i] -= rate_i
                 end
@@ -1674,6 +1676,7 @@ function DataModel(
 
     bad_ids = Any[]
     bad_tmin = Dict{Any, Tuple{Float64, Float64}}()
+    truncated_infusions = Tuple{Any, Any, Any}[]
     for (i, rows) in enumerate(groups)
         tvals = _get_col(df, time_col)[rows]
         _validate_dynamic_covariates(cov, rows, tvals, keys_sorted[i])
@@ -1711,7 +1714,7 @@ function DataModel(
             end
             tspan = (oftype(tmin, start), tmax)
         end
-        callbacks = _build_callbacks(model, df, rows, config, tspan[1])
+        callbacks = _build_callbacks(model, df, rows, config, tspan[1], tspan[2], keys_sorted[i], truncated_infusions)
         if !isempty(de_dyn) && tspan[1] < minimum(tvals)
             error("Formulas request times earlier than the dynamic covariate support for individual $(keys_sorted[i]): the integration span starts at t=$(tspan[1]) (smallest formula time offset $(off_min)), but the dynamic covariate(s) $(join(de_dyn, ", ")) used in @DifferentialEquation are only supported on [$(minimum(tvals)), $(maximum(tvals))] and cannot be extrapolated. Add covariate rows covering t=$(tspan[1]), or change the formula offset (or t0) so that the integration starts at or after $(minimum(tvals)).")
         end
@@ -1726,6 +1729,11 @@ function DataModel(
         cb_times = callbacks !== nothing ? callbacks.all_times : Float64[]
         saveat = _build_saveat(df, rows, obs_rows, time_col, config, time_offsets, cb_times)
         individuals[i] = Individual(series, const_cov, callbacks, tspan, re_groups, saveat, tstops)
+    end
+
+    if !isempty(truncated_infusions)
+        details = join(["$(id): dose at t=$(t0i) stops at t=$(st)" for (id, t0i, st) in truncated_infusions], ", ")
+        @warn "Infusion stop time is after the end of the integration span, so the infusion is truncated and less than AMT is delivered ($(details)). Extend the observation times (or t0/formula offsets) past the infusion end if the full dose should be delivered."
     end
 
     if !isempty(bad_ids)

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -3712,8 +3712,9 @@ function _loglikelihood_individual(dm::DataModel, idx::Int, θ, η_ind, cache::_
         _is_numeric_error(err) || rethrow(err)
         if !Threads.atomic_cas!(_WARNED_NUMERIC_ERROR, false, true)
             @warn "A numeric error ($(nameof(typeof(err)))) was raised while evaluating " *
-                "the likelihood; treating this point as -Inf. Check the domains of " *
-                "`log`, `sqrt` and `^` in @formulas / @DifferentialEquation. " *
+                "the likelihood; treating this point as -Inf. The error was: " *
+                "$(_brief_error_message(err)). If this is a `log`/`sqrt`/`^` domain issue, " *
+                "check those domains in @formulas / @DifferentialEquation. " *
                 "Warned once per fit."
         end
         return -Inf

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -429,7 +429,7 @@ struct FitResult{M <: FittingMethod, R <: MethodResult, S, D, DM, A, K}
 end
 
 """
-    build_fit_result(dm, method, θ; kind=:frequentist, objective, converged=true, iterations=missing,
+    build_fit_result(dm, method, θ; kind=:frequentist, objective, converged=missing, iterations=missing,
                      eb_modes=nothing, eta_vec=nothing, strategies=nothing, solution=nothing,
                      raw=nothing, notes=NamedTuple(), optimizer=nothing,
                      convergence=NamedTuple(), timing=NamedTuple(),
@@ -450,6 +450,11 @@ either scale. `kind` selects the result routing:
     order) so `get_random_effects`, `get_loglikelihood`, and plotting resolve the random effects.
   - `:pooled` - plugged-in random effects supplied through `eta_vec`.
 
+`converged` defaults to `missing` rather than `true`: an estimator that never inspects its
+optimizer's return code must not claim convergence. Pass
+`converged = SciMLBase.successful_retcode(sol)` with the `sol` that
+[`optimize_parameters`](@ref) (or `Optimization.solve`) returned.
+
 Reusing `:frequentist_re` gives the widest random-effect accessor coverage. Note that `compute_uq`
 routes on the `method` *type*; to inherit Wald/profile intervals either pass a built-in `method`
 instance (e.g. `Laplace()`) or define the `uq_family` trait for your method type.
@@ -461,7 +466,7 @@ function build_fit_result(
         dm::DataModel, method::FittingMethod, θ::ComponentArray;
         kind::Symbol = :frequentist,
         objective::Real,
-        converged::Bool = true,
+        converged::Union{Bool, Nothing, Missing} = missing,
         iterations = missing,
         eb_modes = nothing,
         eta_vec = nothing,
@@ -537,10 +542,11 @@ Return the final objective value (e.g. negative log-likelihood for MLE).
 get_objective(res::FitResult) = res.summary.objective
 
 """
-    get_converged(res::FitResult) -> Bool or Nothing
+    get_converged(res::FitResult) -> Bool, Nothing or Missing
 
 Return the convergence flag. `true` indicates successful convergence, `false` indicates
-failure, and `nothing` is returned for methods that do not track convergence (e.g. MCMC).
+failure, `nothing` is returned for methods that do not track convergence (e.g. MCMC), and
+`missing` for a custom estimator that did not report one to [`build_fit_result`](@ref).
 """
 get_converged(res::FitResult) = res.summary.converged
 
@@ -1552,6 +1558,50 @@ function _compute_mcmc_candidates(
     end
 end
 
+# Post-hoc EBE convergence diagnostic: max|∂ℓ/∂b| per batch at the stored modes. Shared by
+# the final EBE passes (SAEM/MCEM/`reestimate_ebes`) and the Laplace-family/GHQ finishes.
+function _ebe_grad_norms(
+        ebe_cache, dm::DataModel, batch_infos, θu::ComponentArray,
+        const_cache, ll_cache, active_set = nothing
+    )
+    ll_local = ll_cache isa AbstractVector ? ll_cache[1] : ll_cache
+    norms = Vector{Float64}(undef, length(batch_infos))
+    for (bi, info) in enumerate(batch_infos)
+        if get_n_b(info) == 0 || (active_set !== nothing && !(bi ∈ active_set))
+            norms[bi] = 0.0
+            continue
+        end
+        b = ebe_cache.bstar_cache.b_star[bi]
+        if isempty(b)
+            norms[bi] = Inf
+            continue
+        end
+        g, _ = _laplace_gradb_cached!(
+            ebe_cache, bi, dm, info, θu, const_cache, ll_local, b
+        )
+        gn = maximum(abs, g)
+        norms[bi] = isfinite(gn) ? Float64(gn) : Inf
+    end
+    return norms
+end
+
+# Warn (never error) when the modes a fit returns miss the EBE gradient tolerance. Skipped
+# for models without random effects and outside plain floating-point θ (never inside AD).
+function _warn_ebe_grad_tol(
+        ebe_cache, dm::DataModel, batch_infos, θu::ComponentArray,
+        const_cache, ll_cache, grad_tol; label::AbstractString = "Fit"
+    )
+    (eltype(θu) <: AbstractFloat && !isempty(batch_infos)) || return nothing
+    tol = Float64(grad_tol)
+    isfinite(tol) && tol > 0 || return nothing
+    norms = _ebe_grad_norms(ebe_cache, dm, batch_infos, θu, const_cache, ll_cache)
+    all(iszero, norms) && return nothing
+    if any(>(tol), norms)
+        @warn "$(label): the returned empirical Bayes estimates do not satisfy the EBE gradient tolerance for all batches; treat the marginal-likelihood approximation with care." max_grad = maximum(norms) grad_tol = tol
+    end
+    return nothing
+end
+
 function _compute_bstars(
         dm::DataModel,
         θu::ComponentArray,
@@ -1576,26 +1626,9 @@ function _compute_bstars(
         SciMLBase.EnsembleSerial()
     active_set = active_batch_indices === nothing ? nothing : Set(active_batch_indices)
 
-    function _batch_grad_norms()
-        norms = Vector{Float64}(undef, n_batches)
-        for (bi, info) in enumerate(batch_infos)
-            if get_n_b(info) == 0 || (active_set !== nothing && !(bi ∈ active_set))
-                norms[bi] = 0.0
-                continue
-            end
-            b = ebe_cache.bstar_cache.b_star[bi]
-            if isempty(b)
-                norms[bi] = Inf
-                continue
-            end
-            g, _ = _laplace_gradb_cached!(
-                ebe_cache, bi, dm, info, θu, const_cache, ll_cache_local, b
-            )
-            gn = maximum(abs, g)
-            norms[bi] = isfinite(gn) ? Float64(gn) : Inf
-        end
-        return norms
-    end
+    _batch_grad_norms() = _ebe_grad_norms(
+        ebe_cache, dm, batch_infos, θu, const_cache, ll_cache_local, active_set
+    )
 
     bstars = _laplace_get_bstar!(
         ebe_cache, dm, batch_infos, θu, const_cache, ll_cache;

--- a/src/estimation/common.jl
+++ b/src/estimation/common.jl
@@ -1101,8 +1101,8 @@ end
 # Resolve the transformed free-parameter optimizer bounds shared by the fixed-effect
 # fit drivers (MLE/MAP/Pooled/GHQuadrature/Laplace/FOCEI and the SAEM/MCEM M-step).
 # Coerces user lb/ub (scalar / NamedTuple / ComponentArray / vector) onto the
-# free-name subset, falls back to the model hard bounds, and applies the
-# BlackBoxOptim finite-bounds + model-intersection + start-clamp rules.
+# free-name subset, falls back to the model hard bounds, applies the finite-bounds +
+# model-intersection rules of the optimizers that need a box, and clamps the start into it.
 # `ignore_model_bounds`/`allow_bbo`/`emit_info` are args (not read off the method)
 # because SAEM/MCEM have no `ignore_model_bounds` field, FOCEI has no BBO support,
 # and Pooled suppresses the warning after refit round 1. Returns
@@ -1173,23 +1173,45 @@ function resolve_optimizer_bounds(
     # Match by module name so OptimizationBBO stays out of this package's dependencies;
     # only a user who actually passes a BBO optimizer needs it installed.
     is_bbo = allow_bbo && nameof(parentmodule(typeof(optimizer))) === :OptimizationBBO
-    if is_bbo && !use_bounds
+    # IPNewton is barrier-only and throws inside Optim's private types without a box;
+    # ParticleSwarm (like BBO) samples particles uniformly inside the box, so an infinite
+    # edge yields all-NaN estimates with a finite objective and no warning (#311).
+    opt_label = is_bbo ? "BlackBoxOptim methods require" : "$(nameof(typeof(optimizer))) requires"
+    requires_bounds = is_bbo || optimizer isa OptimizationOptimJL.IPNewton
+    requires_finite = requires_bounds || optimizer isa OptimizationOptimJL.ParticleSwarm
+    if requires_bounds && !use_bounds
         error(
-            "BlackBoxOptim methods require finite bounds. Add lower/upper bounds in " *
+            "$(opt_label) finite bounds. Add lower/upper bounds in " *
                 "@fixedEffects (on transformed scale) or pass them via " *
                 "$(method_label)(lb=..., ub=...). A quick helper is " *
                 "default_bounds_from_start(dm; margin=...)."
         )
     end
-    if is_bbo && !(all(isfinite, lb) && all(isfinite, ub))
-        error("BlackBoxOptim methods require finite lower and upper bounds for all free parameters.")
+    if requires_finite && use_bounds && !(all(isfinite, lb) && all(isfinite, ub))
+        error("$(opt_label) finite lower and upper bounds for all free parameters.")
     end
-    if is_bbo
+    if requires_finite && use_bounds
         lb = map((u, m) -> isfinite(m) ? max(u, m) : u, collect(lb), lower_vec)
         ub = map((u, m) -> isfinite(m) ? min(u, m) : u, collect(ub), upper_vec)
-        θ0_init = clamp.(collect(θ0_free_t), lb, ub)
-    else
-        θ0_init = θ0_free_t
+    end
+    θ0_init = θ0_free_t
+    # Without this the optimizer reports the violation in preconditioned z-coordinates
+    # (`Initial x[(1,)]=0.0 is outside of [-1.2, -0.8]`), naming no number the user typed;
+    # the EM M-steps anchor z at the current iterate and hit the same message (#311).
+    if use_bounds
+        v = collect(θ0_init)
+        outside = findall(i -> !(lb[i] <= v[i] <= ub[i]), eachindex(v))
+        if !isempty(outside)
+            coord_names = try
+                _flat_names_for_free(fe, collect(free_names))
+            catch
+                Symbol[]
+            end
+            labels = length(coord_names) == length(v) ?
+                string.(coord_names[outside]) : string.("coordinate ", outside)
+            @warn "$(method_label): the start value of $(join(labels, ", ")) lies outside the bounds and was clamped into the box. Values are on the TRANSFORMED parameter scale." start = v[outside] lower = lb[outside] upper = ub[outside]
+            θ0_init = clamp.(v, lb, ub)
+        end
     end
     return lb, ub, use_bounds, θ0_init
 end

--- a/src/estimation/cv.jl
+++ b/src/estimation/cv.jl
@@ -71,6 +71,8 @@ get_fold_results(r::CVResult) = r.fold_results
 Return the combined per-observation score table from all folds. Contains columns
 `:fold`, `:individual`, `:time`, `:outcome`, `:obs`, `:loglikelihood`,
 `:predicted_mean`, and optionally `:loss` when a loss function was supplied.
+Under the Monte-Carlo random-effect modes `:loglikelihood` holds the individual's joint
+predictive marginal on its first row and `0.0` on the others (see [`fit_cv`](@ref)).
 """
 get_obs_scores(r::CVResult) = r.obs_scores
 
@@ -514,7 +516,11 @@ function _cv_evaluate_ebe(
 end
 
 # MC path: marginalize over the conditional (seen) or prior (unseen) using S MC draws.
-# Aggregates per-obs log-likelihoods via logsumexp and predicted means via arithmetic mean.
+# The score is the per-individual JOINT marginal log(1/S Σ_s Π_r p(y_r|η_s)) (#290): the
+# row log-likelihoods are summed within an individual per draw, then logsumexp'd across
+# draws. It is carried on the individual's first row with 0.0 on the others, so every
+# consumer that sums `:loglikelihood` stays correct; per-row values are therefore not
+# per-observation densities in these modes. Predicted means/losses stay per-row means.
 function _cv_evaluate_mc(
         dm_train, dm_test, res_train, θu, ll_cache_test, loss,
         seen_re_mode, unseen_re_mode, n_mc_samples, rng, re_names,
@@ -625,7 +631,8 @@ function _cv_evaluate_mc(
         base_df = all_dfs[s0][j]
         n_rows = nrow(base_df)
 
-        ll_acc = fill(-Inf, n_rows)
+        ll_acc = -Inf                      # logsumexp over draws of the subject sum
+        n_valid_draws = 0
         mean_acc = fill(0.0, n_rows)
         mean_cnt = fill(0, n_rows)
         loss_acc = :loss ∈ names(base_df) ? fill(0.0, n_rows) : nothing
@@ -634,9 +641,15 @@ function _cv_evaluate_mc(
         for s in 1:n_mc_samples
             df_s = all_dfs[s][j]
             nrow(df_s) == n_rows || continue   # ODE failure → contributes 0 probability
+            draw_ll = 0.0
             for r in 1:n_rows
-                lp = df_s[r, :loglikelihood]
-                isnan(lp) || (ll_acc[r] = logaddexp(ll_acc[r], lp))
+                draw_ll += df_s[r, :loglikelihood]
+            end
+            if !isnan(draw_ll)
+                ll_acc = logaddexp(ll_acc, draw_ll)
+                n_valid_draws += 1
+            end
+            for r in 1:n_rows
                 pm = df_s[r, :predicted_mean]
                 if !isnan(pm)
                     mean_acc[r] += pm
@@ -653,7 +666,12 @@ function _cv_evaluate_mc(
         end
 
         df_out = copy(base_df)
-        df_out[!, :loglikelihood] = ll_acc .- log(n_mc_samples)
+        df_out[!, :loglikelihood] = if n_valid_draws == 0
+            fill(NaN, n_rows)              # no usable draw → drop the whole individual
+        else
+            joint_ll = ll_acc - log(n_valid_draws)
+            [r == 1 ? joint_ll : 0.0 for r in 1:n_rows]
+        end
         df_out[!, :predicted_mean] = [
             mean_cnt[r] > 0 ? mean_acc[r] / mean_cnt[r] : NaN
                 for r in 1:n_rows
@@ -716,6 +734,13 @@ performance on the held-out test set. All `kwargs` are forwarded to
 - `fold_serialization`: controls fold-level parallelism. Use `EnsembleThreads()`
   to evaluate folds concurrently.
 - `constants_re`: fix specific RE levels on the natural scale.
+
+The Monte-Carlo modes (`:conditional`/`:montecarlo`) score each test individual by its
+joint predictive marginal `log( (1/S) Σ_s Π_r p(y_r|b_s) )`, not by a sum of
+per-observation predictive densities. That value is stored on the individual's first row
+of `obs_scores` with `0.0` on its remaining rows, so fold totals and
+`mean_obs_loglikelihood` keep summing correctly while a single `:loglikelihood` entry is
+no longer a per-observation quantity in these modes.
 
 With `seen_re_mode=:ebe, unseen_re_mode=:mean` each random effect's level is resolved
 separately, so a crossed test individual keeps the trained value for every level it shares

--- a/src/estimation/dev_api.jl
+++ b/src/estimation/dev_api.jl
@@ -2071,6 +2071,10 @@ in `f_natural`. Do-block friendly:
         -sum(complete_data_loglikelihood(ctx, bi, θn, modes[bi]) for bi in eachindex(get_batch_infos(ctx)))
     end
 
+The returned `sol` carries the optimizer's verdict: pass
+`converged = SciMLBase.successful_retcode(sol)` to [`build_fit_result`](@ref) instead of
+letting it default to `missing`.
+
 `ponytail:` optimizes all fixed effects; apply `constants`/bounds via the explicit
 `free_parameter_layout`/`resolve_optimizer_bounds` path when needed.
 """

--- a/src/estimation/ghquadrature.jl
+++ b/src/estimation/ghquadrature.jl
@@ -566,6 +566,12 @@ function _fit_model_scalar(
         serialization = serialization
     )
 
+    # Post-hoc EBE diagnostic (#311), same check as the Laplace family.
+    _warn_ebe_grad_tol(
+        ebe_cache, dm, batch_infos, θ_hat_u, const_cache, ll_cache,
+        inner_opts.grad_tol; label = string(nameof(typeof(method)))
+    )
+
     # ── Build result ─────────────────────────────────────────────────────────
     isfinite(sol.objective) ||
         _warn_nonfinite_fit(dm, θ_hat_u, string(nameof(typeof(method))))

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -2896,6 +2896,11 @@ function _fit_laplace_family(
     # and not a fit; the flat wall otherwise lets the optimizer report success (#247).
     infeasible_fit = wall_ref[] === nothing
     fitted = resolve_fitted_parameters(layout, _θt_from_z(sol.u))
+    # Post-hoc EBE diagnostic (#311): the whole approximation rests on these modes.
+    infeasible_fit || _warn_ebe_grad_tol(
+        ebe_cache, dm, batch_infos, fitted.untransformed, const_cache, ll_cache,
+        inner_opts.grad_tol; label = string(nameof(typeof(method)))
+    )
     (infeasible_fit || !isfinite(sol.objective)) &&
         _warn_nonfinite_fit(dm, fitted.untransformed, string(nameof(typeof(method))))
     summary = FitSummary(

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -1035,7 +1035,8 @@ function _re_logpdf_batch(
         _is_numeric_error(err) || rethrow(err)
         if !Threads.atomic_cas!(_WARNED_NUMERIC_ERROR, false, true)
             @warn "A numeric error ($(nameof(typeof(err)))) was raised while evaluating " *
-                "the random-effect prior; treating this point as -Inf. Warned once per fit."
+                "the random-effect prior; treating this point as -Inf. The error was: " *
+                "$(_brief_error_message(err)). Warned once per fit."
         end
         return convert(promote_type(eltype(θ), eltype(b)), -Inf)
     end

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -1545,8 +1545,8 @@ function _fit_model(
                     return -Q2val
                 end
                 lb_q2, ub_q2, use_bounds_q2, θ0_q2 = _resolve_optim_bounds(
-                    fe, q2_free_now, collect(θt_q2), method.optimizer, nothing,
-                    nothing, NamedTuple(); allow_bbo = false
+                    fe, q2_free_now, collect(θt_q2), method.optimizer, method.lb,
+                    method.ub, NamedTuple(); allow_bbo = false, method_label = "MCEM"
                 )
                 optf_q2 = OptimizationFunction(obj_q2, method.adtype)
                 z0_q2 = _z_from_q2(θ0_q2)

--- a/src/estimation/mcmc_types.jl
+++ b/src/estimation/mcmc_types.jl
@@ -201,7 +201,7 @@ function Distributions._logpdf(p::_SafeMatrixPrior, x::AbstractMatrix{<:Real})
         if !Threads.atomic_cas!(_WARNED_NUMERIC_ERROR, false, true)
             @warn "A numeric error ($(nameof(typeof(err)))) was raised while evaluating " *
                 "the prior of $(p.name) (a $(nameof(typeof(p.d)))); rejecting this " *
-                "proposal. Warned once per fit."
+                "proposal. The error was: $(_brief_error_message(err)). Warned once per fit."
         end
         return convert(float(eltype(x)), -Inf)
     end

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -2986,11 +2986,14 @@ function _saem_builtin_mean_updates(
         transform,
         inv_transform;
         optimizer = OptimizationOptimJL.LBFGS(linesearch = LineSearches.BackTracking(maxstep = 1.0)),
+        adtype = Optimization.AutoForwardDiff(),
         optim_kwargs::NamedTuple = NamedTuple(),
         serialization::SciMLBase.EnsembleAlgorithm = EnsembleThreads(),
         penalty::NamedTuple = NamedTuple(),
         extra_objective = nothing,
-        anneal_sds::NamedTuple = NamedTuple()
+        anneal_sds::NamedTuple = NamedTuple(),
+        user_lb = nothing,
+        user_ub = nothing
     )
     isempty(mean_params) && return NamedTuple()
     if get_de(get_model(dm)) === nothing
@@ -3034,9 +3037,13 @@ function _saem_builtin_mean_updates(
         return obj
     end
 
-    optf = OptimizationFunction(obj_only, Optimization.AutoForwardDiff())
-    θ0_init = collect(θt_mean)
-    prob = OptimizationProblem(optf, θ0_init)
+    optf = OptimizationFunction(obj_only, adtype)
+    lb, ub, use_bounds, θ0_init = _resolve_optim_bounds(
+        get_fixed(get_model(dm)), mean_names, collect(θt_mean), optimizer,
+        user_lb, user_ub, NamedTuple(); allow_bbo = false, method_label = "SAEM"
+    )
+    prob = use_bounds ? OptimizationProblem(optf, collect(θ0_init); lb = lb, ub = ub) :
+        OptimizationProblem(optf, collect(θ0_init))
     sol = Optimization.solve(prob, optimizer; optim_kwargs...)
     θt_mean_hat = sol.u isa ComponentArray ? sol.u : ComponentArray(sol.u, axs_mean)
 
@@ -3604,10 +3611,12 @@ function _fit_model(
                     dm, batch_infos, b_current,
                     ComponentArray(θu_curr, getaxes(θu_curr)), const_cache,
                     mean_params, cache, sample_store, transform, inv_transform;
-                    optimizer = method.optimizer, optim_kwargs = method.optim_kwargs,
+                    optimizer = method.optimizer, adtype = method.adtype,
+                    optim_kwargs = method.optim_kwargs,
                     serialization = serialization, penalty = penalty,
                     extra_objective = extra_objective,
-                    anneal_sds = anneal_sds
+                    anneal_sds = anneal_sds,
+                    user_lb = method.lb, user_ub = method.ub
                 )
                 if !isempty(mean_updates)
                     iter_constants = merge(iter_constants, mean_updates)
@@ -3700,8 +3709,8 @@ function _fit_model(
                     return -Q2val
                 end
                 lb_q2, ub_q2, use_bounds_q2, θ0_q2 = _resolve_optim_bounds(
-                    fe, q2_free_now, collect(θt_q2), method.optimizer, nothing,
-                    nothing, NamedTuple(); allow_bbo = false
+                    fe, q2_free_now, collect(θt_q2), method.optimizer, method.lb,
+                    method.ub, NamedTuple(); allow_bbo = false, method_label = "SAEM"
                 )
                 optf_q2 = OptimizationFunction(obj_q2, method.adtype)
                 z0_q2 = _z_from_q2(θ0_q2)

--- a/src/model/Covariates.jl
+++ b/src/model/Covariates.jl
@@ -253,16 +253,20 @@ function _parse_covariates(block::Expr)
     block.head == :block || error("@covariates expects a begin ... end block.")
     names = Symbol[]
     exprs = Expr[]
+    ln = nothing
     for stmt in block.args
-        stmt isa LineNumberNode && continue
-        stmt isa Expr || error("Invalid statement in @covariates block.")
-        stmt.head == :(=) || error("Only assignments are allowed in @covariates block.")
+        if stmt isa LineNumberNode
+            ln = stmt
+            continue
+        end
+        stmt isa Expr || error("Invalid statement in @covariates block." * _stmt_loc(ln, stmt))
+        stmt.head == :(=) || error("Only assignments are allowed in @covariates block." * _stmt_loc(ln, stmt))
         lhs, rhs = stmt.args
-        lhs isa Symbol || error("Left-hand side must be a symbol in @covariates block.")
+        lhs isa Symbol || error("Left-hand side must be a symbol in @covariates block." * _stmt_loc(ln, stmt))
         lhs in names &&
-            error("Duplicate covariate $(lhs) in @covariates block; covariate names must be unique.")
+            error("Duplicate covariate $(lhs) in @covariates block; covariate names must be unique." * _stmt_loc(ln, stmt))
         rhs isa Expr && rhs.head == :call ||
-            error("Right-hand side must be a constructor call in @covariates block.")
+            error("Right-hand side must be a constructor call in @covariates block." * _stmt_loc(ln, stmt))
         _validate_covariate_ctor(rhs)
         rhs = _rewrite_univariate_covariate(lhs, rhs)
         push!(names, lhs)

--- a/src/model/DifferentialEquation.jl
+++ b/src/model/DifferentialEquation.jl
@@ -652,20 +652,24 @@ function _parse_de(block::Expr)
     line_exprs = Expr[]
     seen = Set{Symbol}()
 
+    ln = nothing
     for stmt in block.args
-        stmt isa LineNumberNode && continue
-        stmt isa Expr || error("Invalid statement in @DifferentialEquation block.")
+        if stmt isa LineNumberNode
+            ln = stmt
+            continue
+        end
+        stmt isa Expr || error("Invalid statement in @DifferentialEquation block." * _stmt_loc(ln, stmt))
 
         if stmt.head == :(=)
             lhs, rhs = stmt.args
             lhs isa Expr && lhs.head == :call ||
-                error("Derived signals must be function-like: s(t)=... .")
+                error("Derived signals must be function-like: s(t)=... ." * _stmt_loc(ln, stmt))
             name = lhs.args[1]
-            name isa Symbol || error("Derived signal name must be a Symbol.")
-            length(lhs.args) == 2 || error("Derived signal must be of form s(t) = expr.")
+            name isa Symbol || error("Derived signal name must be a Symbol." * _stmt_loc(ln, stmt))
+            length(lhs.args) == 2 || error("Derived signal must be of form s(t) = expr." * _stmt_loc(ln, stmt))
             arg = lhs.args[2]
-            (arg == :t || arg == :ξ) || error("Derived signal argument must be t or ξ.")
-            name in seen && error("Duplicate DE name: $(name).")
+            (arg == :t || arg == :ξ) || error("Derived signal argument must be t or ξ." * _stmt_loc(ln, stmt))
+            name in seen && error("Duplicate DE name: $(name)." * _stmt_loc(ln, stmt))
             push!(seen, name)
             push!(signal_names, name)
             push!(signal_exprs, rhs)
@@ -674,15 +678,15 @@ function _parse_de(block::Expr)
         end
 
         stmt.head == :call && stmt.args[1] == :~ ||
-            error("Only D(x) ~ expr or s(t)=expr are allowed in @DifferentialEquation.")
+            error("Only D(x) ~ expr or s(t)=expr are allowed in @DifferentialEquation." * _stmt_loc(ln, stmt))
         lhs, rhs = stmt.args[2], stmt.args[3]
         lhs isa Expr && lhs.head == :call && lhs.args[1] == :D ||
-            error("Left-hand side must be D(state).")
+            error("Left-hand side must be D(state)." * _stmt_loc(ln, stmt))
         length(lhs.args) == 2 ||
-            error("Left-hand side must be D(state) with a single symbol.")
+            error("Left-hand side must be D(state) with a single symbol." * _stmt_loc(ln, stmt))
         state = lhs.args[2]
-        state isa Symbol || error("State name must be a Symbol.")
-        state in seen && error("Duplicate DE name: $(state).")
+        state isa Symbol || error("State name must be a Symbol." * _stmt_loc(ln, stmt))
+        state in seen && error("Duplicate DE name: $(state)." * _stmt_loc(ln, stmt))
         push!(seen, state)
         push!(state_names, state)
         push!(rhs_exprs, rhs)

--- a/src/model/FixedEffects.jl
+++ b/src/model/FixedEffects.jl
@@ -753,6 +753,16 @@ function _flatten_by_specs(
                     push!(flat_names, Symbol(name, "_", r, "_", c))
                 end
             end
+        elseif spec.kind == :expm
+            # Upper triangle, column by column -- must match `_upper_tri_vec` and the
+            # natural-scale `:expm` branch of `_coords_for_param`. `:lie` keeps linear
+            # indices: its coordinates are [log-eigenvalues; rotation coefficients],
+            # not matrix entries.
+            for c in 1:spec.size[2]
+                for r in 1:c
+                    push!(flat_names, Symbol(name, "_", r, "_", c))
+                end
+            end
         elseif val isa AbstractMatrix
             for r in 1:size(val, 1)
                 for c in 1:size(val, 2)

--- a/src/model/FixedEffects.jl
+++ b/src/model/FixedEffects.jl
@@ -272,6 +272,28 @@ const _PARAM_BLOCK_CTORS = (
     :SplineParameters, :NPFParameter,
 )
 
+# Last symbol of a call head (`f`, `Mod.f`, or a GlobalRef), or `nothing`.
+function _fe_call_head_symbol(fn)
+    fn isa Symbol && return fn
+    fn isa GlobalRef && return fn.name
+    if fn isa Expr && fn.head == :.
+        last = fn.args[end]
+        last isa QuoteNode && (last = last.value)
+        last isa Symbol && return last
+    end
+    return nothing
+end
+
+# A parameter block is a type, so its constructor is capitalized. Operators and ordinary
+# functions (`a = 1 + 2`) must not get a `name =` kwarg spliced in (#313); user-defined
+# blocks are allowed, hence the capitalization rule rather than the allowlist.
+function _fe_is_param_block_call(rhs::Expr)
+    sym = _fe_call_head_symbol(rhs.args[1])
+    sym === nothing && return false
+    sym in _PARAM_BLOCK_CTORS && return true
+    return isuppercase(first(string(sym)))
+end
+
 function _qualify_ctor_head(ex::Expr)
     head = ex.args[1]
     if head isa Symbol && head in _PARAM_BLOCK_CTORS
@@ -284,16 +306,22 @@ function _parse_fixed_effects(block::Expr)
     block.head == :block || error("@fixedEffects expects a begin ... end block.")
     names = Symbol[]
     exprs = Expr[]
+    ln = nothing
     for stmt in block.args
-        stmt isa LineNumberNode && continue
-        stmt isa Expr || error("Invalid statement in @fixedEffects block.")
-        stmt.head == :(=) || error("Only assignments are allowed in @fixedEffects block.")
+        if stmt isa LineNumberNode
+            ln = stmt
+            continue
+        end
+        stmt isa Expr || error("Invalid statement in @fixedEffects block." * _stmt_loc(ln, stmt))
+        stmt.head == :(=) || error("Only assignments are allowed in @fixedEffects block." * _stmt_loc(ln, stmt))
         lhs, rhs = stmt.args
-        lhs isa Symbol || error("Left-hand side must be a symbol in @fixedEffects block.")
+        lhs isa Symbol || error("Left-hand side must be a symbol in @fixedEffects block." * _stmt_loc(ln, stmt))
         lhs in names &&
-            error("Duplicate fixed effect $(lhs) in @fixedEffects block; parameter names must be unique.")
+            error("Duplicate fixed effect $(lhs) in @fixedEffects block; parameter names must be unique." * _stmt_loc(ln, stmt))
         rhs isa Expr && rhs.head == :call ||
-            error("Right-hand side must be a constructor call in @fixedEffects block.")
+            error("Right-hand side must be a constructor call in @fixedEffects block." * _stmt_loc(ln, stmt))
+        _fe_is_param_block_call(rhs) ||
+            error("Right-hand side of `$(lhs) = ...` in @fixedEffects must be a parameter-block constructor call such as RealNumber(...); got `$(rhs)`." * _stmt_loc(ln, stmt))
         push!(names, lhs)
         push!(exprs, _qualify_ctor_head(_with_name_kw(rhs, lhs)))
     end

--- a/src/model/Formulas.jl
+++ b/src/model/Formulas.jl
@@ -427,6 +427,26 @@ function _formulas_crossing_spec(name::Symbol, rhs)
     return (name, _sym(pos[1]), _sym(pos[2]), tmax, kind)
 end
 
+# Deterministic nodes are emitted in declaration order, so a node referencing a name
+# defined further down the block used to fail with a bare UndefVarError at the first
+# evaluation (#314). The shared symbol check cannot see this: its `known` set is
+# unordered.
+function _formulas_check_det_order(ir::FormulasIR, known_names)
+    known = Set{Symbol}(known_names)
+    det_set = Set{Symbol}(ir.det_names)
+    defined = Set{Symbol}()
+    for i in eachindex(ir.det_names)
+        syms = _nl_collect_free_syms!(Set{Symbol}(), ir.det_exprs[i])
+        forward = sort(
+            [s for s in syms if s in det_set && !(s in defined) && !(s in known)]
+        )
+        isempty(forward) ||
+            error("@formulas node `$(ir.det_names[i])` references $(join(string.(forward), ", ")), which is defined later in the same block. Move the definition above `$(ir.det_names[i])`.")
+        push!(defined, ir.det_names[i])
+    end
+    return nothing
+end
+
 function _formulas_build_formulas_expr(
         ir::FormulasIR,
         fixed_names::Vector{Symbol},
@@ -440,6 +460,13 @@ function _formulas_build_formulas_expr(
         signal_names::Vector{Symbol},
         index_sym::Symbol,
         collect_fixed_names::Vector{Symbol} = Symbol[]
+    )
+    _formulas_check_det_order(
+        ir,
+        vcat(
+            fixed_names, re_names, prede_names, const_cov_names, varying_cov_names,
+            helper_names, model_fun_names, state_names, signal_names
+        )
     )
     det_exprs = copy(ir.det_exprs)
     # crossing-time nodes are computed by the solver event callback and merged into

--- a/src/model/Formulas.jl
+++ b/src/model/Formulas.jl
@@ -503,16 +503,18 @@ function _formulas_build_formulas_expr(
     const_cov_set = Set(const_cov_names)
     varying_cov_set = Set(varying_cov_names)
 
-    for sym in var_syms
-        in_fixed = sym in fixed_set
-        in_re = sym in re_set
-        in_pre = sym in prede_set
-        in_const = sym in const_cov_set
-        in_var = sym in varying_cov_set
-        count = (in_fixed ? 1 : 0) + (in_re ? 1 : 0) + (in_pre ? 1 : 0) +
-            (in_const ? 1 : 0) + (in_var ? 1 : 0)
-        count > 1 &&
-            error("Symbol $(sym) is ambiguous in @formulas (appears in multiple namespaces).")
+    # Every namespace a bare name resolves from. Outcome, deterministic-node, helper,
+    # model-function, state and signal names used to be omitted, so an outcome sharing
+    # a name with a fixed effect silently used the fixed effect (#312).
+    let namespaces = (
+            fixed_set, re_set, prede_set, const_cov_set, varying_cov_set,
+            Set(helper_names), Set(model_fun_names), Set(state_names),
+            Set(signal_names), Set(ir.det_names), Set(ir.obs_names),
+        )
+        for sym in union(namespaces...)
+            Base.count(ns -> sym in ns, namespaces) > 1 &&
+                error("Symbol $(sym) is ambiguous in @formulas (appears in multiple namespaces).")
+        end
     end
 
     fixed_used = [s for s in fixed_names if s in var_syms]

--- a/src/model/Formulas.jl
+++ b/src/model/Formulas.jl
@@ -339,40 +339,44 @@ function _parse_formulas(block::Expr)
     det_set = Set{Symbol}()
     obs_set = Set{Symbol}()
 
+    ln = nothing
     for stmt in block.args
-        stmt isa LineNumberNode && continue
-        stmt isa Expr || error("Invalid statement in @formulas block.")
+        if stmt isa LineNumberNode
+            ln = stmt
+            continue
+        end
+        stmt isa Expr || error("Invalid statement in @formulas block." * _stmt_loc(ln, stmt))
         if stmt.head == :(=)
             lhs, rhs = stmt.args
-            lhs isa Symbol || error("Left-hand side must be a symbol in @formulas block.")
-            lhs == :t && error("Left-hand side cannot be t in @formulas block.")
-            lhs == :ξ && error("Left-hand side cannot be ξ in @formulas block.")
+            lhs isa Symbol || error("Left-hand side must be a symbol in @formulas block." * _stmt_loc(ln, stmt))
+            lhs == :t && error("Left-hand side cannot be t in @formulas block." * _stmt_loc(ln, stmt))
+            lhs == :ξ && error("Left-hand side cannot be ξ in @formulas block." * _stmt_loc(ln, stmt))
             lhs in det_set &&
-                error("Duplicate deterministic name $(lhs) in @formulas block.")
+                error("Duplicate deterministic name $(lhs) in @formulas block." * _stmt_loc(ln, stmt))
             lhs in obs_set &&
-                error("Name $(lhs) is already used for an observation in @formulas block.")
+                error("Name $(lhs) is already used for an observation in @formulas block." * _stmt_loc(ln, stmt))
             push!(det_names, lhs)
             push!(det_exprs, rhs)
             push!(det_set, lhs)
             push!(lines, Expr(:(=), lhs, rhs))
         elseif stmt.head == :call && stmt.args[1] == :~
             lhs, rhs = stmt.args[2], stmt.args[3]
-            lhs isa Symbol || error("Left-hand side must be a symbol in @formulas block.")
-            lhs == :t && error("Left-hand side cannot be t in @formulas block.")
-            lhs == :ξ && error("Left-hand side cannot be ξ in @formulas block.")
-            lhs in obs_set && error("Duplicate observation name $(lhs) in @formulas block.")
+            lhs isa Symbol || error("Left-hand side must be a symbol in @formulas block." * _stmt_loc(ln, stmt))
+            lhs == :t && error("Left-hand side cannot be t in @formulas block." * _stmt_loc(ln, stmt))
+            lhs == :ξ && error("Left-hand side cannot be ξ in @formulas block." * _stmt_loc(ln, stmt))
+            lhs in obs_set && error("Duplicate observation name $(lhs) in @formulas block." * _stmt_loc(ln, stmt))
             # `y ~ a` / `y ~ 1.0` / `y ~ nothing` used to leak an internal
             # `Cannot convert Symbol to Expr` from the `Expr[]` push below (#219).
             (rhs isa Expr && rhs.head == :call) ||
-                error("Observation $(lhs) in @formulas must be a distribution, e.g. $(lhs) ~ Normal(mu, sigma); got `$(rhs)`.")
+                error("Observation $(lhs) in @formulas must be a distribution, e.g. $(lhs) ~ Normal(mu, sigma); got `$(rhs)`." * _stmt_loc(ln, stmt))
             lhs in det_set &&
-                error("Name $(lhs) is already used for a deterministic in @formulas block.")
+                error("Name $(lhs) is already used for a deterministic in @formulas block." * _stmt_loc(ln, stmt))
             push!(obs_names, lhs)
             push!(obs_exprs, rhs)
             push!(obs_set, lhs)
             push!(lines, Expr(:call, :~, lhs, rhs))
         else
-            error("Only assignments and ~ observations are allowed in @formulas block.")
+            error("Only assignments and ~ observations are allowed in @formulas block." * _stmt_loc(ln, stmt))
         end
     end
 

--- a/src/model/Helpers.jl
+++ b/src/model/Helpers.jl
@@ -49,12 +49,16 @@ function parse_helpers(block::Expr)::Vector{HelperDef}
     block.head == :block || error("@helpers expects a begin ... end block.")
     defs = HelperDef[]
     seen = Set{Symbol}()
+    ln = nothing
     for stmt in block.args
-        stmt isa LineNumberNode && continue
-        stmt isa Expr || error("Invalid statement in @helpers block.")
+        if stmt isa LineNumberNode
+            ln = stmt
+            continue
+        end
+        stmt isa Expr || error("Invalid statement in @helpers block." * _stmt_loc(ln, stmt))
         def = _parse_helper(stmt)
         if def.name in seen
-            error("Duplicate helper name: $(def.name). Helper names must be unique within @helpers.")
+            error("Duplicate helper name: $(def.name). Helper names must be unique within @helpers." * _stmt_loc(ln, stmt))
         end
         _warn_if_mutating_helper(def)
         push!(seen, def.name)

--- a/src/model/InitialDE.jl
+++ b/src/model/InitialDE.jl
@@ -38,16 +38,20 @@ function _parse_initialde(block::Expr)
     exprs = Expr[]
     seen = Set{Symbol}()
 
+    ln = nothing
     for stmt in block.args
-        stmt isa LineNumberNode && continue
-        stmt isa Expr || error("Invalid statement in @initialDE block.")
-        stmt.head == :(=) || error("Only assignments are allowed in @initialDE block.")
+        if stmt isa LineNumberNode
+            ln = stmt
+            continue
+        end
+        stmt isa Expr || error("Invalid statement in @initialDE block." * _stmt_loc(ln, stmt))
+        stmt.head == :(=) || error("Only assignments are allowed in @initialDE block." * _stmt_loc(ln, stmt))
         lhs, rhs = stmt.args
-        lhs isa Symbol || error("Left-hand side must be a symbol in @initialDE block.")
-        lhs in seen && error("Duplicate initial DE name: $(lhs).")
-        rhs isa LineNumberNode && error("Invalid right-hand side in @initialDE block.")
+        lhs isa Symbol || error("Left-hand side must be a symbol in @initialDE block." * _stmt_loc(ln, stmt))
+        lhs in seen && error("Duplicate initial DE name: $(lhs)." * _stmt_loc(ln, stmt))
+        rhs isa LineNumberNode && error("Invalid right-hand side in @initialDE block." * _stmt_loc(ln, stmt))
         forbidden = _macro_forbidden_symbol(rhs)
-        forbidden === nothing || error("@initialDE uses forbidden symbol $(forbidden).")
+        forbidden === nothing || error("@initialDE uses forbidden symbol $(forbidden)." * _stmt_loc(ln, stmt))
         push!(seen, lhs)
         push!(names, lhs)
         push!(exprs, rhs isa Expr ? rhs : Expr(:call, :identity, rhs))

--- a/src/model/MacroUtils.jl
+++ b/src/model/MacroUtils.jl
@@ -139,3 +139,12 @@ function _rewrite_npf_calls(ex)
     end
     return Expr(ex.head, map(_rewrite_npf_calls, ex.args)...)
 end
+
+# Source location suffix for block-parser errors: the offending statement and the line
+# of the last `LineNumberNode` seen before it (#313).
+function _stmt_loc(ln, stmt)
+    loc = ln isa LineNumberNode ? "$(ln.file):$(ln.line)" : "unknown location"
+    txt = replace(string(stmt), "\n" => " ")
+    length(txt) > 120 && (txt = first(txt, 117) * "...")
+    return " (at $(loc): $(txt))"
+end

--- a/src/model/Model.jl
+++ b/src/model/Model.jl
@@ -272,19 +272,23 @@ function _model_validate_blocks(block::Expr)
         )
     )
     counts = Dict{Symbol, Int}()
+    ln = nothing
     for stmt in block.args
-        stmt isa LineNumberNode && continue
+        if stmt isa LineNumberNode
+            ln = stmt
+            continue
+        end
         stmt isa Expr ||
-            error("Invalid statement in @Model; only macro blocks are allowed.")
+            error("Invalid statement in @Model; only macro blocks are allowed." * _stmt_loc(ln, stmt))
         stmt.head == :macrocall ||
-            error("Invalid statement in @Model; only macro blocks are allowed.")
+            error("Invalid statement in @Model; only macro blocks are allowed." * _stmt_loc(ln, stmt))
         name = _model_macro_name(stmt)
-        name === nothing && error("Invalid macro call in @Model.")
+        name === nothing && error("Invalid macro call in @Model." * _stmt_loc(ln, stmt))
         name in allowed ||
-            error("Unknown block $(name) in @Model. Allowed blocks: $(collect(allowed)).")
+            error("Unknown block $(name) in @Model. Allowed blocks: $(collect(allowed))." * _stmt_loc(ln, stmt))
         counts[name] = get(counts, name, 0) + 1
         counts[name] > 1 &&
-            error("Duplicate $(name) block in @Model. Each block can appear at most once.")
+            error("Duplicate $(name) block in @Model. Each block can appear at most once." * _stmt_loc(ln, stmt))
     end
     return nothing
 end

--- a/src/model/Model.jl
+++ b/src/model/Model.jl
@@ -148,6 +148,44 @@ function _validate_de_covariate_usage(de, covariates)
     return nothing
 end
 
+# The generated DE parameter compiler raises the same two errors, but only on the first
+# ODE solve (#314). The namespaces are known once @Model has assembled its blocks, so
+# mirror the checks (and the messages) here.
+function _validate_de_symbols(
+        de; fixed_names, re_names, prede_names, const_cov_names, dynamic_cov_names,
+        helper_names, model_fun_names
+    )
+    de === nothing && return nothing
+    meta = get_de_meta(de)
+    known_vars = Set{Symbol}(vcat(prede_names, re_names, fixed_names, const_cov_names))
+    for sym in sort(collect(meta.var_syms))
+        sym in known_vars ||
+            error("Unknown symbol $(sym) in DifferentialEquation.")
+    end
+    known_funs = Set{Symbol}(vcat(dynamic_cov_names, model_fun_names, helper_names))
+    for sym in sort(collect(meta.fun_syms))
+        sym in known_funs ||
+            error("Unknown function $(sym) in DifferentialEquation.")
+    end
+    return nothing
+end
+
+# Same messages as the per-individual runtime checks in `_ll_solve_de` /
+# `_crossing_threshold`, raised once at build time (#314).
+function _validate_crossings(formulas; state_names, fixed_names, prede_names)
+    crossings = get_formulas_crossings(formulas)
+    isempty(crossings) && return nothing
+    states = Set{Symbol}(state_names)
+    levels = Set{Symbol}(vcat(fixed_names, prede_names))
+    for spec in crossings
+        spec.state in states ||
+            error("crossing state `$(spec.state)` is not a DE state.")
+        spec.threshold in levels ||
+            error("crossing_time threshold `$(spec.threshold)` was not found among the fixed effects or preDifferentialEquation variables.")
+    end
+    return nothing
+end
+
 """
     FormulasBundle{F, A, O}
 
@@ -389,6 +427,13 @@ function _validate_solver_config(cfg::ODESolverConfig)
         error("Solver kwargs must be a NamedTuple such as (; abstol = 1e-8); got $(typeof(cfg.kwargs)).")
     cfg.args isa Tuple ||
         error("Solver args must be a Tuple; got $(typeof(cfg.args)).")
+    # A non-algorithm `alg` used to reach `solve` unchecked, and on the closed-form path
+    # was never exercised at all (#314).
+    if !(cfg.alg === nothing || cfg.alg isa SciMLBase.AbstractODEAlgorithm)
+        hint = cfg.alg isa Union{Symbol, AbstractString} ?
+            " Did you mean $(cfg.alg)()?" : ""
+        error("alg must be an OrdinaryDiffEq algorithm such as Tsit5(); got $(typeof(cfg.alg)).$(hint)")
+    end
     return nothing
 end
 
@@ -735,6 +780,22 @@ macro Model(block)
             state_names = $(state_names_var),
             signal_names = $(signal_names_var),
             context_module = $(__module__)
+        )
+        _validate_de_symbols(
+            $(de_var);
+            fixed_names = $(fixed_names_var),
+            re_names = $(random_names_var),
+            prede_names = $(prede_names_var),
+            const_cov_names = $(const_cov_names_var),
+            dynamic_cov_names = $(covariates_var).dynamic,
+            helper_names = $(helper_names_var),
+            model_fun_names = $(model_fun_names_var)
+        )
+        _validate_crossings(
+            $(formulas_var);
+            state_names = $(state_names_var),
+            fixed_names = $(fixed_names_var),
+            prede_names = $(prede_names_var)
         )
 
         local (

--- a/src/model/Parameters.jl
+++ b/src/model/Parameters.jl
@@ -262,6 +262,16 @@ function _is_psd(mat::AbstractMatrix{<:Real}; atol::Real = EPSILON)
     return minimum(vals) >= -atol
 end
 
+# Why a matrix failed `_is_psd`. `eigen` runs only on input it cannot throw on, so the
+# diagnostic cannot pre-empt itself (#313).
+function _psd_reject_reason(v::AbstractMatrix{<:Real})
+    size(v, 1) == size(v, 2) ||
+        return "got a non-square $(size(v, 1))x$(size(v, 2)) matrix"
+    all(isfinite, v) || return "got a matrix with non-finite entries"
+    issymmetric(v) || return "got a non-symmetric matrix"
+    return "got matrix with min eigenvalue $(minimum(eigen(Symmetric(v)).values))"
+end
+
 function RealPSDMatrix(
         value::AbstractMatrix{<:Real}; name::Symbol = :unnamed,
         scale::Symbol = :cholesky, prior = Priorless(), calculate_se::Bool = false
@@ -272,7 +282,7 @@ function RealPSDMatrix(
     T = eltype(value) <: AbstractFloat ? eltype(value) : Float64
     v = T.(value)
     _is_psd(v) ||
-        error("Invalid initial value for parameter $(name). Expected symmetric positive semi-definite matrix; got matrix with min eigenvalue $(minimum(eigen(Symmetric(v)).values)).")
+        error("Invalid initial value for parameter $(name). Expected symmetric positive semi-definite matrix; $(_psd_reject_reason(v)).")
     return RealPSDMatrix{T, typeof(v)}(name, v, scale, prior, calculate_se)
 end
 
@@ -401,7 +411,7 @@ function RealLiePSDMatrix(
     T = eltype(value) <: AbstractFloat ? eltype(value) : Float64
     v = T.(value)
     _is_psd(v) ||
-        error("Invalid initial value for parameter $(name). Expected symmetric positive semi-definite matrix; got matrix with min eigenvalue $(minimum(eigen(Symmetric(v)).values)).")
+        error("Invalid initial value for parameter $(name). Expected symmetric positive semi-definite matrix; $(_psd_reject_reason(v)).")
     lo, up = _normalize_eig_bounds(eigenvalue_lower, eigenvalue_upper, size(v, 1), name)
     blk, fixed = _normalize_lie_structure(blocks, fix_eigenvalues, size(v, 1), name)
     blocks !== nothing && _validate_block_diagonal(v, blk, name)

--- a/src/model/PreDE.jl
+++ b/src/model/PreDE.jl
@@ -89,19 +89,23 @@ function _parse_prede(block::Expr)
     names = Symbol[]
     exprs = Expr[]
     lines = Expr[]
+    ln = nothing
     for stmt in block.args
-        stmt isa LineNumberNode && continue
-        stmt isa Expr || error("Invalid statement in @preDifferentialEquation block.")
+        if stmt isa LineNumberNode
+            ln = stmt
+            continue
+        end
+        stmt isa Expr || error("Invalid statement in @preDifferentialEquation block." * _stmt_loc(ln, stmt))
         stmt.head == :(=) ||
-            error("Only assignments are allowed in @preDifferentialEquation block.")
+            error("Only assignments are allowed in @preDifferentialEquation block." * _stmt_loc(ln, stmt))
         lhs, rhs = stmt.args
         lhs isa Symbol ||
-            error("Left-hand side must be a symbol in @preDifferentialEquation block.")
+            error("Left-hand side must be a symbol in @preDifferentialEquation block." * _stmt_loc(ln, stmt))
         rhs isa LineNumberNode &&
-            error("Invalid right-hand side in @preDifferentialEquation block.")
+            error("Invalid right-hand side in @preDifferentialEquation block." * _stmt_loc(ln, stmt))
         forbidden = _macro_forbidden_symbol(rhs)
         forbidden === nothing ||
-            error("preDifferentialEquation uses forbidden symbol $(forbidden).")
+            error("preDifferentialEquation uses forbidden symbol $(forbidden)." * _stmt_loc(ln, stmt))
         rhs isa Expr && _warn_if_mutating_prede(lhs, rhs)
         push!(names, lhs)
         push!(exprs, rhs isa Expr ? rhs : Expr(:call, :identity, rhs))

--- a/src/model/PreDE.jl
+++ b/src/model/PreDE.jl
@@ -200,12 +200,18 @@ macro preDifferentialEquation(block)
             for sym in var_syms
     ]
 
+    # Same fall-through as the variable chain above (#314); a pre-DE variable holding a
+    # function can legitimately be the call head, so those names keep it.
+    _unknown_fun = sym -> sym in names ? :() :
+        :(error($("Unknown function $(sym) in preDifferentialEquation.")))
     binds_funs = [
         quote
                 if hasproperty(model_funs, $(QuoteNode(sym)))
                     $(sym) = getproperty(model_funs, $(QuoteNode(sym)))
             elseif hasproperty(helper_functions, $(QuoteNode(sym)))
                     $(sym) = getproperty(helper_functions, $(QuoteNode(sym)))
+            else
+                    $(_unknown_fun(sym))
             end
             end
             for sym in call_syms

--- a/src/model/RandomEffects.jl
+++ b/src/model/RandomEffects.jl
@@ -245,28 +245,32 @@ function _parse_random_effects(block::Expr)
     re_names = Symbol[]
     dist_exprs = Expr[]
     columns = Symbol[]
+    ln = nothing
     for stmt in block.args
-        stmt isa LineNumberNode && continue
-        stmt isa Expr || error("Invalid statement in @randomEffects block.")
-        stmt.head == :(=) || error("Only assignments are allowed in @randomEffects block.")
+        if stmt isa LineNumberNode
+            ln = stmt
+            continue
+        end
+        stmt isa Expr || error("Invalid statement in @randomEffects block." * _stmt_loc(ln, stmt))
+        stmt.head == :(=) || error("Only assignments are allowed in @randomEffects block." * _stmt_loc(ln, stmt))
         lhs, rhs = stmt.args
-        lhs isa Symbol || error("Left-hand side must be a symbol in @randomEffects block.")
+        lhs isa Symbol || error("Left-hand side must be a symbol in @randomEffects block." * _stmt_loc(ln, stmt))
         lhs in re_names &&
-            error("Duplicate random effect $(lhs) in @randomEffects block; random-effect names must be unique.")
+            error("Duplicate random effect $(lhs) in @randomEffects block; random-effect names must be unique." * _stmt_loc(ln, stmt))
         rhs isa Expr && rhs.head == :call ||
-            error("Right-hand side must be a RandomEffect(...) call.")
+            error("Right-hand side must be a RandomEffect(...) call." * _stmt_loc(ln, stmt))
         _re_ctor_name(rhs.args[1]) === :RandomEffect ||
-            error("Right-hand side must be a RandomEffect(...) call.")
+            error("Right-hand side must be a RandomEffect(...) call." * _stmt_loc(ln, stmt))
 
         dist, column = _re_parse_call_args(rhs, lhs)
         # A bare symbol/number/`nothing` here used to leak `Cannot convert Symbol to Expr`
         # from the `Expr[]` push below (#219).
         (dist isa Expr && dist.head == :call) ||
-            error("RandomEffect $(lhs) needs a distribution, e.g. RandomEffect(Normal(0.0, 1.0); column=:ID); got `$(dist)`.")
+            error("RandomEffect $(lhs) needs a distribution, e.g. RandomEffect(Normal(0.0, 1.0); column=:ID); got `$(dist)`." * _stmt_loc(ln, stmt))
 
         forbidden = _macro_forbidden_symbol(dist)
         forbidden === nothing ||
-            error("RandomEffect $(lhs) uses forbidden symbol $(forbidden).")
+            error("RandomEffect $(lhs) uses forbidden symbol $(forbidden)." * _stmt_loc(ln, stmt))
 
         push!(re_names, lhs)
         push!(dist_exprs, dist)

--- a/src/model/Validation.jl
+++ b/src/model/Validation.jl
@@ -11,9 +11,18 @@ const _NL_TIME_SYMBOLS = (:t, :ξ)
 
 # Symbols that resolve to an actual binding at formula-evaluation time (Base/Distributions/
 # NoLimits names, plus anything defined in the module where @Model was written).
+# Distributions re-exports SpecialFunctions, so `eta`, `beta`, `gamma`, `zeta` and
+# `digamma` -- common parameter names -- used to pass as defined (#312). A name the
+# user's own module resolves (e.g. via `using SpecialFunctions`) still counts.
+function _nl_resolvable_reexport(m::Module, s::Symbol)
+    isdefined(m, s) || return false
+    b = getfield(m, s)
+    return !(b isa Function && nameof(parentmodule(b)) === :SpecialFunctions)
+end
+
 function _nl_symbol_resolvable(s::Symbol, mod::Module)
-    return isdefined(Base, s) || isdefined(Distributions, s) ||
-        isdefined(@__MODULE__, s) || isdefined(mod, s)
+    return isdefined(Base, s) || _nl_resolvable_reexport(Distributions, s) ||
+        _nl_resolvable_reexport(@__MODULE__, s) || isdefined(mod, s)
 end
 
 # Names an expression binds locally: anonymous-function arguments, `do` arguments, and
@@ -137,6 +146,7 @@ end
 
 _nl_fun_out_dim(p) = nothing
 _nl_fun_out_dim(p::SoftTreeParameters) = p.n_output
+_nl_fun_out_dim(p::NNParameters) = p.chain isa FFNN ? p.chain.sizes[end] : nothing
 
 # Collect `f(arg, θ)` and `f(arg, θ)[k]` for model-function names `f`.
 function _nl_collect_fun_calls!(
@@ -184,9 +194,9 @@ function _nl_check_model_fun_calls(exprs, fixed)
                     length(arg.args) - 1 : nothing
                 )
             if got === nothing
-                # A bare scalar argument to a multi-input function is always wrong.
-                (arg isa Symbol || arg isa Number) && want_in > 1 &&
-                    error("$(fun) (parameter $(p.name)) expects a length-$(want_in) input vector; got the scalar `$(arg)`. Write $(fun)([a, b, ...], $(p.name)).")
+                # Only splines take a scalar; every other model function wants a vector.
+                (arg isa Symbol || arg isa Number) && !(p isa SplineParameters) &&
+                    error("$(fun) (parameter $(p.name)) expects a length-$(want_in) input vector; got the scalar `$(arg)`. Write $(fun)([$(want_in == 1 ? string(arg) : "a, b, ...")], $(p.name)).")
             elseif got != want_in
                 error("$(fun) (parameter $(p.name)) expects a length-$(want_in) input vector; got length $(got).")
             end
@@ -209,6 +219,17 @@ function _validate_model_symbols(
     _nl_check_reserved_names(fixed_names, "Fixed effects")
     _nl_check_reserved_names(re_names, "Random effects")
     # Covariates are exempt: `t = Covariate()` is how the time column is declared.
+
+    # A pre-DE output silently shadowed a same-named effect or covariate inside
+    # @DifferentialEquation and @initialDE (#312).
+    for (other, what) in (
+            (fixed_names, "fixed effect"), (re_names, "random effect"),
+            (const_cov_names, "constant covariate"),
+        )
+        clash = sort([s for s in prede_names if s in other])
+        isempty(clash) ||
+            error("@preDifferentialEquation output(s) $(join(string.(clash), ", ")) collide with the $(what)(s) of the same name and would shadow them inside @DifferentialEquation and @initialDE. Rename the pre-DE variable.")
+    end
 
     ir = get_formulas_ir(formulas)
     isempty(ir.obs_names) &&
@@ -258,6 +279,7 @@ function _validate_model_symbols(
         )
     )
     re_syms = get_re_syms(random)
+    re_dist_exprs = get_re_dist_exprs(random)
     for name in re_names
         bad = sort(
             [
@@ -268,6 +290,18 @@ function _validate_model_symbols(
         )
         isempty(bad) ||
             error("RandomEffect `$(name)` references undefined symbol(s) $(join(string.(bad), ", ")). They are not a fixed effect, constant covariate, helper or model function.")
+        heads = _macro_collect_call_symbols(
+            getproperty(re_dist_exprs, name), Set{Symbol}()
+        )
+        bad_calls = sort(
+            [
+                s
+                    for s in heads
+                    if !(s in re_known) && !_nl_symbol_resolvable(s, context_module)
+            ]
+        )
+        isempty(bad_calls) ||
+            error("RandomEffect `$(name)` calls undefined function(s) $(join(string.(bad_calls), ", ")): check for a typo or a missing package extension (e.g. `using Copulas`).")
     end
     return nothing
 end

--- a/src/summaries/data_model_summary.jl
+++ b/src/summaries/data_model_summary.jl
@@ -389,10 +389,13 @@ function summarize(dm::DataModel)
         append!(outcome_stats, _outcome_stat_rows(obs, col[obs_rows]))
     end
 
-    # Declared covariates + per-column stats (observation rows only)
+    # Declared covariates + per-column stats (observation rows, except subject-constant
+    # covariates: those take one row per individual so follow-up length cannot weight
+    # them (#309.7)).
     covariate_declarations = NamedTuple[]
     covariate_stats = NamedTuple[]
     nonnumeric_covariate_columns = String[]
+    first_rows = [rws[1] for rws in get_rows(get_row_groups(dm))]
     for cname in cov.names
         p = getfield(cov.params, cname)
         kind, cols, constant_on = _covariate_kind_and_columns(p)
@@ -400,9 +403,10 @@ function summarize(dm::DataModel)
             covariate_declarations,
             (; name = cname, kind = kind, columns = cols, constant_on = constant_on)
         )
+        is_const = p isa ConstantCovariate || p isa ConstantCovariateVector
         for colname in cols
             col = getproperty(get_df(dm), colname)
-            vals = col[obs_rows]
+            vals = col[is_const ? first_rows : obs_rows]
             st = _descriptive_stats(vals)
             if st.n == 0
                 push!(nonnumeric_covariate_columns, string(cname, ".", colname))
@@ -564,7 +568,8 @@ function Base.show(io::IO, ::MIME"text/plain", s::DataModelSummary)
     _print_covariate_declarations(io, s.covariate_declarations)
     println(io)
     _print_descriptive_table(
-        io, "Covariate descriptive statistics (observation rows)", s.covariate_stats
+        io, "Covariate descriptive statistics (observation rows; constant covariates per individual)",
+        s.covariate_stats
     )
     if !isempty(s.nonnumeric_covariate_columns)
         println(io)

--- a/src/summaries/fit_uq_summary.jl
+++ b/src/summaries/fit_uq_summary.jl
@@ -992,6 +992,7 @@ function Base.show(io::IO, ::MIME"text/plain", s::FitResultSummary)
             "inference" => s.inference,
             "scale" => s.scale,
             "objective" => _fq_fmt_objective(s.objective),
+            "converged" => s.converged === nothing ? "not tracked" : s.converged,
             "iterations" => s.iterations,
             "parameters shown (reported / total)" => "$(s.n_parameters_reported) / $(s.n_parameters_total)",
         ]

--- a/src/utils/GeneralUtils.jl
+++ b/src/utils/GeneralUtils.jl
@@ -131,3 +131,10 @@ end
         err isa DataInterpolations.LeftExtrapolationError ||
         err isa DataInterpolations.RightExtrapolationError
 end
+
+# An exception's own message, flattened to one line. The type name alone hides what the
+# model actually complained about (#313); the cap keeps a long message out of the log.
+function _brief_error_message(err; maxlen::Int = 200)
+    msg = replace(sprint(showerror, err), '\n' => ' ')
+    return length(msg) > maxlen ? first(msg, maxlen - 3) * "..." : msg
+end

--- a/test/api_primitives_tests.jl
+++ b/test/api_primitives_tests.jl
@@ -1099,6 +1099,14 @@ end
         )
         @test NoLimits.get_eb_modes(NoLimits.get_result(res)) !== nothing
         @test NoLimits.get_random_effects(dm, res) isa NamedTuple
+        # #311: a caller who never inspects the retcode does not get a silent `true`
+        @test NoLimits.get_converged(res) === missing
+        res_conv = build_fit_result(
+            ctx, APITestClosedFormEM(), θ̂; kind = :frequentist_re,
+            objective = sol.objective, eb_modes = nothing,
+            converged = NoLimits.SciMLBase.successful_retcode(sol)
+        )
+        @test NoLimits.get_converged(res_conv) isa Bool
     end
 
     # Issue #273: the gradient-bearing primitives get FitContext forms that reuse the

--- a/test/crossing_tests.jl
+++ b/test/crossing_tests.jl
@@ -140,3 +140,54 @@ end
         @test isapprox(acc_ll.rv, acc_pl.rv; atol = 1.0e-6)
     end
 end
+
+@testset "crossing symbols are validated at build time" begin
+    mk(body) = Core.eval(
+        @__MODULE__, Expr(
+            :macrocall, Symbol("@Model"), LineNumberNode(0), body
+        )
+    )
+    # Both used to be raised per individual from inside the solve (#314).
+    @test_throws ErrorException mk(
+        quote
+            @fixedEffects begin
+                k = RealNumber(1.0)
+                level = RealNumber(1.0)
+            end
+            @covariates begin
+                t = Covariate()
+            end
+            @DifferentialEquation begin
+                D(x) ~ k
+            end
+            @initialDE begin
+                x = 0.0
+            end
+            @formulas begin
+                tc = crossing_time(:x2, :level)
+                y ~ Normal(tc, 1.0)
+            end
+        end
+    )
+    @test_throws ErrorException mk(
+        quote
+            @fixedEffects begin
+                k = RealNumber(1.0)
+                level = RealNumber(1.0)
+            end
+            @covariates begin
+                t = Covariate()
+            end
+            @DifferentialEquation begin
+                D(x) ~ k
+            end
+            @initialDE begin
+                x = 0.0
+            end
+            @formulas begin
+                tc = crossing_time(:x, :levelz)
+                y ~ Normal(tc, 1.0)
+            end
+        end
+    )
+end

--- a/test/data_model_ode_tests.jl
+++ b/test/data_model_ode_tests.jl
@@ -57,6 +57,11 @@ end
     model_saveat = set_solver_config(model; saveat_mode = :saveat)
     dm = DataModel(model_saveat, df; primary_id = :ID, time_col = :t)
 
+    # A non-algorithm `alg` is rejected eagerly (#314); real algorithms pass.
+    @test_throws ErrorException set_solver_config(model; alg = :Tsit5)
+    @test set_solver_config(model; alg = Tsit5()) isa NoLimits.Model
+    @test set_solver_config(model; alg = AutoTsit5(Rodas5P())) isa NoLimits.Model
+
     ind = get_individual(dm, 1)
     θ = get_θ0_untransformed(model_saveat.fixed.fixed)
     η = ComponentArray()

--- a/test/data_model_tests.jl
+++ b/test/data_model_tests.jl
@@ -415,6 +415,21 @@ end
     @test_throws ErrorException DataModel(
         model, 42; primary_id = :ID, time_col = :t
     )
+
+    # A declared covariate whose column is absent is named at construction (#315).
+    df_no_age = DataFrame(
+        ID = [1, 1],
+        t = [0.0, 1.0],
+        y = [1.0, 1.1]
+    )
+    @test_throws "Covariate x is declared as ConstantCovariateVector with column Age" DataModel(
+        model, df_no_age; primary_id = :ID, time_col = :t
+    )
+
+    # Swapped positional arguments report the argument order, not a phantom column (#315).
+    @test_throws "Check the argument order" DataModel(
+        df_no_age, model; primary_id = :ID, time_col = :t
+    )
 end
 
 # Shared no-RE model; also reused by the mixed-type primary_id testset below.
@@ -1077,6 +1092,20 @@ end
     )
 
     @test_throws ErrorException DataModel(model, df; primary_id = :ID, time_col = :t)
+
+    # Missings are validated by declaration, so a covariate used only in the RE
+    # distribution is caught at construction (#309.5).
+    df_missing_c1 = DataFrame(
+        ID = [1, 1, 2, 2],
+        SITE = [:A, :A, :B, :B],
+        t = [0.0, 1.0, 0.0, 1.0],
+        c1 = [10.0, 10.0, missing, missing],
+        c2 = [1.0, 1.0, 3.0, 3.0],
+        y = [1.0, 1.1, 0.9, 1.0]
+    )
+    @test_throws "contains missing values" DataModel(
+        model, df_missing_c1; primary_id = :ID, time_col = :t
+    )
 end
 
 @testset "DataModel RE validation only checks used covariates (valid)" begin
@@ -1584,7 +1613,7 @@ end
     @test length(get_individuals(dm_str)) == length(get_individuals(dm))
 end
 
-@testset "DataModel validates missing covariates used by formulas" begin
+@testset "DataModel validates missing covariates by declaration" begin
     model_used = @Model begin
         @fixedEffects begin
             a = RealNumber(0.2)
@@ -1634,8 +1663,11 @@ end
         y = [0.1, 0.2]
     )
 
-    dm = DataModel(model_unused, df_unused_missing; primary_id = :ID, time_col = :t)
-    @test dm isa DataModel
+    # Declared but unused covariates are validated too: their missings otherwise only
+    # surfaced later, inside a distribution or the DE (#309.5, #315).
+    @test_throws "contains missing values" DataModel(
+        model_unused, df_unused_missing; primary_id = :ID, time_col = :t
+    )
 end
 
 @testset "DataModel allows partially missing observables on observation rows (regression)" begin

--- a/test/estimation_common_tests.jl
+++ b/test/estimation_common_tests.jl
@@ -519,6 +519,13 @@ end
     # a + η = 1 - 2 < 0 -> log throws inside the formula
     bad = NoLimits.conditional_loglikelihood(dm, 1, θ, ComponentArray(η = -2.0))
     @test bad == -Inf
+
+    # The exception's own message must survive into the warning (#313); the type name
+    # alone plus generic log/sqrt advice hid what the model actually complained about.
+    NoLimits._WARNED_NUMERIC_ERROR[] = false
+    @test_logs (:warn, r"DomainError with -1\.0.*log was called with a negative real argument") match_mode = :any begin
+        NoLimits.conditional_loglikelihood(dm, 1, θ, ComponentArray(η = -2.0))
+    end
 end
 
 # The sibling of the above for the RE prior: `_loglikelihood_individual`'s guard does not cover

--- a/test/estimation_cv_tests.jl
+++ b/test/estimation_cv_tests.jl
@@ -3,6 +3,7 @@ using DataFrames
 using NoLimits
 using Distributions
 using Random
+using LinearAlgebra: I, Symmetric
 
 # ── Shared fixtures ────────────────────────────────────────────────────────────
 
@@ -256,6 +257,46 @@ end
         fold_os = fr.obs_scores
         @test isapprox(sum(fold_os[!, :loglikelihood]), fr.test_loglikelihood; atol = 1.0e-8)
     end
+end
+
+# The Monte-Carlo modes must score the per-subject JOINT marginal, not the sum of
+# per-observation predictive densities (#290). Normal-Normal random intercept has a
+# closed-form joint: MvNormal(a, ρ² 11ᵀ + σ² I) with ρ = 1 fixed by the RE prior.
+@testset "fit_cv unseen_re_mode=:montecarlo scores the joint marginal (#290)" begin
+    model = _make_re_model()
+    k = 6
+    tvals = collect(0.0:(k - 1))
+    rng = MersenneTwister(290)
+    ntrain = 12
+    us = randn(rng, ntrain)
+    df_train = DataFrame(
+        ID = repeat(2:(ntrain + 1), inner = k),
+        t = repeat(tvals, ntrain),
+        y = [1.0 + us[(i - 1) ÷ k + 1] + 0.3 * randn(rng) for i in 1:(ntrain * k)]
+    )
+    ytest = [0.6, 0.75, 0.6, 0.7, 0.65, 0.8]
+    df = vcat(DataFrame(ID = fill(1, k), t = tvals, y = ytest), df_train)
+    dm = DataModel(model, df; primary_id = :ID, time_col = :t)
+
+    cv = NoLimits.CVSpec(
+        dm, [findall(!=(1), df.ID)], [findall(==(1), df.ID)], :id, 1
+    )
+    res = fit_cv(
+        cv, NoLimits.Laplace();
+        unseen_re_mode = :montecarlo, n_mc_samples = 20_000,
+        rng = MersenneTwister(291), store_results = true
+    )
+
+    θ = NoLimits.get_params(res.fold_results[1].fit_result; scale = :untransformed)
+    Σ = ones(k, k) .+ θ.σ^2 .* I(k)
+    joint = logpdf(MvNormal(fill(θ.a, k), Symmetric(Σ)), ytest)
+    per_obs = sum(logpdf(Normal(θ.a, sqrt(1.0 + θ.σ^2)), ytest[i]) for i in 1:k)
+
+    @test abs(joint - per_obs) > 5.0                       # the two really differ here
+    @test isapprox(res.mean_test_loglikelihood, joint; atol = 0.5)
+    # Row column keeps the joint on the first row, zeros elsewhere, so sums still work.
+    @test isapprox(sum(res.obs_scores[!, :loglikelihood]), joint; atol = 0.5)
+    @test count(!=(0.0), res.obs_scores[!, :loglikelihood]) == 1
 end
 
 @testset "fit_cv accessors" begin

--- a/test/estimation_laplace_tests.jl
+++ b/test/estimation_laplace_tests.jl
@@ -82,6 +82,14 @@ end
     @test length(res.result.eb_modes) == length(get_batches(fx_re_dm()))
 end
 
+# Issue #311: the post-hoc EBE gradient check must stay silent on a healthy fit.
+@testset "Laplace EBE gradient diagnostic is quiet on a healthy fit" begin
+    @test_logs min_level = Base.CoreLogging.Warn fit_model(
+        fx_re_dm(), NoLimits.Laplace(; optim_kwargs = (maxiters = 3,));
+        serialization = _SER
+    )
+end
+
 @testset "Laplace fit (ODE) runs" begin
     @test fx_ode_laplace().summary.converged isa Bool
 end

--- a/test/estimation_mcem_tests.jl
+++ b/test/estimation_mcem_tests.jl
@@ -243,6 +243,20 @@ end
     @test res isa FitResult
 end
 
+# #311: `ω` appears only in the RE distribution, so it is solved in the Q2-only M-step,
+# which passed `nothing, nothing` where the user bounds belong and let ω run to its
+# unconstrained MLE (natural ~0.29, far below exp(2)).
+@testset "MCEM user bounds reach the Q2-only M-step" begin
+    method = NoLimits.MCEM(
+        sampler = MH(), turing_kwargs = (n_samples = 2, n_adapt = 2, progress = false),
+        maxiters = 2, optim_kwargs = (; maxiters = 5),
+        lb = ComponentArray(a = -10.0, σ = -10.0, ω = 2.0),
+        ub = ComponentArray(a = 10.0, σ = 10.0, ω = 3.0)
+    )
+    res = fit_model(fx_re_dm(), method)
+    @test NoLimits.get_params(res; scale = :untransformed).ω >= exp(2.0) - 1.0e-6
+end
+
 @testset "MCEM with ODE model" begin
     res = fit_model(
         fx_ode_dm(),

--- a/test/estimation_mle_tests.jl
+++ b/test/estimation_mle_tests.jl
@@ -582,6 +582,25 @@ end
         dm; theta_untransformed = ComponentArray(a = NaN, s = 0.3)
     )
 
+    # #311: ParticleSwarm samples particles uniformly inside the box (an infinite edge
+    # gives all-NaN estimates with a finite objective) and IPNewton is barrier-only, so
+    # both are rejected instead of silently returning junk or throwing from inside Optim.
+    @test_throws ErrorException fit(
+        NoLimits.MLE(
+            optimizer = Optim.ParticleSwarm(), optim_kwargs = (; maxiters = 5),
+            lb = [-2.0, -2.0], ub = [Inf, Inf]
+        )
+    )
+    @test_throws ErrorException fit(
+        NoLimits.MLE(optimizer = Optim.IPNewton(), optim_kwargs = K)
+    )
+    # #311: a start outside the box used to surface as `Initial x[(1,)]=0.0 is outside of
+    # [...]` in preconditioned z-coordinates, naming no number the user typed.
+    @test_logs (:warn, r"clamped into the box") match_mode = :any fit(
+        NoLimits.MLE(optim_kwargs = K, lb = [-1.0, -1.0], ub = [1.0, 1.0]);
+        theta_0_untransformed = (a = 5.0, s = 0.5)
+    )
+
     @test fit(NoLimits.MLE(optim_kwargs = K, lb = [-5.0, -5.0], ub = [5.0, 5.0])) isa
         FitResult
     @test fit(NoLimits.MLE(optim_kwargs = K); penalty = (a = 10.0,)) isa FitResult

--- a/test/estimation_saem2_tests.jl
+++ b/test/estimation_saem2_tests.jl
@@ -5,6 +5,7 @@ using Distributions
 using Turing
 using Random
 using SciMLBase
+using Optimization
 using OptimizationOptimisers
 using OptimizationBBO
 using LinearAlgebra
@@ -583,6 +584,25 @@ end
     @test NoLimits.get_closed_form_mstep_used(res)
     @test notes.closed_form_mstep_mode == :closed_form_only
     @test :builtin_stats in notes.closed_form_mstep_sources
+end
+
+# #311: the `builtin_mean = :glm` M-step hardcoded ForwardDiff and built its problem with
+# no box, so it ignored both `adtype` and every bound. `sa_burnin_iters = 0` is what makes
+# the path reachable in a 2-iteration fit.
+@testset "SAEM builtin_mean glm honours adtype and bounds" begin
+    res = fit_model(
+        fx_tiny_re_dm(),
+        NoLimits.SAEM(;
+            sampler = MH(), turing_kwargs = (n_samples = 2, n_adapt = 2, progress = false),
+            SAEM_FAST...,
+            builtin_mean = :glm,
+            sa_burnin_iters = 0,
+            adtype = Optimization.AutoFiniteDiff(),
+            lb = (; a = 0.7, σ = -10.0),
+            ub = (; a = 0.9, σ = 10.0)
+        )
+    )
+    @test 0.7 - 1.0e-6 <= NoLimits.get_params(res; scale = :untransformed).a <= 0.9 + 1.0e-6
 end
 
 @testset "SAEM builtin_mean glm (Bernoulli + Poisson)" begin

--- a/test/fixed_effects_tests.jl
+++ b/test/fixed_effects_tests.jl
@@ -209,6 +209,13 @@ end
     @test length(θt_psd.Ω) == 3
     θrt_psd = get_inverse_transform(fe_psd)(θt_psd)
     @test isapprox(θrt_psd.Ω, get_θ0_untransformed(fe_psd).Ω; rtol = 1.0e-6, atol = 1.0e-8)
+    # `:expm` coordinates are the upper triangle column by column, and the flat names
+    # must say which entry each one is (#306).
+    fe_psd3 = @fixedEffects begin
+        Ω = RealPSDMatrix([1.2 0.1 0.0; 0.1 1.1 0.0; 0.0 0.0 1.3], scale = :expm)
+    end
+    @test get_flat_names(fe_psd3) ==
+        [:Ω_1_1, :Ω_1_2, :Ω_2_2, :Ω_1_3, :Ω_2_3, :Ω_3_3]
 end
 
 @testset "FixedEffects mixtures" begin

--- a/test/fixed_effects_tests.jl
+++ b/test/fixed_effects_tests.jl
@@ -485,3 +485,39 @@ end
     @test_throws ArgumentError NoLimits._validate_theta_0(dm, bad)
     @test NoLimits._validate_theta_0(dm, NoLimits._coerce_theta_0(dm, (; σ = 0.3))) === nothing
 end
+
+# Block-parser errors must name the offending statement and its source line, and a
+# non-constructor right-hand side must not get a `name =` kwarg spliced in (#313).
+@testset "@fixedEffects parse errors name the statement (#313)" begin
+    bad_stmt = try
+        @eval @fixedEffects begin
+            sigma
+        end
+        nothing
+    catch err
+        err
+    end
+    @test occursin(
+        r"Invalid statement in @fixedEffects block\. \(at .*: sigma\)",
+        sprint(showerror, bad_stmt)
+    )
+
+    bad_rhs = try
+        @eval @fixedEffects begin
+            a = 1 + 2
+        end
+        nothing
+    catch err
+        err
+    end
+    @test occursin(
+        r"must be a parameter-block constructor call such as RealNumber\(\.\.\.\); got `1 \+ 2`",
+        sprint(showerror, bad_rhs)
+    )
+
+    # Module-qualified constructors still build.
+    fe = @fixedEffects begin
+        a = NoLimits.RealNumber(1.0)
+    end
+    @test get_names(fe) == [:a]
+end

--- a/test/formulas_tests.jl
+++ b/test/formulas_tests.jl
@@ -363,6 +363,23 @@ end
             end
         end
     )
+    # A deterministic node referencing a name defined later in the block (#314).
+    @test_throws ErrorException mk(
+        quote
+            @fixedEffects begin
+                a = RealNumber(1.0)
+                b = RealNumber(1.0)
+            end
+            @covariates begin
+                t = Covariate()
+            end
+            @formulas begin
+                mu = base + b
+                base = a
+                y ~ Normal(mu, 1.0)
+            end
+        end
+    )
     # `=` instead of `~` leaves the model without any observation.
     @test_throws ErrorException mk(
         quote

--- a/test/model_macro_tests.jl
+++ b/test/model_macro_tests.jl
@@ -86,6 +86,43 @@ end
         end
     end
 
+    # Unknown DE symbols used to surface only on the first ODE solve (#314).
+    @test_throws ErrorException @eval @Model begin
+        @fixedEffects begin
+            a = RealNumber(1.0)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @DifferentialEquation begin
+            D(x1) ~ -aa * x1
+        end
+        @initialDE begin
+            x1 = 1.0
+        end
+        @formulas begin
+            obs ~ Normal(x1(t), 1.0)
+        end
+    end
+
+    @test_throws ErrorException @eval @Model begin
+        @fixedEffects begin
+            a = RealNumber(1.0)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @DifferentialEquation begin
+            D(x1) ~ -sqr(a) * x1
+        end
+        @initialDE begin
+            x1 = 1.0
+        end
+        @formulas begin
+            obs ~ Normal(x1(t), 1.0)
+        end
+    end
+
     @test_throws LoadError @eval @Model begin
         @fixedEffects begin
             a = RealNumber(1.0)

--- a/test/model_macro_tests.jl
+++ b/test/model_macro_tests.jl
@@ -206,6 +206,85 @@ end
         end
         foo = 1 + 2
     end
+
+    # `eta`/`beta`/`gamma`/`zeta`/`digamma` are SpecialFunctions re-exports and used to
+    # pass the undefined-symbol check (#312).
+    @test_throws "undefined symbol(s) eta" @Model begin
+        @fixedEffects begin
+            a = RealNumber(0.2)
+        end
+        @formulas begin
+            y ~ Normal(a + eta, 1.0)
+        end
+    end
+
+    # A misspelled random-effect distribution used to fail only at fit time (#312).
+    @test_throws "calls undefined function(s) Normall" @Model begin
+        @fixedEffects begin
+            a = RealNumber(0.2)
+            om = RealNumber(0.3, scale = :log)
+        end
+        @randomEffects begin
+            b = RandomEffect(Normall(0.0, om); column = :ID)
+        end
+        @formulas begin
+            y ~ Normal(a + b, 1.0)
+        end
+    end
+
+    # An outcome name colliding with a fixed effect used to resolve to the fixed effect (#312).
+    @test_throws "ambiguous in @formulas" @Model begin
+        @fixedEffects begin
+            y = RealNumber(0.7)
+        end
+        @formulas begin
+            y ~ Normal(y, 1.0)
+        end
+    end
+
+    # A pre-DE output used to silently shadow a same-named fixed effect (#312).
+    @test_throws "collide with the fixed effect" @Model begin
+        @fixedEffects begin
+            a = RealNumber(0.3)
+            sig = RealNumber(0.4, scale = :log)
+        end
+        @preDifferentialEquation begin
+            a = 99.0
+        end
+        @DifferentialEquation begin
+            D(x1) ~ -a * x1
+        end
+        @initialDE begin
+            x1 = 1.0
+        end
+        @formulas begin
+            y ~ Normal(x1(t), sig)
+        end
+    end
+
+    # A length-1 network called with a bare scalar used to escape the checker (#316).
+    @test_throws "got the scalar `t`" @Model begin
+        @fixedEffects begin
+            sig = RealNumber(0.4, scale = :log)
+            zeta = FFNNParameters((1, 4, 1); function_name = :NN1)
+        end
+        @formulas begin
+            lin = NN1(t, zeta)[1]
+            obs ~ Normal(lin, sig)
+        end
+    end
+
+    # Output-index bounds were only checked for soft trees (#316).
+    @test_throws "index [2] is out of range" @Model begin
+        @fixedEffects begin
+            sig = RealNumber(0.4, scale = :log)
+            zeta = FFNNParameters((1, 4, 1); function_name = :NN1)
+        end
+        @formulas begin
+            lin = NN1([t], zeta)[2]
+            obs ~ Normal(lin, sig)
+        end
+    end
 end
 
 @testset "Model macro constant_on defaults" begin

--- a/test/ode_callbacks_tests.jl
+++ b/test/ode_callbacks_tests.jl
@@ -153,6 +153,15 @@ using OrdinaryDiffEq
         @test isfinite(ll_first)
         @test ll_first == ll_second
 
+        # An infusion whose stop time is past the end of the integration span is
+        # truncated there, so less than AMT is delivered (#308).
+        df_over = copy(df_evt)
+        df_over.AMT = [0.0, 2.0, 0.0]
+        @test_logs (:warn, r"truncat") match_mode = :any DataModel(
+            model, df_over; primary_id = :ID, time_col = :t,
+            evid_col = :EVID, amt_col = :AMT, rate_col = :RATE, cmt_col = :CMT
+        )
+
         # A RATE opposing AMT would silently reverse the dose direction (#170).
         df_bad = copy(df_evt)
         df_bad.RATE = [0.0, -0.5, 0.0]

--- a/test/parameters_tests.jl
+++ b/test/parameters_tests.jl
@@ -50,6 +50,16 @@ using Turing: Flat
         [1.0 2.0; 2.0 1.0]; name = :bad_psd, scale = :log
     )
     @test_throws ErrorException RealPSDMatrix([1.0 2.0; 3.0 4.0]; name = :bad_psd2)
+    # The rejection message must not recompute `eigen` on input `eigen` throws on (#313).
+    @test_throws r"parameter Om.*non-square 2x3" RealPSDMatrix(
+        [1.0 2.0 3.0; 4.0 5.0 6.0]; name = :Om
+    )
+    @test_throws r"parameter Om.*non-finite entries" RealPSDMatrix(
+        [1.0 NaN; NaN 1.0]; name = :Om
+    )
+    @test_throws r"parameter Om.*non-finite entries" RealLiePSDMatrix(
+        [1.0 NaN; NaN 1.0]; name = :Om
+    )
     @test_throws ErrorException RealPSDMatrix(
         [1.0 0.0; 0.0 1.0]; name = :bad_psd_scale, scale = :foo
     )

--- a/test/prede_tests.jl
+++ b/test/prede_tests.jl
@@ -49,6 +49,15 @@ end
     @test_throws ErrorException build_unknown(
         ComponentArray(), ComponentArray(), NamedTuple(), NamedTuple(), NamedTuple()
     )
+
+    # Same for an unknown helper / model function (#314).
+    prede_unknown_fun = @preDifferentialEquation begin
+        v = sqr(1.0)
+    end
+    build_unknown_fun = get_prede_builder(prede_unknown_fun)
+    @test_throws ErrorException build_unknown_fun(
+        ComponentArray(), ComponentArray(), NamedTuple(), NamedTuple(), NamedTuple()
+    )
 end
 
 @testset "PreDifferentialEquation mutation warnings" begin

--- a/test/summaries_tests.jl
+++ b/test/summaries_tests.jl
@@ -296,6 +296,8 @@ end
     txt_fit = sprint(show, MIME"text/plain"(), s_fit)
     @test occursin("FitResultSummary", txt_fit)
     @test occursin("Outcome data coverage", txt_fit)
+    # #311: the rich report shows the stored convergence flag, not just the terse show
+    @test occursin("converged", txt_fit)
 
     s_fit_all = summarize(res; include_non_se = true)
     @test s_fit_all.n_parameters_reported == 3

--- a/test/summaries_tests.jl
+++ b/test/summaries_tests.jl
@@ -219,6 +219,11 @@ end
     @test z_stats.n == 4
     @test z_stats.mean ≈ 2.5 atol = 1.0e-12
 
+    # A subject-constant covariate is summarized once per individual, not per row (#309.7).
+    x_stats = only(filter(row -> row.name == Symbol("x.x"), s.covariate_stats)).stats
+    @test x_stats.n == 2
+    @test x_stats.mean ≈ 15.0 atol = 1.0e-12
+
     re_id = only(filter(r -> r.name == :η_id, s.random_effect_summaries))
     @test re_id.group == :ID
     @test re_id.n_levels == 2


### PR DESCRIPTION
Second bug batch: the remaining open issues in the #290 to #316 range. One commit per issue (two for #311), each with regression assertions inside existing testsets. No feature work.

Closes #290, closes #311, closes #312, closes #313, closes #314, closes #315, closes #316.
Closes #306, closes #308, closes #309 (their remaining LOW items are handled here; everything else landed in #317).

## #290 cross-validation
- `fit_cv` with `unseen_re_mode = :montecarlo` / `seen_re_mode = :conditional` now scores each held-out individual by the joint predictive marginal `log((1/S) Σ_s Π_r p(y_r | η_s))` instead of a sum of per-observation predictive densities. Verified against the closed-form `MvNormal` marginal on a random-intercept model (the old value was 6.3 nats too optimistic at k = 6).
- Layout: the joint value sits on the individual's first row of `obs_scores` with `0.0` on the others, so every existing aggregator keeps summing correctly. Docstrings and `docs/src/estimation/cv.md` updated. A draw whose subject sum is NaN is skipped per individual; an individual with no usable draw is dropped with the existing warning.

## #311 optimizer layer
- SAEM `builtin_mean = :glm` M-step now honours `adtype`, user `lb`/`ub` and the model's declared bounds.
- The Q2-only M-step in SAEM and MCEM passes the user's `lb`/`ub` instead of `nothing`.
- `resolve_optimizer_bounds`: `IPNewton` requires a box (clear error, like BBO), `ParticleSwarm` requires finite bounds when a box is given; any optimizer's start outside the box is clamped with a warning naming the coordinates (transformed scale), so the opaque `Initial x[(1,)]=0.0 is outside of [...]` z-space message is gone.
- `build_fit_result` defaults `converged` to `missing` instead of `true`; `optimize_parameters` docs and the method-developer guide, the custom-estimator tutorial and its asset script pass `converged = SciMLBase.successful_retcode(sol)`. The tutorial's pre-rendered `summarize` output blocks are now one line stale until the assets are regenerated.
- `summarize(res)` prints the `converged` flag.
- Laplace/FOCEI and GHQuadrature emit the same post-hoc EBE gradient-tolerance warning as SAEM/MCEM and `reestimate_ebes` (shared helper, warning only, never inside AD).

## #312 / #316 symbol resolution and model-function checks
- `eta`, `beta`, `gamma`, `zeta`, `digamma` no longer count as defined via the Distributions re-export of SpecialFunctions. A formula that genuinely wants `loggamma` now needs `using SpecialFunctions` in the model's module.
- Random-effect distribution call heads are validated at `@Model` time (`Normall(...)` errors, naming the random effect and hinting at a missing extension).
- The `@formulas` ambiguity check spans all namespaces (fixed, random, preDE, covariates, helpers, model functions, DE states, signals, deterministic nodes, outcomes).
- A `@preDifferentialEquation` output that collides with a fixed effect, random effect or constant covariate errors instead of silently shadowing it.
- Length-1 networks and soft trees called with a bare scalar are rejected at build time; FFNN output-index bounds are checked like soft trees.
- Not done: the "unused declared effect" warning (#312 finding 5) needs symbol accessors for `@DifferentialEquation` and `@initialDE` that do not exist yet.

## #313 error plumbing
- The numeric-guard warning carries the caught exception's own message (flattened, capped at 200 chars) and softer advice; same for the two other sites that warn.
- `RealPSDMatrix` / `RealLiePSDMatrix` build their rejection message without recomputing `eigen` on input that would throw.
- Nine block parsers append the offending statement and `file:line` to every parse error (four sites listed in the issue raise no errors and were left alone).
- A `@fixedEffects` right-hand side that is not a parameter-block constructor (`a = 1 + 2`) errors clearly instead of receiving a synthesized `name =` keyword. User-defined blocks stay allowed via a capitalized-head rule.
- Not done: distribution arity checking (#313 finding 5).

## #314 static checks at build time
- `@preDifferentialEquation` also errors on an unknown function head (the variable branch landed in #317).
- Unknown symbols and functions in `@DifferentialEquation` are reported at `@Model` time with the same messages the lazy compiler used.
- `crossing_time` / `crossing_rootval` state and threshold names are checked once at `@Model` time.
- `set_solver_config(alg = ...)` rejects anything that is not an `AbstractODEAlgorithm`, with a `Did you mean Tsit5()?` hint for symbols and strings.
- A `@formulas` deterministic node that references a node defined later in the block errors at build time.
- Not done: eager `closed_form = :diagonal` eligibility (needs the DataModel-side Symbolics pass) and the outcome-support check (needs a new evaluator).

## #315 DataModel ergonomics (plus #309 findings 5 and 7)
- Every declared covariate's backing column must exist (one upfront pass, before all other covariate validation).
- `DataModel(df, model)` errors with the argument-order hint instead of `column name :formulas not found`.
- Missing values are validated for every declared covariate, not only those used in `@formulas`. The existing test that asserted a declared-but-unused covariate may contain missings was flipped, matching the documented promise in `covariates.md`.
- `summarize(dm)` reports subject-constant covariates over one row per individual.

## #306 / #308 leftovers
- `RealPSDMatrix` coordinates under `:expm` get positional names in the upper-triangle column order that `_coords_for_param` uses. `:lie` keeps linear indices because its coordinates are log-eigenvalues and rotation parameters, not matrix entries.
- An infusion whose stop time exceeds the individual's integration span warns once per DataModel with ids and times.
- `docs/src/data-model-construction.md` documents pre-dose scoring of an observation at a dose time and `EVID = 2` at the start time replacing `@initialDE`.

## Validation
Targeted Pkg-sandbox runs on this branch (37 test files including aqua), plus Runic clean on `src test docs ext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
