### PR TITLE
Supply fg so Laplace/FOCEI use the analytic outer gradient

### DIFF
--- a/src/estimation/ghquadrature.jl
+++ b/src/estimation/ghquadrature.jl
@@ -583,6 +583,10 @@ function _fit_model_scalar(
     θ_hat_u = inv_transform(θ_hat_t)
 
     # ── Post-hoc EB mode finding (for get_random_effects) ────────────────────
+    # Cold-solve the modes at θ̂: a warm start returns the stale residual of whichever θ
+    # the optimizer tried last (same warm-start issue as the Laplace family).
+    invalidate!()
+    fill!(ebe_cache.bstar_cache.has_bstar, false)
     _laplace_get_bstar!(
         ebe_cache, dm, batch_infos, θ_hat_u, const_cache, ll_cache;
         optimizer = inner_opts.optimizer,

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -2963,17 +2963,19 @@ function _fit_laplace_family(
     )
     sol = Optimization.solve(prob, opt_use; solve_kwargs...)
 
-    # Mini-batched objectives are per-minibatch; re-evaluate on all batches at the fitted
-    # θ (this also refreshes every batch's EB mode, which the diagnostics below use).
-    # The same evaluation runs when `wall_ref` is still empty: optimizers that only call
-    # the fused AD objective (Optimisers.jl rules) never evaluate it in Float64, which
+    # Final full-data evaluation at θ̂ (#322). The optimizer's last evaluation need not be
+    # at `sol.u` (Optim keeps the state of a rejected line-search trial), and a
+    # warm-started inner solve returns as soon as it meets its own stopping tolerance
+    # (often at iteration 0), so the cached EB modes carry the residual of whichever θ was
+    # tried last. Dropping the warm state re-solves the modes cold at θ̂, so `eb_modes`,
+    # the reported objective and the diagnostic below all describe the fitted model. It
+    # also covers mini-batched objectives (per-selection) and optimizers that only call
+    # the fused AD objective (Optimisers.jl rules), which never evaluate it in Float64 and
     # would otherwise look like an infeasible fit.
-    final_obj = sol.objective
-    if mb !== nothing || wall_ref[] === nothing
-        mb_ref[] = nothing
-        invalidate!()
-        final_obj = obj_only(sol.u, nothing)
-    end
+    mb_ref[] = nothing
+    invalidate!()
+    fill!(ebe_cache.bstar_cache.has_bstar, false)
+    final_obj = obj_only(sol.u, nothing)
 
     # No feasible point was ever reached, so `sol.objective` is the infeasibility wall
     # and not a fit; the flat wall otherwise lets the optimizer report success (#247).

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -2934,6 +2934,16 @@ function _fit_laplace_family(
         grad = (G, z, p) -> begin
             # chain rule for θt = θt0 + s .* z
             G .= s_pc .* obj_grad(z, p)[2]
+        end,
+        # Without `fg`, Optimization.jl builds a fused AD `fg!` by differentiating
+        # `obj_only` and ignores `grad` (Optim's line search and every Optimisers rule
+        # call it), so the analytic marginal gradient would go unused.
+        fg = (G, z, p) -> begin
+            obj, g = obj_grad(z, p)
+            G .= s_pc .* g
+            # `obj_grad` reports infeasibility as `Inf`; return the same finite wall as
+            # `obj_only` so the line search backtracks instead of giving up.
+            return isfinite(obj) ? obj : _infeasible(typeof(obj))
         end
     )
     lb, ub, use_bounds, θ0_init = _resolve_optim_bounds(

--- a/test/estimation_laplace2_tests.jl
+++ b/test/estimation_laplace2_tests.jl
@@ -966,3 +966,23 @@ end
     @test obj < 1.0e9
     @test NoLimits.get_summary(res).notes == NamedTuple()
 end
+
+# Optimization.jl builds a fused AD `fg!` from the objective whenever the
+# `OptimizationFunction` carries no `fg`, silently ignoring the analytic `grad`; the fit
+# then partly follows AD through the inner EBE solves and depends on `adtype`. With `fg`
+# supplied, `NoAD()` - which cannot produce a gradient at all - must give the identical
+# fit, because only the analytic gradient is ever used.
+@testset "Laplace uses the analytic gradient (fg)" begin
+    ads = (Optimization.AutoForwardDiff(), SciMLBase.NoAD())
+    for ctor in (NoLimits.Laplace, NoLimits.FOCEI)
+        f1, f2 = map(ads) do ad
+            fit_model(
+                fx_re_dm(), ctor(adtype = ad, optim_kwargs = (; maxiters = 6));
+                serialization = SciMLBase.EnsembleSerial()
+            )
+        end
+        @test NoLimits.get_params(f1; scale = :transformed) ==
+            NoLimits.get_params(f2; scale = :transformed)
+        @test NoLimits.get_objective(f1) == NoLimits.get_objective(f2)
+    end
+end

--- a/test/estimation_laplace2_tests.jl
+++ b/test/estimation_laplace2_tests.jl
@@ -986,3 +986,31 @@ end
         @test NoLimits.get_objective(f1) == NoLimits.get_objective(f2)
     end
 end
+
+# Issue #322: the optimizer's last objective evaluation need not be at `sol.u`, so the
+# returned EB modes must be refreshed at the fitted θ, not left at a line-search trial.
+@testset "returned EB modes are the modes at the fitted θ (#322)" begin
+    dm = fx_re_dm()
+    _, batch_infos, const_cache = NoLimits._build_re_batch_infos(dm, NamedTuple())
+    ll_cache = NoLimits.build_ll_cache(
+        dm; serialization = SciMLBase.EnsembleSerial(), force_saveat = true
+    )
+    for maxiters in (1, 2, 3, 4)
+        method = NoLimits.Laplace(; optim_kwargs = (; maxiters))
+        res = fit_model(dm, method; serialization = SciMLBase.EnsembleSerial())
+        @test isfinite(NoLimits.get_objective(res))
+        θu = NoLimits.get_params(res; scale = :untransformed)
+        cache = NoLimits._init_laplace_eval_cache(length(batch_infos), Float64)
+        for (bi, b) in enumerate(res.result.eb_modes)
+            cache.bstar_cache.b_star[bi] = b
+            cache.bstar_cache.has_bstar[bi] = true
+        end
+        norms = NoLimits._ebe_grad_norms(
+            cache, dm, batch_infos, θu, const_cache, ll_cache
+        )
+        @test maximum(norms) < 1.0e-10
+        res2 = fit_model(dm, method; serialization = SciMLBase.EnsembleSerial())
+        @test NoLimits.get_params(res2; scale = :transformed) ==
+            NoLimits.get_params(res; scale = :transformed)
+    end
+end


### PR DESCRIPTION
Closes #321.

## What

Two related fixes in the Laplace-family outer loop, plus the same fix for GHQuadrature's post-hoc EB pass.

**1. Analytic gradient was partly bypassed.** `_fit_laplace_family` supplied only `grad` to `OptimizationFunction`. Optimization.jl builds a fused AD `fg!` by differentiating `obj_only` whenever `fg === nothing` and ignores `grad` for that path (`allowsfg` is true for Optim optimizers and Optimisers rules). Measured on the fx_re_dm fixture (LBFGS, maxiters = 6): 41 analytic `grad` calls but 4 `value_gradient!` calls per fit went through the AD `fg!`, each a full ForwardDiff pass through the inner EBE solves; under Adam every evaluation was AD. This PR adds `fg` built from the existing `obj_grad` (same preconditioning chain rule). Infeasible points map to the same finite wall `obj_only` returns so the backtracking line search keeps backtracking.

**2. Returned EB modes belonged to the wrong θ (pre-existing, exposed by 1 on the x64 CI shard).** After `solve`, the EBE cache held the modes from the optimizer's last evaluated θ, which for Optim is often a rejected line-search trial, not `sol.u`. Re-evaluating at θ̂ alone did not help: the warm-started inner LBFGS returns "Success at 0 iterations" from a near-mode start and carries the stale residual through. So the post-solve full-data evaluation now solves the modes cold at θ̂ (`invalidate!()` + `fill!(has_bstar, false)`), which is what SAEM/MCEM already do via `_compute_bstars`. Measured max EBE gradient norm of the returned modes on the fixture, before → after: maxiters 1: 5.3e-9 → 3.1e-13; 2: 3.2e-9 → 1.2e-13; 3: 8.3e-9 → 1.6e-13 (CI x64 saw 2.8e-7 here, tripping the #311 diagnostic). GHQuadrature's post-hoc pass had the same exposure (2.7e-7 at maxiters = 1 before, 1.3e-13 after) and gets the same two lines. Cost: one extra full-data evaluation per fit; measured test-file runtimes unchanged.

| | before | after |
|---|---|---|
| Laplace params/objective equal across `AutoForwardDiff` and `NoAD` | no | yes (`==`) |
| FOCEI params equal across adtypes | no (1e-9 differences) | yes (`==`) |
| Laplace warm fit time (AutoForwardDiff) | 0.072 s | 0.035 s |
| Returned EB modes satisfy the inner gradient tolerance at θ̂ | no (up to 8e-7) | yes (~1e-13) |

## Tests

New testsets in `estimation_laplace2_tests.jl`: (a) Laplace and FOCEI fits bit-identical across `adtype = AutoForwardDiff()` and `SciMLBase.NoAD()`; (b) returned EB modes have inner gradient norm below 1e-10 at θ̂ for several `maxiters`. Run locally via `Pkg.test` with `NL_TEST_FILES`: `estimation_laplace_tests.jl`, `estimation_laplace2_tests.jl`, `estimation_focei_tests.jl`, `estimation_ghquadrature_tests.jl`, `estimation_ghquadrature2_tests.jl`, `uq_tests.jl`, `estimation_multistart_tests.jl`, `api_primitives_tests.jl`, `estimation_cv_tests.jl`, `summaries_tests.jl`; all pass with no expectation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
