### PR TITLE
release: v0.2.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NoLimits"
 uuid = "1d491b74-35a5-408f-ae19-cf8524c3769d"
 license = "MIT"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["Manuel Huth", "Jonas Arruda", "Clemens Peiter", "Roy Gusinow", "Nina Schmid", "Jan Hasenauer"]
 
 [deps]


### PR DESCRIPTION
Version bump to v0.2.8.

Mini-batching (`update_schedule`) for Laplace, FOCEI, MLE, MAP and GHQuadrature (#281), analytic outer gradients for the Laplace family, and a large batch of bug fixes across estimation, UQ, covariates, events and model building (#283, #284, #290, #304, #306, #308-#316, #321, #323).

🤖 Generated with [Claude Code](https://claude.com/claude-code)