### PR TITLE
fix: stable Model type across @Model expansions (RE/DE closures + RGF tag)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -68,6 +68,7 @@ makedocs(;
             "Multistart" => "estimation/multistart.md",
             "Cross-Validation" => "estimation/cv.md",
             "Saving & Loading" => "estimation/saving-and-loading.md",
+            "Precompiling Models" => "estimation/precompiling-models.md",
         ],
         "Uncertainty Quantification" => [
             "Overview" => "uncertainty-quantification/index.md",

--- a/docs/src/estimation/precompiling-models.md
+++ b/docs/src/estimation/precompiling-models.md
@@ -1,0 +1,112 @@
+# Precompiling Models
+
+## Why
+
+Every distinct `@Model` block generates code that is specialized to that model, so the
+first `fit_model` call in a fresh Julia session pays a compilation cost that can
+dominate a small analysis (tens of seconds for an ODE model). That cost can be cached
+across sessions by defining the model inside a small user package with a
+[PrecompileTools](https://github.com/JuliaLang/PrecompileTools.jl) workload.
+
+This works because the functions NoLimits generates are `RuntimeGeneratedFunction`s
+whose *types* are keyed by a content hash of the model expressions. The cached
+specializations therefore remain valid in a new session as long as the model text is
+unchanged, and since [PR #328](https://github.com/manuhuth/NoLimits.jl/pull/328) the
+`Model` type no longer depends on where or how often the block is expanded.
+
+## Recipe
+
+Create a package (`Pkg.generate("MyModels")`, then `Pkg.develop(path = "MyModels")` to
+use it from your analysis environment) and add `NoLimits`, `DataFrames`,
+`Distributions`, and `PrecompileTools` to it with `Pkg.add`.
+
+`MyModels/src/MyModels.jl`:
+
+```julia
+module MyModels
+
+using NoLimits, DataFrames, Distributions, PrecompileTools
+
+function build_model()
+    m = @Model begin
+        @fixedEffects begin
+            a = RealNumber(0.3)
+            σ = RealNumber(0.4, scale = :log)
+        end
+        @covariates begin
+            t = Covariate()
+        end
+        @randomEffects begin
+            η = RandomEffect(Normal(0.0, 1.0); column = :ID)
+        end
+        @DifferentialEquation begin
+            D(x1) ~ -a * exp(η) * x1
+        end
+        @initialDE begin
+            x1 = 1.0
+        end
+        @formulas begin
+            y ~ Normal(x1(t), σ)
+        end
+    end
+    return set_solver_config(m; saveat_mode = :saveat)
+end
+
+build_dm(df) = DataModel(build_model(), df; primary_id = :ID, time_col = :t)
+
+fit(dm) = fit_model(dm, NoLimits.Laplace(); serialization = NoLimits.EnsembleSerial())
+
+@compile_workload begin
+    df = DataFrame(
+        ID = repeat(1:6, inner = 3),
+        t = repeat([0.0, 1.0, 2.0], 6),
+        y = [exp(-0.3 * t) + 0.05 * i / 6 for (i, t) in zip(repeat(1:6, inner = 3), repeat([0.0, 1.0, 2.0], 6))]
+    )
+    dm = build_dm(df)
+    fit_model(dm, NoLimits.Laplace(; optim_kwargs = (maxiters = 3,)); serialization = NoLimits.EnsembleSerial())
+end
+
+end
+```
+
+The workload runs on a tiny synthetic dataset for a few iterations. What gets cached is
+the code specialized to the model and the estimator, so neither the data values nor the
+iteration count matter. In your analysis:
+
+```julia
+using MyModels
+
+dm = MyModels.build_dm(real_df)
+res = MyModels.fit(dm)
+```
+
+## What is cached and what is not
+
+- Cached: every estimator and data path the workload exercises, such as `DataModel`
+  construction and `fit_model` for that estimator type. Use the same estimator and
+  `serialization` types you will use later; a different estimator or option type
+  compiles anew on its first call.
+- Changing fixed-effect initial values, bounds, or the covariate data does not
+  invalidate the cache. Changing any expression inside `@formulas`,
+  `@DifferentialEquation`, `@initialDE`, `@preDifferentialEquation`, or a
+  `@randomEffects` distribution changes the generated code and triggers recompilation
+  of that model. That includes literals, for example `Normal(0.0, 1.0)` to
+  `Normal(0.0, 0.7)`.
+- Not cached: the Turing-based estimators `MCMC`, `MCEM`, and `VI` build a model
+  definition per call and are compiled once per session.
+
+Measured on Julia 1.12 for the small ODE model above with `Laplace`:
+
+| | First fit in a fresh session | Pkgimage size |
+| --- | --- | --- |
+| Without workload | 55 s | - |
+| With workload | < 0.1 s | ~85 MB |
+
+## Tips
+
+- Keep model packages small, ideally one package per model family, so editing one model
+  only re-precompiles that package.
+- [`save_fit`/`load_fit`](saving-and-loading.md) complement this: the fit result carries
+  the numbers, the model package supplies the code.
+- `get_source(model)` returns the stored block expressions, which is a convenient
+  starting point for generating such a package from a model you already have.

--- a/docs/src/estimation/saving-and-loading.md
+++ b/docs/src/estimation/saving-and-loading.md
@@ -1,6 +1,6 @@
 # Saving and Loading Fit Results
 
-Fit results can be persisted to disk using `save_fit` and reloaded with `load_fit`. Results are stored as [JLD2](https://github.com/JuliaIO/JLD2.jl) files. Because the `DataModel` contains runtime-generated closures (from the `@Model` macro) that cannot be serialized, these are stripped on save and must be reconstructed on load. All numerical content - parameters, objectives, chains, empirical Bayes modes - is preserved exactly.
+Fit results can be persisted to disk using `save_fit` and reloaded with `load_fit`. Results are stored as [JLD2](https://github.com/JuliaIO/JLD2.jl) files. Because the `DataModel` contains runtime-generated closures (from the `@Model` macro) that cannot be serialized, these are stripped on save and must be reconstructed on load. All numerical content - parameters, objectives, chains, empirical Bayes modes - is preserved exactly. Reconstructing the model in a new session recompiles the generated code; see [Precompiling Models](precompiling-models.md) for how to cache that compilation across sessions.
 
 !!! note "JLD2 is an optional dependency"
     `save_fit` and `load_fit` live in a package extension, so JLD2 is not installed with

--- a/src/model/DifferentialEquation.jl
+++ b/src/model/DifferentialEquation.jl
@@ -172,6 +172,25 @@ end
 
 @inline (a::DESignalAccessor)(t) = a.f(a.sol, a.pc, t)
 
+# Callable struct instead of a gensym'd closure over `signal_fns`: two byte-identical
+# `@DifferentialEquation` blocks must produce the same type regardless of the module
+# they expand in (issue #327). `names` lists states then signals.
+struct _DEAccessors{names, nstates, S}
+    signal_fns::S
+end
+
+function _DEAccessors{names, nstates}(fns::S) where {names, nstates, S}
+    return _DEAccessors{names, nstates, S}(fns)
+end
+
+@generated function (a::_DEAccessors{names, nstates})(sol, pc) where {names, nstates}
+    vals = Any[:(DEStateAccessor(sol, $i)) for i in 1:nstates]
+    for j in 1:(length(names) - nstates)
+        push!(vals, :(DESignalAccessor(sol, pc, a.signal_fns[$j])))
+    end
+    return :(NamedTuple{$names}(($(vals...),)))
+end
+
 """
     DEStaticContext{B, I}
 
@@ -721,6 +740,7 @@ Must be paired with `@initialDE` when used inside `@Model`.
 """
 macro DifferentialEquation(block)
     RuntimeGeneratedFunctions.init(__module__)
+    mod = @__MODULE__
     state_names, rhs_exprs, signal_names, signal_exprs, line_exprs = _parse_de(block)
     signal_set = Set(signal_names)
 
@@ -888,32 +908,23 @@ macro DifferentialEquation(block)
             end
             ) for i in eachindex(signal_names)
     ]
-    accessor_names = vcat(state_names, signal_names)
-    accessor_vals = vcat(
-        [:(DEStateAccessor(sol, $i)) for i in eachindex(state_names)],
-        [:(DESignalAccessor(sol, pc, signal_fns[$i])) for i in eachindex(signal_names)]
-    )
-    accessors_nt = Expr(
-        :call,
-        Expr(:curly, :NamedTuple, Expr(:tuple, QuoteNode.(accessor_names)...)),
-        Expr(:tuple, accessor_vals...)
-    )
-    accessors_fn_sym = gensym(:de_accessors_)
-    accessors_expr = :(
-        function $(accessors_fn_sym)(sol, pc)
-            return $accessors_nt
-        end
-    )
+    accessor_names_expr = Expr(:tuple, QuoteNode.(vcat(state_names, signal_names))...)
+
+    # RGF tags are NoLimits itself, so the function types do not carry the caller
+    # module. Construction stays inside the quote: the bodies must be re-registered in
+    # the RGF cache in every fresh session.
+    compile_expr = _qualify_context_globals(compile_expr, __module__)
+    f!_expr = _qualify_context_globals(f!_expr, __module__)
+    f_expr = _qualify_context_globals(f_expr, __module__)
+    signal_fn_exprs = [_qualify_context_globals(ex, __module__) for ex in signal_fn_exprs]
 
     state_names_expr = Expr(:vect, QuoteNode.(state_names)...)
     signal_names_expr = Expr(:vect, QuoteNode.(signal_names)...)
     lines_expr = Expr(:vect, QuoteNode.(line_exprs)...)
     return quote
-        compile_rgf = RuntimeGeneratedFunction(
-            @__MODULE__, @__MODULE__, $(QuoteNode(compile_expr))
-        )
-        f!_rgf = RuntimeGeneratedFunction(@__MODULE__, @__MODULE__, $(QuoteNode(f!_expr)))
-        f_rgf = RuntimeGeneratedFunction(@__MODULE__, @__MODULE__, $(QuoteNode(f_expr)))
+        compile_rgf = RuntimeGeneratedFunction($mod, $mod, $(QuoteNode(compile_expr)))
+        f!_rgf = RuntimeGeneratedFunction($mod, $mod, $(QuoteNode(f!_expr)))
+        f_rgf = RuntimeGeneratedFunction($mod, $mod, $(QuoteNode(f_expr)))
         meta = DifferentialEquationMeta(
             $state_names_expr, $signal_names_expr,
             $(Expr(:vect, map(QuoteNode, collect(var_syms_no_states))...)),
@@ -926,14 +937,16 @@ macro DifferentialEquation(block)
                 [
                     :(
                             RuntimeGeneratedFunction(
-                                @__MODULE__, @__MODULE__, $(QuoteNode(signal_fn_exprs[i]))
+                                $mod, $mod, $(QuoteNode(signal_fn_exprs[i]))
                             )
                         )
                         for i in eachindex(signal_fn_exprs)
                 ]...
             ),
         )
-        $(accessors_expr)
-        DifferentialEquation(meta, builders, $(accessors_fn_sym))
+        DifferentialEquation(
+            meta, builders,
+            _DEAccessors{$accessor_names_expr, $(length(state_names))}(signal_fns)
+        )
     end
 end

--- a/src/model/Formulas.jl
+++ b/src/model/Formulas.jl
@@ -659,12 +659,21 @@ function _qualify_context_globals(ex, mod::Module)
     (mod === @__MODULE__) && return ex
     locals = Set{Symbol}()
     _collect_assigned_syms!(locals, ex)
-    if ex isa Expr && ex.head == :function && ex.args[1] isa Expr
-        for a in ex.args[1].args
-            a isa Symbol && push!(locals, a)
-        end
+    if ex isa Expr && ex.head == :function
+        _collect_arg_syms!(locals, ex.args[1])
     end
     return _qcg(ex, mod, locals)
+end
+# Argument names, including a lone `f(p)` arg and typed `x::T` args.
+_collect_arg_syms!(::Set{Symbol}, ::Any) = nothing
+_collect_arg_syms!(s::Set{Symbol}, a::Symbol) = (push!(s, a); nothing)
+function _collect_arg_syms!(s::Set{Symbol}, ex::Expr)
+    if ex.head === :(::) || ex.head === :kw
+        _collect_arg_syms!(s, ex.args[1])
+    else
+        foreach(a -> _collect_arg_syms!(s, a), ex.args)
+    end
+    return nothing
 end
 _collect_assigned_syms!(::Set{Symbol}, ex) = nothing
 function _collect_assigned_syms!(s::Set{Symbol}, ex::Expr)

--- a/src/model/RandomEffects.jl
+++ b/src/model/RandomEffects.jl
@@ -29,6 +29,65 @@ struct RandomEffectsBuilders{C, L}
     logpdf::L
 end
 
+# Callable structs instead of per-expansion closures/named methods: two byte-identical
+# `@randomEffects` blocks must produce the same `RandomEffects` type regardless of the
+# module they expand in (issue #327).
+struct _REDistBuilder{F}
+    f::F
+end
+
+function (b::_REDistBuilder)(
+        fixed_effects::ComponentArray,
+        constant_features_i::NamedTuple,
+        model_funs::NamedTuple
+    )
+    return b.f(fixed_effects, constant_features_i, model_funs, NamedTuple())
+end
+
+function (b::_REDistBuilder)(
+        fixed_effects::AbstractArray,
+        constant_features_i::NamedTuple,
+        model_funs::NamedTuple
+    )
+    return b.f(
+        _re_componentize(fixed_effects), constant_features_i, model_funs, NamedTuple()
+    )
+end
+
+function (b::_REDistBuilder)(
+        fixed_effects::ComponentArray,
+        constant_features_i::NamedTuple,
+        model_funs::NamedTuple,
+        helper_functions::NamedTuple
+    )
+    return b.f(fixed_effects, constant_features_i, model_funs, helper_functions)
+end
+
+function (b::_REDistBuilder)(
+        fixed_effects::AbstractArray,
+        constant_features_i::NamedTuple,
+        model_funs::NamedTuple,
+        helper_functions::NamedTuple
+    )
+    return b.f(
+        _re_componentize(fixed_effects), constant_features_i, model_funs, helper_functions
+    )
+end
+
+struct _RELogpdf{names} end
+
+@generated function (::_RELogpdf{names})(dists, re_values) where {names}
+    ex = :(0.0)
+    for n in names
+        ex = :(
+            $ex + logpdf(
+                getproperty(dists, $(QuoteNode(n))), getproperty(re_values, $(QuoteNode(n)))
+            )
+        )
+    end
+    return ex
+end
+
 """
     RandomEffects
 
@@ -399,15 +458,27 @@ macro randomEffects(block)
     # generated function as `sym in Set([...])`, allocating a fresh Set on every
     # builder invocation — and the builder runs per RE level per log-density
     # evaluation in the estimation hot paths.)
+    #
+    # A speculative `hasproperty` bind makes the symbol local, so it escapes the
+    # GlobalRef rewrite below. Seed it from the caller module when only that module
+    # defines it (user types, `Copulas`, ...); the branches overwrite it when they hit.
+    _caller_ref = function (s::Symbol)
+        (__module__ === @__MODULE__) && return nothing
+        return (!isdefined(@__MODULE__, s) && isdefined(__module__, s)) ?
+            :($(s) = $(GlobalRef(__module__, s))) : nothing
+    end
+
     binds_vars = [
         if sym in prop_syms
                 quote
+                    $(_caller_ref(sym))
                     if hasproperty(constant_features_i, $(QuoteNode(sym)))
                         $(sym) = getproperty(constant_features_i, $(QuoteNode(sym)))
                 end
                 end
         else
                 quote
+                    $(_caller_ref(sym))
                     if hasproperty(constant_features_i, $(QuoteNode(sym)))
                         $(sym) = getproperty(constant_features_i, $(QuoteNode(sym)))
                 elseif hasproperty(fixed_effects, $(QuoteNode(sym)))
@@ -420,6 +491,7 @@ macro randomEffects(block)
 
     binds_funs = [
         quote
+                $(_caller_ref(sym))
                 if hasproperty(model_funs, $(QuoteNode(sym)))
                     $(sym) = getproperty(model_funs, $(QuoteNode(sym)))
             elseif hasproperty(helper_functions, $(QuoteNode(sym)))
@@ -437,6 +509,7 @@ macro randomEffects(block)
         :tuple, (Expr(:(=), re_names[i], re_names[i]) for i in eachindex(re_names))...
     )
 
+    mod = @__MODULE__
     func_expr = :(
         function (
                 fixed_effects::ComponentArray,
@@ -460,48 +533,12 @@ macro randomEffects(block)
     )
     dist_expr_values = Expr(:tuple, (QuoteNode.(dist_exprs))...)
 
+    # RGF tag is NoLimits itself, so the function type does not carry the caller module.
+    # Construction stays inside the quote: the body must be re-registered in the RGF
+    # cache in every fresh session.
+    func_expr = _qualify_context_globals(func_expr, __module__)
     return quote
-        create_dist = RuntimeGeneratedFunction(
-            @__MODULE__, @__MODULE__, $(QuoteNode(func_expr))
-        )
-        function create_wrapper(
-                fixed_effects::ComponentArray,
-                constant_features_i::NamedTuple,
-                model_funs::NamedTuple
-            )
-            return create_dist(fixed_effects, constant_features_i, model_funs, NamedTuple())
-        end
-        function create_wrapper(
-                fixed_effects::AbstractArray,
-                constant_features_i::NamedTuple,
-                model_funs::NamedTuple
-            )
-            return create_dist(
-                _re_componentize(fixed_effects),
-                constant_features_i, model_funs, NamedTuple()
-            )
-        end
-        function create_wrapper(
-                fixed_effects::ComponentArray,
-                constant_features_i::NamedTuple,
-                model_funs::NamedTuple,
-                helper_functions::NamedTuple
-            )
-            return create_dist(
-                fixed_effects, constant_features_i, model_funs, helper_functions
-            )
-        end
-        function create_wrapper(
-                fixed_effects::AbstractArray,
-                constant_features_i::NamedTuple,
-                model_funs::NamedTuple,
-                helper_functions::NamedTuple
-            )
-            return create_dist(
-                _re_componentize(fixed_effects),
-                constant_features_i, model_funs, helper_functions
-            )
-        end
+        create_dist = RuntimeGeneratedFunction($mod, $mod, $(QuoteNode(func_expr)))
         meta = RandomEffectsMeta(
             $re_names_expr,
             NamedTuple{($(QuoteNode.(re_names)...),)}($groups_values),
@@ -509,24 +546,10 @@ macro randomEffects(block)
             $re_syms_expr,
             NamedTuple{($(QuoteNode.(re_names)...),)}($dist_expr_values)
         )
-        logpdf_fn = function (dists, re_values)
-            total = 0.0
-            $(
-                Expr(
-                    :block,
-                    [
-                        :(
-                                total += logpdf(
-                                    getproperty(dists, $(QuoteNode(n))),
-                                    getproperty(re_values, $(QuoteNode(n)))
-                                )
-                            ) for n in re_names
-                    ]...
-                )
-            )
-            return total
-        end
-        builders = RandomEffectsBuilders(create_wrapper, logpdf_fn)
+        builders = RandomEffectsBuilders(
+            _REDistBuilder(create_dist),
+            _RELogpdf{$(Expr(:tuple, QuoteNode.(re_names)...))}()
+        )
         RandomEffects(meta, builders)
     end
 end

--- a/test/model_macro_tests.jl
+++ b/test/model_macro_tests.jl
@@ -510,3 +510,37 @@ end
 
     @test ok === true
 end
+
+@testset "Model type is identical across expansion modules" begin
+    body = quote
+        @Model begin
+            @fixedEffects begin
+                a = RealNumber(0.3)
+                σ = RealNumber(0.4, scale = :log)
+            end
+            @covariates begin
+                t = Covariate()
+            end
+            @randomEffects begin
+                η = RandomEffect(Normal(0.0, 1.0); column = :ID)
+            end
+            @DifferentialEquation begin
+                D(x1) ~ -a * exp(η) * x1
+                sig(t) = 2.0 * x1
+            end
+            @initialDE begin
+                x1 = 1.0
+            end
+            @formulas begin
+                y ~ Normal(x1(t) + 0.0 * sig(t), σ)
+            end
+        end
+    end
+    types = map(1:2) do _
+        mod = Core.eval(Main, :(module $(gensym(:LDTypeStable)) end))
+        Core.eval(mod, :(using NoLimits))
+        Core.eval(mod, :(using Distributions))
+        typeof(Core.eval(mod, body))
+    end
+    @test types[1] === types[2]
+end


### PR DESCRIPTION
## What

`typeof(model)` is now identical for two byte-identical `@Model` blocks, no matter which module they expand in (twice in `Main`, in a user package, inside a `@compile_workload`).

Three per-expansion type sources are removed:

1. **RGF cache tag.** `@randomEffects` and `@DifferentialEquation` emitted `RuntimeGeneratedFunction(@__MODULE__, @__MODULE__, ...)` inside the returned `quote`, so the tag was the *caller* module and entered the function type. The tag is now the NoLimits module itself, spliced at macro-definition time. `@formulas` already did this; `@preDifferentialEquation` and `@initialDE` were already fine.
2. **`@randomEffects` closures.** The four emitted `create_wrapper` methods and the `logpdf_fn` closure are replaced by top-level callable structs `_REDistBuilder{F}` and `_RELogpdf{names}` (the latter an unrolled `@generated` sum, non-allocating and ForwardDiff-friendly).
3. **`@DifferentialEquation` accessor closure.** The gensym'd `de_accessors_...` function closing over the runtime-local `signal_fns` is replaced by the top-level `_DEAccessors{names, nstates, S}` callable struct, built via `@generated` so the returned `NamedTuple` stays type-stable. `get_de_accessors_builder(de)(sol, compiled)` is unchanged for callers.

RGF construction deliberately stays inside the emitted `quote`: the bodies must be re-registered in the RGF cache in every fresh session, which is what makes the pkgimage-cached specializations usable.

## Why the qualification changes came along

With the tag moved to NoLimits, caller-module-only names in the emitted bodies would no longer resolve. Both macros now run their expressions through `_qualify_context_globals`, and `@randomEffects` additionally seeds each speculative `hasproperty` bind from the caller module (a `hasproperty` bind makes the symbol local, so it escapes the `GlobalRef` rewrite). That is what keeps `Copulas.SklarDist` and user-defined functions in RE distributions working.

`_qualify_context_globals` also gained `_collect_arg_syms!`, so typed (`x::T`) and single-argument (`f(p)`) parameter names are collected as locals and can no longer be rewritten into `GlobalRef`s.

## Verified

Type-equality script (two `Main` expansions + one inside `module Foo`, model with RE + ODE + a signal, plus a variant using a `Foo`-local helper inside the RE distribution):

```
m1 == m2      : true
m1 == Foo.m   : true
user-helper fit objective: -26.942259189213296
plain fit:                 -26.942259189213296
```

The user-helper model builds a `DataModel` and runs `fit_model(dm, Laplace(; optim_kwargs = (maxiters = 3,)); serialization = EnsembleSerial())` to exercise the `GlobalRef` path end to end.

Test suite (through the real Pkg test sandbox):

```
NL_TEST_FILES="model_macro_tests.jl,model_tests.jl,random_effects_tests.jl,differential_equation_tests.jl,data_model_ode_tests.jl,copulas_tests.jl,ad_random_effects.jl" julia --project -e 'using Pkg; Pkg.test()'
  ad_random_effects.jl            17/17
  random_effects_tests.jl         41/41
  differential_equation_tests.jl  15/15
  model_macro_tests.jl            35/35
  model_tests.jl                   7/7
  data_model_ode_tests.jl         19/19
  copulas_tests.jl                38/38
  -> Testing NoLimits tests passed

NL_TEST_GROUP=12 julia --project -e 'using Pkg; Pkg.test()'   # estimation_laplace_tests.jl 35/35, passed
NL_TEST_GROUP=4  julia --project -e 'using Pkg; Pkg.test()'   # closed_form_ode2_tests.jl  33/33, passed
NL_TEST_FILES="aqua_tests.jl" julia --project -e 'using Pkg; Pkg.test()'  # 9/9, passed
```

One test was added to `test/model_macro_tests.jl` (no new test file, no new fixture model): it expands the same RE + DE + signal model in two fresh gensym'd modules and asserts the resulting `Model` types are identical.

Runic 1.9.0 (the version pinned in `Format.yml`) reports the tree clean.

Addresses the cache-key causes in #327

## Docs

New page `docs/src/estimation/precompiling-models.md` ("Precompiling Models", registered in `docs/make.jl` under Estimation): how to cache a model's generated code across Julia sessions by defining the model in a small user package with a PrecompileTools `@compile_workload`. Covers why the stable `Model` type and content-hashed `RuntimeGeneratedFunction`s make this work, a copy-paste package recipe, what invalidates the cache (any expression change inside `@formulas`/`@DifferentialEquation`/`@initialDE`/`@preDifferentialEquation`/`@randomEffects`, but not initial values, bounds, or data), the Turing-based estimators that cannot be cached, and measured numbers (55 s to under 0.1 s for the first fit). `saving-and-loading.md` gains one cross-reference sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

