### PR TITLE
fix: bug batch #331-#343

### DIFF
--- a/ext/turing/mcem.jl
+++ b/ext/turing/mcem.jl
@@ -176,16 +176,20 @@ function NoLimits._mcem_sample_batch_turing(
     # Turing ≥ 0.45 defaults to FlexiChains; `_extract_b_samples` consumes the chain via
     # the MCMCChains API (`names`/`Array`), so force an MCMCChains.Chains result here.
     tkwargs = merge(tkwargs, (chain_type = MCMCChains.Chains,))
+    # `adapt` is not a Turing keyword; the adaptive Hamiltonian samplers read `nadapts`
+    # and everything else silently ignored it (#335).
+    adapt_kw = (_mcmc_is_adaptive(sampler) && !haskey(tkwargs, :nadapts)) ?
+        (; nadapts = n_adapt) : (;)
     chain = if warm_start && last_params isa NamedTuple && !isempty(last_params)
         init = DynamicPPL.InitFromParams(last_params)
         Base.invokelatest(
             Turing.sample, rng, model, sampler, n_samples;
-            adapt = n_adapt, initial_params = init, tkwargs...
+            adapt_kw..., initial_params = init, tkwargs...
         )
     else
         Base.invokelatest(
             Turing.sample, rng, model, sampler, n_samples;
-            adapt = n_adapt, tkwargs...
+            adapt_kw..., tkwargs...
         )
     end
     samples, lastp, lastb = _extract_b_samples(chain, info, re_names)

--- a/ext/turing/mcmc.jl
+++ b/ext/turing/mcmc.jl
@@ -31,14 +31,20 @@ end
 @inline NoLimits._mcmc_sampler_kind(::HMC) = :hmc
 @inline NoLimits._mcmc_sampler_kind(::MH) = :mh
 
+# Only the Hamiltonian samplers adapt; anything else would carry a phantom warmup count
+# that later trims real posterior draws (#335).
+@inline _mcmc_is_adaptive(sampler) = NoLimits._mcmc_sampler_kind(sampler) in (:hmc, :nuts)
+
 @inline function _mcmc_sampler_defaults(sampler)
     kind = NoLimits._mcmc_sampler_kind(sampler)
     if kind == :mh
         return (n_samples = 2500, n_adapt = 0)
     elseif kind == :hmc
         return (n_samples = 1500, n_adapt = 750)
-    else
+    elseif kind == :nuts
         return (n_samples = 1000, n_adapt = 500)
+    else
+        return (n_samples = 1000, n_adapt = 0)
     end
 end
 
@@ -387,6 +393,7 @@ function NoLimits._mcmc_fit_impl(
         rng = rng,
         theta_0_untransformed = theta_0_untransformed,
         store_data_model = store_data_model,
+        extra_objective = extra_objective,
     )
     re_names = get_re_names(get_random(get_model(dm)))
     isempty(keys(penalty)) ||
@@ -538,16 +545,36 @@ function NoLimits._mcmc_fit_impl(
     # opt into a different chain type via turing_kwargs.
     haskey(turing_kwargs, :chain_type) ||
         (turing_kwargs = merge(turing_kwargs, (chain_type = MCMCChains.Chains,)))
-    chain = Turing.sample(rng, model, sampler, n_samples; adapt = n_adapt, turing_kwargs...)
+    # Turing's adaptive Hamiltonian samplers take `nadapts`; the `adapt` keyword this
+    # adapter used to pass was absorbed by `kwargs...` and never controlled adaptation,
+    # so the requested count was silently replaced by the sampler default (#335).
+    is_adaptive = _mcmc_is_adaptive(sampler)
+    adapt_kw = (is_adaptive && !haskey(turing_kwargs, :nadapts)) ? (; nadapts = n_adapt) : (;)
+    chain = Turing.sample(rng, model, sampler, n_samples; adapt_kw..., turing_kwargs...)
+
+    # Turing discards the adaptation iterations before returning, so the retained chain
+    # normally holds NO warmup rows. Everything downstream (posterior means, chain UQ,
+    # the objective summary) drops `n_adapt` rows from the STORED chain, so record the
+    # rows that are actually there instead of the number requested (#335).
+    n_adapt_eff = is_adaptive ? Int(get(turing_kwargs, :nadapts, n_adapt)) : 0
+    discard_initial = Int(
+        get(
+            turing_kwargs, :discard_initial,
+            get(turing_kwargs, :discard_adapt, true) ? n_adapt_eff : 0
+        )
+    )
+    n_warmup = clamp(n_adapt_eff - discard_initial, 0, max(0, size(chain, 1) - 1))
 
     obs = get_df(dm)[:, get_obs_cols(dm)]
     summary = FitSummary(
-        _mcmc_objective(chain, n_adapt), missing,
+        _mcmc_objective(chain, n_warmup), missing,
         FitParameters(ComponentArray(), ComponentArray()),
         NamedTuple()
     )
     diagnostics = FitDiagnostics(
-        (;), (sampler = sampler,), (n_samples = n_samples, n_adapt = n_adapt), NamedTuple()
+        (;), (sampler = sampler,),
+        (n_samples = n_samples, n_adapt = n_warmup, n_adapt_requested = n_adapt_eff),
+        NamedTuple()
     )
     result = MCMCResult(chain, sampler, n_samples, NamedTuple(), obs)
     res = FitResult(

--- a/ext/turing/vi.jl
+++ b/ext/turing/vi.jl
@@ -131,6 +131,7 @@ function NoLimits._vi_fit_impl(
         rng = rng,
         theta_0_untransformed = theta_0_untransformed,
         store_data_model = store_data_model,
+        extra_objective = extra_objective,
     )
     re_names = get_re_names(get_random(get_model(dm)))
     if !isempty(re_names)

--- a/src/estimation/cv.jl
+++ b/src/estimation/cv.jl
@@ -625,9 +625,15 @@ function _cv_evaluate_mc(
 
     # Aggregate across samples: logsumexp for loglikelihood, mean for predicted_mean/loss
     result_dfs = DataFrame[]
+    n_failed_draws = 0
+    n_failed_inds = 0
     for j in 1:n_test
         s0 = findfirst(s -> !isempty(all_dfs[s][j]), 1:n_mc_samples)
-        s0 === nothing && continue
+        if s0 === nothing
+            n_failed_draws += n_mc_samples
+            n_failed_inds += 1
+            continue
+        end
         base_df = all_dfs[s0][j]
         n_rows = nrow(base_df)
 
@@ -635,7 +641,7 @@ function _cv_evaluate_mc(
         n_valid_draws = 0
         mean_acc = fill(0.0, n_rows)
         mean_cnt = fill(0, n_rows)
-        loss_acc = :loss ∈ names(base_df) ? fill(0.0, n_rows) : nothing
+        loss_acc = hasproperty(base_df, :loss) ? fill(0.0, n_rows) : nothing
         loss_cnt = loss_acc !== nothing ? fill(0, n_rows) : nothing
 
         for s in 1:n_mc_samples
@@ -655,7 +661,7 @@ function _cv_evaluate_mc(
                     mean_acc[r] += pm
                     mean_cnt[r] += 1
                 end
-                if loss_acc !== nothing && :loss ∈ names(df_s)
+                if loss_acc !== nothing && hasproperty(df_s, :loss)
                     lv = Float64(df_s[r, :loss])
                     if !isnan(lv)
                         loss_acc[r] += lv
@@ -669,7 +675,7 @@ function _cv_evaluate_mc(
         df_out[!, :loglikelihood] = if n_valid_draws == 0
             fill(NaN, n_rows)              # no usable draw → drop the whole individual
         else
-            joint_ll = ll_acc - log(n_valid_draws)
+            joint_ll = ll_acc - log(n_mc_samples)
             [r == 1 ? joint_ll : 0.0 for r in 1:n_rows]
         end
         df_out[!, :predicted_mean] = [
@@ -682,8 +688,13 @@ function _cv_evaluate_mc(
                     for r in 1:n_rows
             ]
         end
+        n_failed_draws += n_mc_samples - n_valid_draws
         push!(result_dfs, df_out)
     end
+
+    # A failed draw contributes zero probability and stays in the denominator (#332);
+    # say how much of the requested Monte Carlo budget was actually usable.
+    n_failed_draws == 0 || @warn "fit_cv: $(n_failed_draws) of $(n_mc_samples * n_test) Monte Carlo draws could not be evaluated and contributed zero probability to the predictive likelihood; $(n_failed_inds) test individual(s) lost every draw and are omitted from the fold."
 
     return isempty(result_dfs) ? DataFrame() : vcat(result_dfs...)
 end
@@ -793,7 +804,12 @@ function fit_cv(
 
     n_folds = cv_spec.n_folds
     dm_ref = cv_spec.dm
-    fold_rngs = _spawn_child_rngs(rng, n_folds)
+    # Two independent streams per fold: the training fit must be reproducible from the
+    # supplied `rng`, and the predictive draws must not shift with how many numbers the
+    # training algorithm consumed (#334).
+    child_rngs = _spawn_child_rngs(rng, 2 * n_folds)
+    train_rngs = child_rngs[1:n_folds]
+    fold_rngs = child_rngs[(n_folds + 1):(2 * n_folds)]
 
     function _run_fold(f)
         dm_train = _rebuild_dm(dm_ref, cv_spec.train_rows[f])
@@ -810,7 +826,10 @@ function fit_cv(
         end
         dm_test = _rebuild_dm(dm_ref, eval_rows)
 
-        base_kw = (store_data_model = false, ode_args = ode_args, ode_kwargs = ode_kwargs)
+        base_kw = (
+            store_data_model = false, ode_args = ode_args, ode_kwargs = ode_kwargs,
+            rng = train_rngs[f],
+        )
         fit_kw = _cv_method_accepts_constants_re(method) ?
             merge(base_kw, (constants_re = constants_re,)) : base_kw
         res_train = fit_model(dm_train, method, args...; fit_kw..., kwargs...)

--- a/src/estimation/focei.jl
+++ b/src/estimation/focei.jl
@@ -832,6 +832,7 @@ function _fit_model(
         constants = constants, constants_re = constants_re, penalty = penalty,
         ode_args = ode_args, ode_kwargs = ode_kwargs, serialization = serialization,
         rng = rng, theta_0_untransformed = theta_0_untransformed, store_data_model = store_data_model,
+        extra_objective = extra_objective,
     )
     re_names = get_re_names(get_random(get_model(dm)))
     isempty(re_names) &&

--- a/src/estimation/ghquadrature.jl
+++ b/src/estimation/ghquadrature.jl
@@ -412,6 +412,7 @@ function _fit_model_scalar(
         rng = rng,
         theta_0_untransformed = theta_0_untransformed,
         store_data_model = store_data_model,
+        extra_objective = extra_objective,
     )
 
     # ── Validate ────────────────────────────────────────────────────────────

--- a/src/estimation/laplace.jl
+++ b/src/estimation/laplace.jl
@@ -2706,6 +2706,7 @@ function _fit_model(
         rng = rng,
         theta_0_untransformed = theta_0_untransformed,
         store_data_model = store_data_model,
+        extra_objective = extra_objective,
     )
     re_names = get_re_names(get_random(get_model(dm)))
     isempty(re_names) &&

--- a/src/estimation/map.jl
+++ b/src/estimation/map.jl
@@ -107,6 +107,7 @@ function _fit_model(
         rng = rng,
         theta_0_untransformed = theta_0_untransformed,
         store_data_model = store_data_model,
+        extra_objective = extra_objective,
     )
     return _fit_no_re(
         dm, method;

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -1227,6 +1227,7 @@ function _fit_model(
         theta_0_untransformed = theta_0_untransformed,
         store_eb_modes = store_eb_modes,
         store_data_model = store_data_model,
+        extra_objective = extra_objective,
     )
     re_names = get_re_names(get_random(get_model(dm)))
     isempty(re_names) &&

--- a/src/estimation/mle.jl
+++ b/src/estimation/mle.jl
@@ -272,6 +272,7 @@ function _fit_model(
         rng = rng,
         theta_0_untransformed = theta_0_untransformed,
         store_data_model = store_data_model,
+        extra_objective = extra_objective,
     )
     return _fit_no_re(
         dm, method;

--- a/src/estimation/pooled.jl
+++ b/src/estimation/pooled.jl
@@ -1047,7 +1047,8 @@ function _fit_pooled(
         rng::AbstractRNG,
         theta_0_untransformed::Union{Nothing, ComponentArray} = nothing,
         store_data_model::Bool = true,
-        fit_args::Tuple = ()
+        fit_args::Tuple = (),
+        extra_objective = nothing
     )
     model = get_model(dm)
     fe = get_fixed(model)
@@ -1214,6 +1215,7 @@ function _fit_pooled(
         rng = rng,
         theta_0_untransformed = theta_0_untransformed,
         store_data_model = store_data_model,
+        extra_objective = extra_objective,
     )
     return FitResult(
         method, result, summary, diag,
@@ -1380,7 +1382,8 @@ function _fit_model(
         rng = rng,
         theta_0_untransformed = theta_0_untransformed,
         store_data_model = store_data_model,
-        fit_args = args
+        fit_args = args,
+        extra_objective = extra_objective
     )
 end
 
@@ -1422,6 +1425,7 @@ function _fit_model(
         rng = rng,
         theta_0_untransformed = theta_0_untransformed,
         store_data_model = store_data_model,
-        fit_args = args
+        fit_args = args,
+        extra_objective = extra_objective
     )
 end

--- a/src/estimation/population_moments.jl
+++ b/src/estimation/population_moments.jl
@@ -65,6 +65,10 @@ function ensemble_moments(simulate, θu, re_half, R::AbstractMatrix)
     M2 = zeros(eltype(μ), nt)
     @inbounds for l in 2:n_s
         y = simulate(θu, _ens_draw(Dh, R, l))
+        # Unchecked indexing below: a shorter draw would read out of bounds, a longer one
+        # would be silently truncated (#343).
+        length(y) == nt ||
+            error("ensemble_moments: `simulate` returned $(length(y)) time point(s) for draw $(l) but $(nt) for draw 1; the output length must not depend on the random-effect realization.")
         for j in 1:nt
             d = y[j] - μ[j]
             μ[j] += d / l
@@ -81,6 +85,10 @@ end
 # with per-entry or scalar noise standard deviation σ. `offset` is added to each
 # prediction entry (the measurement-variance add-on), avoiding a per-eval temporary.
 function _pm_gauss_nll(obs, pred, σ; offset = 0.0)
+    length(pred) == length(obs) ||
+        error("population_moment_term: the model predicts $(length(pred)) time point(s) but $(length(obs)) were observed; a prefix is not scored implicitly (#343).")
+    σ isa Number || length(σ) == length(obs) ||
+        error("population_moment_term: the noise SD has $(length(σ)) entries but $(length(obs)) observations were supplied; pass a scalar or a matching vector.")
     acc = zero(eltype(pred))
     @inbounds for j in eachindex(obs)
         s = _pm_scalar_or(σ, j)
@@ -138,6 +146,11 @@ function population_moment_term(;
         error("population_moment_term: `sd_mean` is required when `mean` is supplied.")
     has_var && sd_var === nothing &&
         error("population_moment_term: `sd_var` is required when `var` is supplied (SCSH).")
+    # An empty series scores exactly zero and looks like a successful term (#343).
+    has_mean && isempty(mean) &&
+        error("population_moment_term: `mean` is empty; supply at least one observed time point or omit it.")
+    has_var && isempty(var) &&
+        error("population_moment_term: `var` is empty; supply at least one observed time point or omit it.")
     return function pop_moment_nll(θu)
         μ, Σ = ensemble_moments(simulate, θu, re_half, samples)
         nll = zero(eltype(μ))

--- a/src/estimation/remeasure.jl
+++ b/src/estimation/remeasure.jl
@@ -305,10 +305,19 @@ function build_re_measure_from_batch(
                 L_k = _lower_chol_from_cov(d_inner.Σ)
                 push!(μ_segs, μ_k)
                 push!(L_diags, L_k)
-                let μ = μ_k, L = L_k
+                let μ = μ_k, L = L_k, d = length(μ_k)
+                    # The z segment is laid out on the NATURAL simplex dimension d+1 while
+                    # the transport needs only d normal coordinates, so `L * z_k` used to
+                    # throw a DimensionMismatch (#342). Consume the first d and leave the
+                    # trailing coordinate unused.
+                    # ponytail: the unused coordinate costs grid nodes, not accuracy — a
+                    # Smolyak rule of level L in n dims restricted to a factor that is
+                    # constant in one coordinate is exactly the level-L rule in n-1 dims.
+                    # Upgrade path: carry reference-space ranges separately from the
+                    # natural RE layout (LaplaceRECache.dims / _REInfo.ranges).
                     push!(
                         segment_fns, z_k -> begin
-                            u = μ .+ L * z_k
+                            u = μ .+ L * view(z_k, 1:d)
                             unnorm = vcat(exp.(u), one(eltype(u)))
                             unnorm ./ sum(unnorm)
                         end

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -3147,6 +3147,7 @@ function _fit_model(
         theta_0_untransformed = theta_0_untransformed,
         store_eb_modes = store_eb_modes,
         store_data_model = store_data_model,
+        extra_objective = extra_objective,
     )
     re_names = get_re_names(get_random(get_model(dm)))
     isempty(re_names) &&

--- a/src/model/Parameters.jl
+++ b/src/model/Parameters.jl
@@ -39,6 +39,21 @@ function _warn_logit_unrepresentable(name, what, x)
     return nothing
 end
 
+# The stick-breaking transform is defined on the OPEN simplex: a zero weight (or a
+# probability of exactly 1) empties the stick and leaves the later logits undefined. The
+# blocks used to accept those and hand the optimizer NaN coordinates (#336).
+function _check_simplex_interior(name, what, p::AbstractVector{<:Real})
+    for i in eachindex(p)
+        (p[i] > 0 && p[i] < 1) && continue
+        throw(
+            ArgumentError(
+                "Parameter $(name): $(what) has entry $(i) equal to $(p[i]). The :stickbreak transform is defined on the open simplex, so every probability must be strictly between 0 and 1 (a structural zero or an absorbing transition cannot be estimated with this parameterization). Use a small positive weight instead."
+            )
+        )
+    end
+    return nothing
+end
+
 """
     Priorless()
 
@@ -838,6 +853,7 @@ function ProbabilityVector(
     abs(s - one(T)) <= atol ||
         error("ProbabilityVector for parameter $(name) must sum to 1 (within 1e-6); got sum=$(s).")
     v = v ./ s   # silent normalization
+    _check_simplex_interior(name, "initial value", v)
     return ProbabilityVector{T, typeof(v)}(name, v, scale, prior, calculate_se)
 end
 
@@ -891,6 +907,9 @@ function DiscreteTransitionMatrix(
     all(abs.(row_sums .- one(T)) .<= atol) ||
         error("Each row of DiscreteTransitionMatrix for parameter $(name) must sum to 1 (within 1e-6); got row sums=$(vec(row_sums)).")
     v = v ./ row_sums   # silent row-wise normalization
+    for i in 1:n
+        _check_simplex_interior(name, "initial value in row $(i)", v[i, :])
+    end
     return DiscreteTransitionMatrix{T, typeof(v)}(name, v, scale, prior, calculate_se)
 end
 

--- a/src/plotting/plotting.jl
+++ b/src/plotting/plotting.jl
@@ -1036,6 +1036,58 @@ function _posterior_drawn_params(
     error("Posterior draws are supported only for MCMC and VI fit results.")
 end
 
+# Posterior draws of the FIXED effects only. `_posterior_drawn_params` also assembles a
+# per-individual η from the training levels, which cannot be resolved for unseen subjects;
+# `predict(:population)` integrates the fixed effects while the random effects stay at
+# their prior location, so it needs the θ draws alone (#339).
+function _posterior_theta_draws(
+        res::FitResult, dm::DataModel, max_draws::Int, rng::AbstractRNG
+    )
+    max_draws >= 1 || error("marginal_draws must be >= 1.")
+    consts = _fit_kw(res, :constants, NamedTuple())
+    if get_result(res) isa MCMCResult
+        chain = get_chain(res)
+        draw_idxs = _mcmc_draw_indices(chain, _mcmc_warmup(res), max_draws, rng)
+        isempty(draw_idxs) && error("No MCMC draws available after warmup.")
+        idx_map = _mcmc_param_index_map(chain)
+        vals = Array(chain)
+        n_chains = size(vals, 3)
+        return [
+            begin
+                    chain_idx = rand(rng, 1:n_chains)
+                    _coordwise_fixed_from_means(
+                        dm, "MCMC chain",
+                        key -> (
+                            sym = Symbol(key);
+                            haskey(idx_map, sym) ?
+                            _mcmc_param_value(vals, iter_idx, idx_map[sym], chain_idx) :
+                            nothing
+                        );
+                        overrides = consts
+                    )
+                end for iter_idx in draw_idxs
+        ]
+    elseif get_result(res) isa VIResult
+        raw = sample_posterior(res; n_draws = max_draws, rng = rng, return_names = true)
+        draws = raw.draws
+        size(draws, 1) >= 1 || error("No VI posterior draws available.")
+        idx_map = Dict{String, Int}(
+            string(n) => i for (i, n) in enumerate(raw.names)
+        )
+        return [
+            _coordwise_fixed_from_means(
+                    dm, "VI posterior",
+                    key -> (
+                        idx = _lookup_chain_index(idx_map, key);
+                        idx != 0 ? Float64(draws[k, idx]) : nothing
+                    );
+                    overrides = consts
+                ) for k in 1:size(draws, 1)
+        ]
+    end
+    error("Posterior draws are supported only for MCMC and VI fit results.")
+end
+
 function _default_random_effects(
         res::FitResult,
         dm::DataModel,

--- a/src/plotting/plotting_residuals.jl
+++ b/src/plotting/plotting_residuals.jl
@@ -932,7 +932,9 @@ Predict the response on new data from a fitted model. The fixed effects are take
 from `res`; how the random effects are chosen is controlled by `re_mode`:
 
 - `:population` (default): random effects at their prior mean (the typical-subject
-  "PRED"), so the predictions apply to previously unseen subjects.
+  "PRED"), so the predictions apply to previously unseen subjects. For an MCMC/VI fit
+  the fixed effects are integrated over `marginal_draws` posterior draws rather than
+  plugged in at their posterior mean.
 - `:ebe`: reuse the empirical-Bayes estimate from the fit for any subject whose
   random-effect grouping signature is present in the training data (the individual
   "IPRED"); subjects not seen in training fall back to the population value.
@@ -1001,6 +1003,16 @@ function predict(
     # Inherit and normalize once, so every re_mode sees the same fixed levels (#251).
     constants_re = _res_constants_re(res, constants_re, dm_new)
     if re_mode == :population
+        # A posterior fit's :population prediction is the posterior MEAN of the
+        # conditional mean, not the conditional mean at the posterior-mean parameter;
+        # for a nonlinear model these differ (#339).
+        if _is_posterior_draw_fit(res)
+            return _predict_posterior_population(
+                res, dm_new; fitted_stat = fitted_stat, constants_re = constants_re,
+                marginal_draws = marginal_draws, rng = rng,
+                ode_args = ode_args, ode_kwargs = ode_kwargs, kwargs...
+            )
+        end
         df = get_residuals(
             dm_new; params = NamedTuple(θ), residuals = [:raw],
             fitted_stat = fitted_stat, constants_re = constants_re,
@@ -1162,6 +1174,55 @@ function _eta_with_fixed_levels(ind, η_ebe, re_names, fixed_maps::NamedTuple)
     )
 end
 
+# Draw-wise predictive mean for MCMC/VI fits: evaluate the population prediction at each
+# posterior draw of the fixed effects and average (#339). Random effects stay at their
+# prior location, so this is the posterior version of `re_mode = :population`.
+function _predict_posterior_population(
+        res::FitResult, dm_new::DataModel;
+        fitted_stat, constants_re::NamedTuple, marginal_draws::Int,
+        rng::AbstractRNG, ode_args::Tuple, ode_kwargs::NamedTuple, kwargs...
+    )
+    θ_draws = _posterior_theta_draws(res, dm_new, marginal_draws, rng)
+    return _average_prediction_frames(
+        get_residuals(
+                dm_new; params = NamedTuple(θ_d), residuals = [:raw],
+                fitted_stat = fitted_stat, constants_re = constants_re,
+                ode_args = ode_args, ode_kwargs = ode_kwargs, kwargs...
+            ) for θ_d in θ_draws
+    )
+end
+
+# Element-wise mean of the `fitted` column over an iterator of per-draw residual frames.
+# Accumulators stay untyped so multivariate fitted values remain per-component vectors,
+# and a missing entry simply drops out of its own average. Consumed lazily: the caller
+# passes a generator so only one frame is alive at a time.
+function _average_prediction_frames(frames)
+    base = nothing
+    sum_acc = Any[]
+    cnt_acc = Int[]
+    for df in frames
+        if base === nothing
+            base = df
+            sum_acc = Any[nothing for _ in 1:nrow(df)]
+            cnt_acc = zeros(Int, nrow(df))
+        end
+        for r in eachindex(sum_acc)
+            fr = df.fitted[r]
+            ismissing(fr) && continue
+            sum_acc[r] = cnt_acc[r] == 0 ? fr : sum_acc[r] .+ fr
+            cnt_acc[r] += 1
+        end
+    end
+    base === nothing && error("No prediction draws were produced.")
+    prediction = [
+        cnt_acc[r] > 0 ? sum_acc[r] ./ cnt_acc[r] : missing
+            for r in eachindex(sum_acc)
+    ]
+    return _prediction_frame(
+        base.id, base.time, base.observable, identity.(prediction)
+    )
+end
+
 # Monte-Carlo marginal prediction: integrate the random effects over their prior,
 # averaging the per-draw predicted means.
 function _predict_marginal(
@@ -1187,54 +1248,35 @@ function _predict_marginal(
     sample_rngs = _spawn_child_rngs(rng, marginal_draws)
     n_new = length(get_individuals(dm_new))
 
-    # Accumulators are untyped so multivariate fitted values stay per-component vectors.
-    sum_acc = Any[]
-    cnt_acc = Int[]
-    id_col = nothing
-    time_col = nothing
-    obs_col = nothing
-    for s in 1:marginal_draws
-        srng = sample_rngs[s]
-        level_vals = Dict{Symbol, Dict{Any, Any}}()
-        for re in re_names
-            m = Dict{Any, Any}()
-            for lvl in re_meta[re].levels_free
-                m[lvl] = rand(srng, re_meta[re].dist)
+    return _average_prediction_frames(
+        begin
+                srng = sample_rngs[s]
+                level_vals = Dict{Symbol, Dict{Any, Any}}()
+                for re in re_names
+                    m = Dict{Any, Any}()
+                    for lvl in re_meta[re].levels_free
+                        m[lvl] = rand(srng, re_meta[re].dist)
+                end
+                    level_vals[re] = m
             end
-            level_vals[re] = m
-        end
-        get_free_value = (re, lvl, dim) -> level_vals[re][lvl]
-        η_vec = Vector{ComponentArray}(undef, n_new)
-        for j in 1:n_new
-            η_vec[j] = _assemble_individual_eta(
-                get_individuals(dm_new)[j], re_names, level_dims, fixed_maps,
-                get_free_value
-            )
-        end
-        cache = _fill_plot_cache(
-            dm_new, θ, η_vec, constants_re, true,
-            ode_args, ode_kwargs
-        )
-        df = get_residuals(
-            dm_new; cache = cache, params = NamedTuple(θ),
-            residuals = [:raw], fitted_stat = fitted_stat, constants_re = constants_re,
-            ode_args = ode_args, ode_kwargs = ode_kwargs, kwargs...
-        )
-        if isempty(sum_acc)
-            sum_acc = Any[nothing for _ in 1:nrow(df)]
-            cnt_acc = zeros(Int, nrow(df))
-            id_col, time_col, obs_col = df.id, df.time, df.observable
-        end
-        for r in 1:length(sum_acc)
-            fr = df.fitted[r]
-            ismissing(fr) && continue
-            sum_acc[r] = cnt_acc[r] == 0 ? fr : sum_acc[r] .+ fr
-            cnt_acc[r] += 1
-        end
-    end
-    prediction = [
-        cnt_acc[r] > 0 ? sum_acc[r] ./ cnt_acc[r] : missing
-            for r in 1:length(sum_acc)
-    ]
-    return _prediction_frame(id_col, time_col, obs_col, identity.(prediction))
+                get_free_value = (re, lvl, dim) -> level_vals[re][lvl]
+                η_vec = Vector{ComponentArray}(undef, n_new)
+                for j in 1:n_new
+                    η_vec[j] = _assemble_individual_eta(
+                        get_individuals(dm_new)[j], re_names, level_dims, fixed_maps,
+                        get_free_value
+                    )
+            end
+                cache = _fill_plot_cache(
+                    dm_new, θ, η_vec, constants_re, true,
+                    ode_args, ode_kwargs
+                )
+                get_residuals(
+                    dm_new; cache = cache, params = NamedTuple(θ),
+                    residuals = [:raw], fitted_stat = fitted_stat,
+                    constants_re = constants_re,
+                    ode_args = ode_args, ode_kwargs = ode_kwargs, kwargs...
+                )
+            end for s in 1:marginal_draws
+    )
 end

--- a/src/uq/mcmc_refit.jl
+++ b/src/uq/mcmc_refit.jl
@@ -88,19 +88,22 @@ function _compute_uq_mcmc_refit(
     method_refit = _mcmc_refit_method(
         mcmc_method, mcmc_sampler, mcmc_turing_kwargs, mcmc_adtype
     )
-    fitkw = merge(
-        (
-            constants = constants_all,
-            constants_re = constants_re_use,
-            ode_args = ode_args_use,
-            ode_kwargs = ode_kwargs_use,
-            serialization = serialization_use,
-            rng = rng,
-            theta_0_untransformed = θ_hat_u,
-            store_data_model = true,
-        ),
-        mcmc_fit_kwargs
+    # Carry the fitted objective's `extra_objective` into the refit; without it the
+    # posterior targets a different model than the point estimate did (#331).
+    extra_use = _fit_kw(res, :extra_objective, nothing)
+    base_fitkw = (
+        constants = constants_all,
+        constants_re = constants_re_use,
+        ode_args = ode_args_use,
+        ode_kwargs = ode_kwargs_use,
+        serialization = serialization_use,
+        rng = rng,
+        theta_0_untransformed = θ_hat_u,
+        store_data_model = true,
     )
+    extra_use === nothing ||
+        (base_fitkw = merge(base_fitkw, (extra_objective = extra_use,)))
+    fitkw = merge(base_fitkw, mcmc_fit_kwargs)
     refit_res = fit_model(dm, method_refit; fitkw...)
 
     uq_chain = _compute_uq_chain(

--- a/src/uq/profile.jl
+++ b/src/uq/profile.jl
@@ -20,8 +20,12 @@ end
     left = max(left, x0 - width)
     right = min(right, x0 + width)
 
-    # Keep bounds strictly enclosing x0 for LikelihoodProfiler checks.
+    # Keep bounds strictly enclosing x0 for LikelihoodProfiler checks. The inward push
+    # never crosses x0 itself: an estimate closer to a bound than the default ϵ is still
+    # strictly interior and remains profilable (#341).
     ϵ = max(1.0e-8, abs(x0) * 1.0e-8)
+    isfinite(lb) && x0 > lb && (ϵ = min(ϵ, (x0 - lb) / 2))
+    isfinite(ub) && x0 < ub && (ϵ = min(ϵ, (ub - x0) / 2))
     if !(left < x0)
         left = x0 - 10 * ϵ
     end
@@ -36,8 +40,27 @@ end
         right = min(right, ub - ϵ)
     end
     left < x0 < right ||
-        error("Unable to construct valid profile scan bounds around parameter estimate $(x0). Try larger profile_scan_width or relaxed bounds.")
+        error("Unable to construct profile scan bounds around parameter estimate $(x0): it sits on the boundary of its box [$(lb), $(ub)], so no interval strictly enclosing it exists inside the domain. A larger profile_scan_width cannot help; relax the bound or exclude this coordinate from profile UQ.")
     return (left, right)
+end
+
+# Fit-time `lb`/`ub` overrides and `ignore_model_bounds` are part of the estimator's
+# contract, so the profile must scan the domain the estimate came from, not the declared
+# model box (#340). Methods without those options keep the model bounds.
+function _profile_effective_bounds(method, free_names, lb_full, ub_full)
+    (hasproperty(method, :lb) && hasproperty(method, :ub)) || return (lb_full, ub_full)
+    n = length(lb_full)
+    ignore = hasproperty(method, :ignore_model_bounds) && method.ignore_model_bounds
+    fb_lo = ignore ? fill(-Inf, n) : lb_full
+    fb_hi = ignore ? fill(Inf, n) : ub_full
+    resolve = function (bound, fallback)
+        bound === nothing && return fallback
+        bound isa Number && return fill(Float64(bound), n)
+        b = bound isa NamedTuple ? ComponentArray(bound) : bound
+        v = b isa ComponentArray ? collect(_ca_subset(b, free_names)) : collect(bound)
+        return length(v) == n ? Float64.(v) : fallback
+    end
+    return (resolve(method.lb, fb_lo), resolve(method.ub, fb_hi))
 end
 
 function _build_uq_obj_no_re(
@@ -67,6 +90,9 @@ function _build_uq_obj_no_re(
 
     ll_cache = _build_ll_cache_uq(dm, ode_args_use, ode_kwargs_use, serialization_use)
     use_penalty = !isempty(keys(penalty_use))
+    # The fit minimized loglik + prior + penalty + extra_objective; profiling anything
+    # else profiles a different objective (#331).
+    extra_use = _fit_kw(res, :extra_objective, nothing)
     use_prior = method isa MAP
 
     function obj_full(x::AbstractVector)
@@ -85,6 +111,7 @@ function _build_uq_obj_no_re(
             obj += -lp
         end
         use_penalty && (obj += _penalty_value(θu, penalty_use))
+        extra_use === nothing || (obj += extra_use(θu))
         return Float64(obj)
     end
 
@@ -135,6 +162,7 @@ function _build_uq_obj_re(
     ebe_cache = _init_laplace_eval_cache(length(batch_infos), Float64)
     cache_opts = LaplaceCacheOptions(0.0)
     use_penalty = !isempty(keys(penalty_use))
+    extra_use = _fit_kw(res, :extra_objective, nothing)   # see the no-RE builder (#331)
     seed = rand(rng, UInt64)
 
     function obj_full(x::AbstractVector)
@@ -169,6 +197,7 @@ function _build_uq_obj_re(
         obj == Inf && return Inf
 
         use_penalty && (obj += _penalty_value(θu, penalty_use))
+        extra_use === nothing || (obj += extra_use(θu))
         return Float64(obj)
     end
 
@@ -278,8 +307,13 @@ function _compute_uq_profile(
     loss_crit = obj0 + threshold
 
     lower_t, upper_t = get_bounds_transformed(fe)
-    lb_coords = _coords_on_transformed_layout(fe, lower_t, free_names; natural = false)[active_idx]
-    ub_coords = _coords_on_transformed_layout(fe, upper_t, free_names; natural = false)[active_idx]
+    lb_full, ub_full = _profile_effective_bounds(
+        get_method(res), free_names,
+        _coords_on_transformed_layout(fe, lower_t, free_names; natural = false),
+        _coords_on_transformed_layout(fe, upper_t, free_names; natural = false)
+    )
+    lb_coords = lb_full[active_idx]
+    ub_coords = ub_full[active_idx]
 
     p = length(xhat_active)
     lower_prof_t = fill(NaN, p)
@@ -301,10 +335,13 @@ function _compute_uq_profile(
 
     for j in 1:p
         errors[j] = nothing
-        scan_lo, scan_hi = _profile_scan_bounds(
-            xhat_active[j], lb_coords[j], ub_coords[j], Float64(profile_scan_width)
-        )
+        # Scan-bound construction is inside the per-coordinate handler: a bound-pinned
+        # estimate is a normal outcome of a constrained fit and must not abort the
+        # intervals of every other coordinate (#341).
         r = try
+            scan_lo, scan_hi = _profile_scan_bounds(
+                xhat_active[j], lb_coords[j], ub_coords[j], Float64(profile_scan_width)
+            )
             _profile_run(
                 profiler, optprob, xhat_active, j, scan_lo, scan_hi,
                 threshold, profile_kwargs

--- a/src/uq/wald.jl
+++ b/src/uq/wald.jl
@@ -111,6 +111,7 @@ function _wald_closed_form_natural_vcov(
     )
     p = size(Vn, 1)
     r = ones(Float64, p)
+    direct = Pair{Int, Float64}[]
     for j in eachindex(active_kinds)
         j <= p || break
         kind = active_kinds[j]
@@ -123,11 +124,22 @@ function _wald_closed_form_natural_vcov(
             continue
         end
         v_old = Vn[j, j]
-        (isfinite(v_new) && v_new >= 0 && v_old > 0) || continue
-        r[j] = sqrt(v_new / v_old)
+        (isfinite(v_new) && v_new >= 0) || continue
+        if v_old > 0
+            r[j] = sqrt(v_new / v_old)
+        else
+            # No empirical spread to rescale (a single usable draw, or a coordinate the
+            # draws never moved). The exact variance is known, so write it in rather than
+            # reporting zero uncertainty; a PSD matrix with a zero diagonal entry has a
+            # zero row/column, so no off-diagonal is lost (#338).
+            push!(direct, j => v_new)
+        end
     end
-    all(isone, r) && return Vn
+    (all(isone, r) && isempty(direct)) && return Vn
     Vn2 = Diagonal(r) * Vn * Diagonal(r)
+    for (j, v) in direct
+        Vn2[j, j] = v
+    end
     return Matrix{Float64}(0.5 .* (Vn2 .+ Vn2'))
 end
 
@@ -214,6 +226,13 @@ function _finalize_wald_uqresult(
     ]
     Vn_use = _cov_from_draws(all(Vn_rows) ? Vn_src : Vn_src[Vn_rows, :])
     Vn_use = _wald_closed_form_natural_vcov(Vn_use, est_t, Vt, active_kinds)
+    # Fewer than two usable draws leaves the sampled moments undefined. The closed forms
+    # above still fill the :identity and :log coordinates exactly; the rest would read as
+    # zero uncertainty, which is a lack of samples, not certainty (#338).
+    n_usable = count(Vn_rows)
+    if n_usable < 2 && any(k -> !(k === :identity || k === :log), active_kinds)
+        @warn "Wald natural-scale covariance built from $(n_usable) usable draw(s): sampled moments are undefined, so only :identity and :log coordinates carry an exact variance and the remaining entries are zero. Use n_draws >= 2."
+    end
 
     diag = merge(
         (;
@@ -330,6 +349,9 @@ function _compute_uq_wald_no_re(
     penalty_use = _resolve_fit_kw(res, penalty, :penalty, NamedTuple())
     ode_args_use = _resolve_fit_kw(res, ode_args, :ode_args, ())
     ode_kwargs_use = _resolve_fit_kw(res, ode_kwargs, :ode_kwargs, NamedTuple())
+    # The fitting objective included `extra_objective`; a covariance built without it
+    # inverts a different Hessian (#331).
+    extra_use = _fit_kw(res, :extra_objective, nothing)
     serialization_use = _resolve_fit_kw(
         res, serialization, :serialization, EnsembleSerial()
     )
@@ -401,6 +423,7 @@ function _compute_uq_wald_no_re(
             obj += -lp
         end
         use_penalty && (obj += _penalty_value(θu, penalty_use))
+        extra_use === nothing || (obj += extra_use(θu))
         return obj
     end
 
@@ -506,6 +529,7 @@ function _compute_uq_wald_re(
     penalty_use = _resolve_fit_kw(res, penalty, :penalty, NamedTuple())
     ode_args_use = _resolve_fit_kw(res, ode_args, :ode_args, ())
     ode_kwargs_use = _resolve_fit_kw(res, ode_kwargs, :ode_kwargs, NamedTuple())
+    extra_use = _fit_kw(res, :extra_objective, nothing)   # see the no-RE path (#331)
     # Force SERIAL evaluation of the random-effects Laplace objective (EB solve + inner
     # logdet/Hessian) used to build the covariance. The threaded per-batch inner Hessian
     # is non-deterministic run-to-run (it produces a varying Wald covariance) — the
@@ -596,6 +620,7 @@ function _compute_uq_wald_re(
         obj == Inf && return Inf
 
         use_penalty && (obj += _penalty_value(θu, penalty_use))
+        extra_use === nothing || (obj += extra_use(θu))
         return obj
     end
 

--- a/src/utils/ParameterTranformations.jl
+++ b/src/utils/ParameterTranformations.jl
@@ -318,6 +318,15 @@ function stickbreak_forward(p::AbstractVector{<:Real})
     remaining = one(T)
     for i in 1:(k - 1)
         pi = T(p[i])
+        # An exhausted stick (remaining == 0 at a simplex vertex / absorbing row) makes
+        # pi / remaining a 0/0 NaN. Say what is wrong instead: `_forward_or_argerror`
+        # turns a DomainError into the declaration-level message (#336, same policy as #249).
+        remaining > 0 || throw(
+            DomainError(
+                p,
+                "stickbreak_forward: the probability vector is on the boundary of the simplex (all remaining mass is consumed at index $(i)). The :stickbreak transform is defined on the open interior only; move every entry strictly between 0 and 1."
+            )
+        )
         νi = pi / remaining
         t[i] = logit_forward(νi)
         remaining -= pi
@@ -456,8 +465,9 @@ function _stickbreak_inv_jacobian_T(t::AbstractVector{<:Real}, g::AbstractVector
     g_t = Vector{T}(undef, k1)
     S = T(g[k]) * p[k]  # = g[k] * r[k]
     for j in k1:-1:1
-        σj = logit_inverse(T(t[j]))
-        σj_prime = σj * (one(T) - σj)
+        # The clamped inverse is locally constant beyond ±LOGIT_CLAMP, so the pullback
+        # must use the clamped derivative too (#337).
+        σj_prime = _logit_inv_jacobian(T(t[j]))
         rj1 = r[j + 1]
         g_t[j] = σj_prime * r[j] * (T(g[j]) - S / rj1)
         S += T(g[j]) * p[j]
@@ -963,12 +973,19 @@ function _block_logabsdetjac(spec::TransformSpec, block)
     end
 end
 
+# log|d logit_inverse / dz|. The inverse clamps at ±LOGIT_CLAMP, so outside that interval
+# the map is constant and the determinant is singular, not merely small (#337).
+@inline function _logabsdetjac_logit_scalar(z::Real)
+    abs(z) >= LOGIT_CLAMP && return typeof(float(z))(-Inf)
+    sig = logit_inverse(z)
+    return log(sig) + log(one(sig) - sig)
+end
+
 # Scalar / diagonal closed forms. :log -> sum z (dexp/dz = exp z); :logit -> sum log sigma(1-sigma).
 function _logabsdetjac_logit(block)
     s = zero(_block_eltype(block))
     for z in _block_scalars(block)
-        sig = logit_inverse(z)
-        s += log(sig) + log(one(sig) - sig)
+        s += _logabsdetjac_logit_scalar(z)
     end
     return s
 end
@@ -981,8 +998,7 @@ function _logabsdetjac_elementwise(spec::TransformSpec, block)
         if m === :log
             s += block[j]
         elseif m === :logit
-            sig = logit_inverse(block[j])
-            s += log(sig) + log(one(sig) - sig)
+            s += _logabsdetjac_logit_scalar(block[j])
         end
     end
     return s
@@ -1027,7 +1043,7 @@ function _logabsdetjac_stickbreak(block)
     logrem = zero(T)
     @inbounds for i in eachindex(block)
         sig = logit_inverse(T(block[i]))
-        total += log(sig) + log(one(T) - sig) + logrem
+        total += _logabsdetjac_logit_scalar(T(block[i])) + logrem
         logrem += log(one(T) - sig)
     end
     return total

--- a/test/estimation_cv_tests.jl
+++ b/test/estimation_cv_tests.jl
@@ -297,6 +297,18 @@ end
     # Row column keeps the joint on the first row, zeros elsewhere, so sums still work.
     @test isapprox(sum(res.obs_scores[!, :loglikelihood]), joint; atol = 0.5)
     @test count(!=(0.0), res.obs_scores[!, :loglikelihood]) == 1
+
+    # #333: the reported Monte Carlo loss is the AVERAGE over draws. `_spawn_child_rngs`
+    # takes the first seed from the same position regardless of how many are requested,
+    # so draw 1 is shared between the two runs below; the loss column used to copy draw 1
+    # and was therefore identical.
+    sq_loss(d, y) = (y - mean(d))^2
+    kw = (; unseen_re_mode = :montecarlo, loss = sq_loss)
+    r1 = fit_cv(cv, NoLimits.Laplace(); kw..., n_mc_samples = 1, rng = MersenneTwister(291))
+    r8 = fit_cv(cv, NoLimits.Laplace(); kw..., n_mc_samples = 8, rng = MersenneTwister(291))
+    @test "loss" ∈ names(r8.obs_scores)
+    @test all(isfinite, r8.obs_scores[!, :loss])
+    @test r1.obs_scores[1, :loss] != r8.obs_scores[1, :loss]
 end
 
 @testset "fit_cv accessors" begin

--- a/test/estimation_mcmc_tests.jl
+++ b/test/estimation_mcmc_tests.jl
@@ -24,6 +24,32 @@ using SciMLBase
     hmc_defaults = _TuringExt._mcmc_sampler_defaults(HMC(0.01, 5))
     @test hmc_defaults.n_samples == 1500
     @test hmc_defaults.n_adapt == 750
+
+    # A non-adaptive sampler must not carry a phantom warmup count: the stored number is
+    # what later gets trimmed off the returned chain (#335).
+    @test _TuringExt._mcmc_sampler_defaults(PG(5)).n_adapt == 0
+    @test _TuringExt._mcmc_is_adaptive(NUTS())
+    @test !_TuringExt._mcmc_is_adaptive(MH())
+end
+
+@testset "MCMC warmup diagnostics describe rows in the chain (#335)" begin
+    # Turing discards its adaptation iterations before returning, so the stored `n_adapt`
+    # must be the retained warmup (zero), not the requested count — that count used to be
+    # subtracted again from real posterior draws.
+    dm = fx_nore_prior_dm()
+    for n_adapt in (0, 3)
+        res = fit_model(
+            dm,
+            NoLimits.MCMC(;
+                turing_kwargs = (n_samples = 10, n_adapt = n_adapt, progress = false)
+            );
+            rng = MersenneTwister(4)
+        )
+        conv = NoLimits.get_diagnostics(res).convergence
+        @test size(NoLimits.get_chain(res), 1) == 10
+        @test conv.n_adapt == 0
+        @test conv.n_adapt_requested == n_adapt
+    end
 end
 
 @testset "MCMC basic (no RE)" begin
@@ -37,6 +63,31 @@ end
     @test res isa FitResult
     @test NoLimits.get_chain(res) isa MCMCChains.Chains
     @test NoLimits.get_observed(res).y == fx_nore_df().y
+end
+
+@testset "predict(:population) integrates the posterior for MCMC fits (#339)" begin
+    # The plug-in path evaluated one parameter vector and ignored the posterior entirely,
+    # so `marginal_draws` and `rng` had no effect on the result.
+    dm = fx_nore_prior_dm()
+    res = fit_model(
+        dm,
+        NoLimits.MCMC(;
+            sampler = MH(),
+            turing_kwargs = (n_samples = 200, n_adapt = 0, progress = false, verbose = false)
+        );
+        rng = MersenneTwister(9)
+    )
+    df = fx_nore_df()
+    kw = (; re_mode = :population)
+    p_a = NoLimits.predict(res, df; kw..., marginal_draws = 8, rng = MersenneTwister(1))
+    p_b = NoLimits.predict(res, df; kw..., marginal_draws = 8, rng = MersenneTwister(1))
+    p_c = NoLimits.predict(res, df; kw..., marginal_draws = 150, rng = MersenneTwister(1))
+    @test p_a.prediction == p_b.prediction        # same rng, same draws
+    @test p_a.prediction != p_c.prediction        # the draws actually enter the answer
+    # This model's conditional mean is linear in the parameters, so integrating the
+    # posterior and plugging in its mean agree up to Monte Carlo error.
+    θ = NoLimits.get_params(res; scale = :untransformed)
+    @test isapprox(p_c.prediction, θ.a .+ θ.b .* df.t; rtol = 0.2, atol = 0.05)
 end
 
 @testset "MCMC serial vs threaded is reproducible (MH)" begin

--- a/test/estimation_saem_tests.jl
+++ b/test/estimation_saem_tests.jl
@@ -337,6 +337,16 @@ end
     res_lit = fit_model(dm_lit, NoLimits.SAEM(maxiters = 3, progress = false))
     @test res_lit isa FitResult
     @test isfinite(NoLimits.get_params(res_lit; scale = :untransformed).σ)
+
+    # #342: GHQuadrature laid the quadrature nodes out on the natural simplex dimension
+    # d+1 while the transport needs d normal coordinates, so every MvLogitNormal batch
+    # threw a DimensionMismatch. Same fixture, no extra model.
+    res_ghq = fit_model(
+        dm_lit, NoLimits.GHQuadrature(; level = 1, optim_kwargs = (maxiters = 2,));
+        serialization = SciMLBase.EnsembleSerial()
+    )
+    @test res_ghq isa FitResult
+    @test isfinite(get_objective(res_ghq))
 end
 
 @testset "SAEM builtin stats MvLogNormal and MvLogitNormal RE" begin

--- a/test/extra_objective_tests.jl
+++ b/test/extra_objective_tests.jl
@@ -197,3 +197,37 @@ end
     @test r0 isa FitResult
     @test r1 isa FitResult
 end
+
+@testset "population moment helpers validate shapes before their unchecked loops (#343)" begin
+    R = reshape([-1.0, 1.0], 1, 2)
+    sim = (θ, b) -> [b[1], 2b[1]]
+
+    # A simulation whose output length depends on the draw silently truncated (or read
+    # out of bounds) inside the @inbounds Welford loop.
+    @test_throws ErrorException ensemble_moments(
+        (θ, b) -> b[1] < 0 ? [b[1]] : [b[1], 999.0], nothing, θ -> [1.0], R
+    )
+    @test ensemble_moments((θ, b) -> [b[1]], nothing, θ -> [1.0], R) isa Tuple
+
+    # Prediction/observation and noise lengths must line up; a prefix is not scored.
+    @test_throws ErrorException population_moment_term(
+        simulate = sim, re_half = θ -> [1.0], samples = R, mean = [0.0], sd_mean = 1.0
+    )(nothing)
+    @test_throws ErrorException population_moment_term(
+        simulate = sim, re_half = θ -> [1.0], samples = R,
+        mean = [0.0, 0.0], sd_mean = [1.0]
+    )(nothing)
+    # An empty series scored exactly zero and looked like a successful term.
+    @test_throws ErrorException population_moment_term(
+        simulate = sim, re_half = θ -> [1.0], samples = R, mean = Float64[], sd_mean = 1.0
+    )
+    # The matching case still works, with a scalar or a per-time noise vector.
+    @test population_moment_term(
+        simulate = sim, re_half = θ -> [1.0], samples = R,
+        mean = [0.0, 0.0], sd_mean = 1.0
+    )(nothing) isa Real
+    @test population_moment_term(
+        simulate = sim, re_half = θ -> [1.0], samples = R,
+        mean = [0.0, 0.0], sd_mean = [1.0, 1.0]
+    )(nothing) isa Real
+end

--- a/test/stickbreak_tests.jl
+++ b/test/stickbreak_tests.jl
@@ -45,6 +45,35 @@ using Random
         @test_throws ErrorException ProbabilityVector([1.0])
     end
 
+    @testset "simplex boundary values are rejected (#336)" begin
+        # The :stickbreak transform is defined on the open simplex: an exhausted stick
+        # used to divide 0 by 0 and put NaN into the transformed start.
+        @test_throws ArgumentError ProbabilityVector([1.0, 0.0, 0.0])
+        @test_throws ArgumentError ProbabilityVector([0.5, 0.5, 0.0, 0.0])
+        @test_throws ArgumentError DiscreteTransitionMatrix(Matrix{Float64}(I, 3, 3))
+        @test_throws ArgumentError DiscreteTransitionMatrix([0.5 0.5; 0.0 1.0])
+        @test_throws DomainError NoLimits.stickbreak_forward([1.0, 0.0, 0.0])
+        # Interior values are untouched.
+        @test ProbabilityVector([0.2, 0.5, 0.3]) isa ProbabilityVector
+        @test DiscreteTransitionMatrix([0.8 0.2; 0.3 0.7]) isa DiscreteTransitionMatrix
+    end
+
+    @testset "clamped logit: analytic pullback and log-Jacobian agree (#337)" begin
+        # Beyond ±LOGIT_CLAMP the inverse is constant, so its derivative is zero and the
+        # change-of-variables determinant is singular, not merely small.
+        t = [25.0]
+        g = [0.0, 1.0 / NoLimits.stickbreak_inverse(t)[2]]
+        @test NoLimits._stickbreak_inv_jacobian_T(t, g) ≈
+            ForwardDiff.gradient(z -> log(NoLimits.stickbreak_inverse(z)[2]), t) atol = 1.0e-12
+        t0 = [0.0]
+        g0 = [0.0, 1.0 / NoLimits.stickbreak_inverse(t0)[2]]
+        @test NoLimits._stickbreak_inv_jacobian_T(t0, g0) ≈
+            ForwardDiff.gradient(z -> log(NoLimits.stickbreak_inverse(z)[2]), t0) atol = 1.0e-10
+        @test NoLimits._logabsdetjac_logit([25.0]) == -Inf
+        @test NoLimits._logabsdetjac_stickbreak([25.0]) == -Inf
+        @test NoLimits._logabsdetjac_logit([0.0]) ≈ log(0.25)
+    end
+
     @testset "ProbabilityVector error: negative entry" begin
         @test_throws ErrorException ProbabilityVector([-0.1, 0.6, 0.5])
     end

--- a/test/uq_tests.jl
+++ b/test/uq_tests.jl
@@ -395,6 +395,82 @@ end
     @test !NoLimits._wald_usable_draw_row([NaN, 0.0, 0.0], 40)
 end
 
+@testset "Wald and profile reuse the fit's extra_objective (#331)" begin
+    # Normal location model with a known-variance quadratic extra term centred at the
+    # sample mean: the estimate is unchanged, so the covariance isolates the term. The
+    # objective Hessian is n/σ̂² + k, and Wald must invert exactly that.
+    ys = [0.2, 0.3, 0.1, 0.2, 0.25, 0.35]
+    df = DataFrame(ID = [1, 1, 2, 2, 3, 3], t = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0], y = ys)
+    dm = DataModel(_UQ_SE1_MODEL, df; primary_id = :ID, time_col = :t)
+    c = sum(ys) / length(ys)
+    k = 7.0
+    res = fit_model(dm, NoLimits.MLE(); extra_objective = θ -> 0.5 * k * (θ.a - c)^2)
+    θ̂ = get_params(res; scale = :untransformed)
+    @test isapprox(θ̂.a, c; atol = 1.0e-5)
+
+    uq = compute_uq(res; method = :wald, n_draws = 20, rng = Random.Xoshiro(3))
+    expected = 1.0 / (length(ys) / θ̂.σ^2 + k)
+    @test isapprox(get_uq_vcov(uq; scale = :transformed)[1, 1], expected; rtol = 1.0e-4)
+
+    # Without the term the same fit gives the plain 1/(n/σ̂²).
+    res0 = fit_model(dm, NoLimits.MLE())
+    uq0 = compute_uq(res0; method = :wald, n_draws = 20, rng = Random.Xoshiro(3))
+    θ̂0 = get_params(res0; scale = :untransformed)
+    @test isapprox(
+        get_uq_vcov(uq0; scale = :transformed)[1, 1],
+        θ̂0.σ^2 / length(ys); rtol = 1.0e-4
+    )
+
+    # The profile objective must be the fit's objective too, so it is still stationary
+    # at the estimate (a plain -loglik profile would not be).
+    uqp = compute_uq(res; method = :profile)
+    @test get_uq_diagnostics(uqp).loss_at_estimate <= get_uq_diagnostics(uqp).loss_critical
+end
+
+@testset "Profile UQ scans the fit's bounds, not the declared ones (#340)" begin
+    df = DataFrame(ID = [1, 1, 2, 2, 3, 3], t = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0], y = [0.2, 0.3, 0.1, 0.2, 0.25, 0.35])
+    dm = DataModel(_UQ_SE1_MODEL, df; primary_id = :ID, time_col = :t)
+    # `a` is declared unbounded; the fit restricts it to a box narrower than its
+    # likelihood interval, so the profile must run out of domain instead of scanning past
+    # the estimator's own bounds.
+    res_box = fit_model(dm, NoLimits.MLE(; lb = [0.2, -Inf], ub = [0.3, Inf]))
+    uq_box = compute_uq(res_box; method = :profile)
+    ib = get_uq_intervals(uq_box; scale = :transformed, as_component = false)
+    @test isnan(ib.lower[1]) || ib.lower[1] >= 0.2 - 1.0e-8
+    @test isnan(ib.upper[1]) || ib.upper[1] <= 0.3 + 1.0e-8
+    @test !all(get_uq_diagnostics(uq_box).endpoint_found)
+
+    # Control: the same model fitted without the box does find both endpoints, and they
+    # lie outside it — which is exactly what the bounded profile must not report.
+    res_free = fit_model(dm, NoLimits.MLE())
+    uq_free = compute_uq(res_free; method = :profile)
+    ifree = get_uq_intervals(uq_free; scale = :transformed, as_component = false)
+    @test all(get_uq_diagnostics(uq_free).endpoint_found)
+    @test ifree.lower[1] < 0.2 || ifree.upper[1] > 0.3
+end
+
+@testset "Wald n_draws=1 keeps the exact scalar variance (#338)" begin
+    df = DataFrame(ID = [1, 1, 2, 2, 3, 3], t = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0], y = [0.2, 0.3, 0.1, 0.2, 0.25, 0.35])
+    dm = DataModel(_UQ_SE1_MODEL, df; primary_id = :ID, time_col = :t)
+    res = fit_model(dm, NoLimits.MLE())
+    uq = compute_uq(res; method = :wald, n_draws = 1, rng = Random.Xoshiro(4))
+    # `a` is an :identity coordinate, so the natural variance is the transformed one; a
+    # single draw used to report it as exactly zero.
+    @test get_uq_vcov(uq; scale = :natural)[1, 1] ≈ get_uq_vcov(uq; scale = :transformed)[1, 1]
+    @test get_uq_vcov(uq; scale = :natural)[1, 1] > 0
+end
+
+@testset "_profile_scan_bounds: interior estimates near a bound survive (#341)" begin
+    # A strictly interior estimate closer to the bound than the default epsilon used to
+    # throw, and the throw sat outside the per-coordinate handler.
+    lo, hi = NoLimits._profile_scan_bounds(1.0e-10, 0.0, 1.0, 3.0)
+    @test lo < 1.0e-10 < hi
+    lo2, hi2 = NoLimits._profile_scan_bounds(0.5, 0.0, 1.0, 3.0)
+    @test 0.0 < lo2 < 0.5 < hi2 < 1.0
+    # A genuinely bound-pinned estimate still cannot be enclosed, but says so accurately.
+    @test_throws ErrorException NoLimits._profile_scan_bounds(0.0, 0.0, 1.0, 3.0)
+end
+
 @testset "UQ profile for MLE" begin
     df = DataFrame(
         ID = [1, 1, 2, 2, 3, 3],


### PR DESCRIPTION
One batch for the thirteen issues from the latest review round: #331, #332, #333, #334, #335, #336, #337, #338, #339, #340, #341, #342, #343.

## UQ objective fidelity

**#331 — Wald and profile UQ silently omitted `extra_objective`.**
Every estimator now keeps `extra_objective` in its fit metadata, and Wald (both the no-RE and the RE path), profile UQ (both objective builders) and the `mcmc_refit` refit add it back. A covariance or profile built without it inverts a different Hessian than the one the optimizer minimized.

**#338 — Wald with `n_draws = 1` reported zero natural-scale variance.**
`_wald_closed_form_natural_vcov` skipped its exact scalar correction whenever the empirical variance was zero, so the fallback defeated the correction. The exact variance is now written in directly for `:identity` and `:log`, and fewer than two usable draws warns for the coordinates that genuinely need sampled moments. Lack of samples is no longer encoded as certainty.

**#340 — profile UQ ignored fit-time `lb`/`ub` and `ignore_model_bounds`.**
Profiling reconstructed the declared model box, so it could scan outside the domain the estimate came from (or restore bounds the fit was told to ignore). The estimator's effective bounds now drive both the scan range and the nuisance optimization.

**#341 — one bound-pinned coordinate aborted the whole profile request.**
Scan-bound construction sat outside the per-coordinate `try`, so a single boundary estimate turned every other interval into an exception. It is now inside the handler. The inward epsilon also no longer crosses the estimate, so a strictly interior estimate closer to a bound than `1e-8` stays profilable, and the failure message no longer suggests a scan width that cannot help.

## Cross-validation

**#332 — Monte Carlo CV renormalized away failed draws.**
The comment said a failed ODE contributes zero probability but the denominator dropped it, inflating the held-out log score by `log(S/m)`. Failed draws now stay in the denominator, and the failed-draw and all-failed-individual counts are reported.

**#333 — the Monte Carlo custom loss was the first draw, not the average.**
`names(df)` returns Strings, so `:loss in names(df)` was always false and the loss column was never overwritten. Two `hasproperty` checks.

**#334 — `fit_cv` consumed `rng` but never passed one to the training fits.**
Stochastic and mini-batched estimators therefore depended on the ambient RNG. `fit_cv` now derives independent training and scoring streams per fold and passes the training stream to `fit_model`, so the predictive draws also stop shifting with how many numbers the training algorithm consumed.

## Transforms

**#336 — accepted simplex boundary values produced NaN transformed parameters.**
`ProbabilityVector` and `DiscreteTransitionMatrix` accepted simplex vertices and absorbing rows that `stickbreak_forward` then turned into `0/0`. The declaration is now rejected with a parameter-specific message, and `stickbreak_forward` throws a `DomainError` on an exhausted stick, which `_forward_or_argerror` turns into the same declaration-level error the other transform-domain boundaries produce (#249).

**#337 — clamped probability transforms had inconsistent analytic derivatives.**
The inverse logit clamps at ±20, but the stick-breaking pullback and the logit / elementwise / stick-breaking log-Jacobians still used the unclamped sigmoid, so at saturation they disagreed with the function actually evaluated by an order-one amount. All three now go through one saturation-aware helper: the gradient is zero and the change-of-variables determinant is singular outside the clipping interval. `logabsdetjac` is the public Bijectors-style primitive only, so the `-Inf` never reaches an optimizer.

## Estimation and prediction

**#335 — the Turing adapter ignored `n_adapt` and discarded posterior draws as warmup.**
Turing's adaptive Hamiltonian samplers consume `nadapts`; the `adapt` keyword this adapter passed was absorbed by `kwargs...` and never controlled adaptation, so a requested count (zero included) was silently replaced by the sampler default. Turing also discards adaptation before returning the chain, yet the stored `n_adapt` was treated downstream as rows still present and subtracted again. The stored value is now the retained warmup (normally zero), the request is kept alongside as `n_adapt_requested`, and a non-adaptive sampler no longer carries a phantom warmup default. The EM batch adapter gets the same keyword fix.

**#339 — Bayesian `predict(:population)` used plug-in parameters.**
It evaluated one fixed-effect vector and discarded the posterior, contradicting both its documentation and the error that directs MCMC/VI users to this mode. It now evaluates the population prediction at each posterior draw of the fixed effects and averages, which differs from the plug-in whenever the model is nonlinear. The draw-wise averaging is shared with the existing `:marginal` path rather than duplicated.

**#342 — GHQuadrature threw `DimensionMismatch` on every `MvLogitNormal` batch.**
The node layout used the natural simplex dimension `d+1` while the reference transport needs the inner normal's `d`. The segment now consumes the first `d` coordinates of its slice. This is deliberately the padding fix rather than a reference-dimension refactor: a Smolyak rule of level `L` in `n` dimensions applied to a factor that is constant in one coordinate is exactly the level-`L` rule in `n-1` dimensions, verified numerically to machine precision across several `(d, L)`, so accuracy is unchanged and only the node count grows. The trade-off and the upgrade path (carrying reference-space ranges separately from the natural RE layout) are recorded in a comment at the site.

**#343 — population-moment helpers indexed unchecked without shape validation.**
`ensemble_moments` fixed `nt` from the first draw and indexed later draws under `@inbounds`; `_pm_gauss_nll` looped over `eachindex(obs)` while indexing `pred` and `σ`; an empty observation series was accepted and scored exactly zero. All three are now validated before the unchecked loops.

## Tests

Regression coverage extends existing testsets and reuses existing fixtures, adding no new `@Model`:

- `uq_tests.jl` — the #331 analytic oracle (Normal location model with `0.5·k·(a-c)²` centred at the sample mean, so the estimate is unchanged and the Wald variance must be `1/(n/σ̂² + k)` rather than `σ̂²/n`), the #338 single-draw variance, #340 with a control fit that finds endpoints outside the box, and a #341 unit test of the scan-bound helper.
- `stickbreak_tests.jl` — #336 boundary rejection, #337 pullback and log-Jacobian agreement against ForwardDiff at and inside the clamp.
- `estimation_cv_tests.jl` — #333, folded into the existing joint-marginal testset.
- `estimation_mcmc_tests.jl` — #335 warmup diagnostics and non-adaptive defaults, #339 draw dependence.
- `estimation_saem_tests.jl` — #342, on the existing `MvLogitNormal` fixture.
- `extra_objective_tests.jl` — #343 shape validation.

## Verification

Four sandbox runs, all green, covering every touched path:

| files | result |
|---|---|
| stickbreak, logabsdetjac, transform, parameters, fixed_effects, extra_objective, ad_stickbreak_hmm | pass |
| uq, uq_edge_cases, estimation_cv, estimation_mle, estimation_map, stickbreak_uq_natural_extension | pass |
| estimation_mcmc, estimation_mcmc_re, estimation_vi, estimation_ghquadrature ×2, plotting_functions, residual_plots, estimation_mcem | pass |
| final re-run with the new tests: stickbreak 151, uq 238, extra_objective 24, estimation_cv 99, estimation_mcmc 49, estimation_saem 83, residual_plots 107, serialization 53, aqua 9 | 813 pass, 0 fail |

Aqua clean, Runic clean.

Closes #331, closes #332, closes #333, closes #334, closes #335, closes #336, closes #337, closes #338, closes #339, closes #340, closes #341, closes #342, closes #343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
