### PR TITLE
MCEM closed-form M-step, literal/offset mean centring, flow-crash fix (v0.2.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,15 @@
   `β + offset` form described above, because the covariance is now centered on that mean.
   The previous update centered on the pooled empirical mean, which absorbed the
   covariate-driven between-subject spread into the random-effect variance.
+- **`SAEM` and `MCEM` closed-form variance estimates change for literal-mean random
+  effects**, i.e. the common `Normal(0.0, ω)` / `LogNormal(0.0, ω)` form. The mean is known
+  there, so the exact conditional maximizer is the second moment *about that mean*,
+  `sqrt(Σ(η - μ)² / n)`. The previous update computed `second - mean * mean'`, subtracting
+  the pooled empirical mean of the draws, which is the maximizer only when the mean is a
+  free parameter estimated from those same moments. The old value was biased low by
+  `E[η - μ]²`, and that bias is not always small: on the `fx_re_dm` test fixture the
+  closed-form ω moves from 0.162 to 0.228 at identical draws. Only the closed-form path
+  changes, so `builtin_stats = :none` reproduces the previous numbers.
 - Method-level `lb`/`ub` never constrained closed-form updates (they are transformed-scale
   bounds for the optimizer); closed-form values are clamped to each fixed effect's own
   declared natural-scale bounds. The SAEM documentation claimed otherwise and has been

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.2.10
+
 ### Bug fixes
 
 - A normalizing-flow random effect could kill a whole `SAEM` fit instead of scoring the bad

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ### Bug fixes
 
+- The warning raised when a Wald covariance is projected to the nearest PSD matrix
+  recommended `method = :profile / :mcmc`. Neither name was right for every fit: the
+  keyword is `:mcmc_refit`, and profile UQ is restricted to MLE/MAP/Laplace/GHQuadrature
+  results, so an MCEM or SAEM user following the advice hit
+  "Profile UQ is currently supported for ...". The message now names only the backends that
+  exist for the fit at hand.
+
 - A normalizing-flow random effect could kill a whole `SAEM` fit instead of scoring the bad
   proposal `-Inf`. When the Q2 M-step drives a planar layer's weight to exactly `w = 0`,
   `Bijectors.get_u_hat` returns `u_hat = NaN` while `w'u_hat` stays finite, the `NaN`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- A normalizing-flow random effect could kill a whole `SAEM` fit instead of scoring the bad
+  proposal `-Inf`. When the Q2 M-step drives a planar layer's weight to exactly `w = 0`,
+  `Bijectors.get_u_hat` returns `u_hat = NaN` while `w'u_hat` stays finite, the `NaN`
+  propagates into the next layer's `find_alpha`, and Roots rejects the resulting `[NaN, NaN]`
+  bracket with `ArgumentError("The interval [a,b] is not a bracketing interval...")`. The
+  random-effect prior already wraps that call intending to score it `-Inf`, but
+  `_is_numeric_error` classified `ArgumentError` by message only and this message matched
+  none of the alternatives, so the guard rethrew. Roots' bracketing message is now
+  classified as a numeric error, which closes the same hole in `_re_logpdf_batch` and
+  `_laplace_logf_batch` at once, so every estimator gets it. Only paths that previously
+  threw are affected: no successful fit changes. This is not a Bijectors 0.16 regression;
+  Bijectors 0.15.24 with `Roots.ITP` fails identically, and the compat bounds are unchanged.
+
 ### New features
 
 - `MCEM` gained the closed-form M-step that `SAEM` already had, through four new keywords

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 ## Unreleased
 
+### New features
+
+- `MCEM` gained the closed-form M-step that `SAEM` already had, through four new keywords
+  with SAEM's names, meanings and defaults: `builtin_stats` (default `:auto`),
+  `resid_var_param`, `re_cov_params` and `re_mean_params`. Parameters whose Monte Carlo
+  Q-maximizer is available in closed form (Gaussian/log-normal random-effect means and
+  covariances, `Exponential` random-effect scales, the residual scale, supported HMM
+  emissions) are updated from the sufficient statistics of the current E-step draws, and
+  the remaining free parameters are optimized numerically as before. When nothing is left
+  the numerical M-step is skipped entirely. Unlike SAEM there is no stochastic-approximation
+  smoothing: the statistics are a plain Monte Carlo average over this iteration's draws.
+  The path removes the optimizer's BLAS calls from the M-step, which is what made the same
+  fit differ in its last bits between AVX-512 and AVX2/Zen machines. It disables itself for
+  an `MCEM_IS` E-step (weighted draws, unweighted statistics) and when `extra_objective` is
+  passed (the M-step is then not separable), each with an info message. The routing is
+  logged at startup and recorded in `notes` as `closed_form_targets`, `numeric_targets`,
+  `closed_form_mstep_mode` and `builtin_stats_closed_form_eligibility`, with
+  `get_closed_form_mstep_used(get_result(res))` as the one-line check.
+- A random-effect mean written as `β + offset`, where `β` is a fixed effect and the offset
+  carries no fixed effect (for example the allometric `LogNormal(CL_mean + 0.75 * log(wt /
+  70), sigma_CL)`), is now a closed-form target for both `SAEM` and `MCEM`. The per-level
+  offset is subtracted before the moments are formed, so `β` is updated in closed form and
+  the covariance update centers on the structured mean instead of the pooled empirical one.
+  A mean with two free fixed effects in it (`μ0 + β * x`) remains ineligible.
+
+### Behavior changes
+
+- **`MCEM` results change for models with an exponential-family block**, because
+  `builtin_stats` defaults to `:auto`. The closed-form update is the exact maximizer of the
+  same Monte Carlo Q-function over those parameters, so the estimator's target is unchanged,
+  but it carries none of the optimizer's tolerance or jitter: the sequence of iterates
+  differs, the windowed drift test typically fires earlier, and the reported iteration count
+  and objective move. Pass `MCEM(builtin_stats = :none)` to restore the previous, fully
+  numerical M-step exactly.
+- **`SAEM` covariance estimates change for random effects with a structured mean** of the
+  `β + offset` form described above, because the covariance is now centered on that mean.
+  The previous update centered on the pooled empirical mean, which absorbed the
+  covariate-driven between-subject spread into the random-effect variance.
+- Method-level `lb`/`ub` never constrained closed-form updates (they are transformed-scale
+  bounds for the optimizer); closed-form values are clamped to each fixed effect's own
+  declared natural-scale bounds. The SAEM documentation claimed otherwise and has been
+  corrected.
+
+### Documentation
+
+- The `SAEM` docstring listed `builtin_stats = :on`/`:off` and
+  `builtin_mean = :additive`/`:all`, none of which exist. The accepted values are
+  `:auto`/`:closed_form`/`:gaussian_re`/`:none` and `:none`/`:glm`.
+- Enabling the Turing extension is now documented as `import Turing` rather than
+  `using Turing`, because `using Turing` collides with the NoLimits exports `Laplace`,
+  `MAP`, `MLE`, `loglikelihood`, `logprior` and `predict`.
+- Backfilled the missing `## v0.2.0` heading below (its release notes were folded into the
+  `v0.2.1` section when the changelog was first written).
+
 ## v0.2.9
 
 ### Bug fixes
@@ -164,7 +218,7 @@
 
 - Turing.jl is now a weak dependency (#36). `using NoLimits` no longer loads it, cutting
   load time and dependency count; `MCMC`, `VI`, the chain-based UQ refit and the Turing
-  E-step samplers require an explicit `using Turing`. `MCEM`'s default E-step is now the
+  E-step samplers require an explicit `import Turing`. `MCEM`'s default E-step is now the
   Turing-free `MCEM_MCMC(sampler = SaemixMH(), sample_schedule = 100)` - pass
   `NUTS(0.75)` / `250` to restore the previous default.
 - Random effects can be given a copula distribution from Copulas.jl (#177), loaded via
@@ -355,6 +409,8 @@
   every fresh dependency resolve, including CI, the docs build and Aqua's
   persistent-tasks probe. The cap can be lifted once LikelihoodProfiler imports
   `SciMLBase` itself.
+
+## v0.2.0
 
 ### Breaking changes
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NoLimits"
 uuid = "1d491b74-35a5-408f-ae19-cf8524c3769d"
 license = "MIT"
-version = "0.2.9"
+version = "0.2.10"
 authors = ["Manuel Huth", "Jonas Arruda", "Clemens Peiter", "Roy Gusinow", "Nina Schmid", "Jan Hasenauer"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ plot_fits(res)                          # fit vs. data
 ```
 
 Swapping the inference paradigm is a one-line change: `fit_model(dm, SAEM())`, `fit_model(dm, MCEM())`,
-or `fit_model(dm, MCMC())` all fit the *same* model (`MCMC` needs `using Turing`). More examples — neural-ODE models, Markov-model
+or `fit_model(dm, MCMC())` all fit the *same* model (`MCMC` needs `import Turing`). More examples — neural-ODE models, Markov-model
 outcomes, normalizing-flow random effects, count outcomes, censored data, and multi-method
 comparison — are in the [Tutorials](https://manuhuth.github.io/NoLimits.jl/dev/tutorials/mixed-effects-multiple-methods).
 

--- a/docs/src/estimation/index.md
+++ b/docs/src/estimation/index.md
@@ -114,7 +114,8 @@ The following example defines a nonlinear mixed-effects model and fits it with L
 using NoLimits
 using DataFrames
 using Distributions
-using Turing        # MCMC needs the Turing extension
+import Turing       # MCMC needs the Turing extension (`import`, not `using`: see
+                    # Optional Dependencies for the export clash)
 
 model = @Model begin
     @fixedEffects begin

--- a/docs/src/estimation/mcem.md
+++ b/docs/src/estimation/mcem.md
@@ -15,8 +15,8 @@ MCEM supports two E-step implementations, controlled by the `e_step` argument.
 
 The default strategy. Draws samples from the exact conditional distribution `p(b | y, θ)`
 with an MCMC kernel. The default kernel is the native `SaemixMH`, so this path needs no
-Turing; passing a [Turing.jl](https://turinglang.org/) sampler such as `NUTS()` or `MH()`
-requires `using Turing`.
+Turing; passing a [Turing.jl](https://turinglang.org/) sampler such as `Turing.NUTS()` or
+`Turing.MH()` requires `import Turing`.
 
 ```julia
 NoLimits.MCEM_MCMC(;
@@ -28,8 +28,10 @@ NoLimits.MCEM_MCMC(;
 ```
 
 - `sampler` - E-step kernel. Native (no Turing): `SaemixMH()`, `AdaptiveNoLimitsMH()`.
-  Turing samplers such as `MH()` or `NUTS(...)` need `using Turing`. Before v0.2.3 this
-  defaulted to `NUTS(0.75)` with `sample_schedule = 250`.
+  Turing samplers such as `Turing.MH()` or `Turing.NUTS(...)` need `import Turing` (not
+  `using Turing`, which collides with the NoLimits exports `Laplace`, `MAP`, `MLE`,
+  `loglikelihood`, `logprior` and `predict`). Before v0.2.3 this defaulted to `NUTS(0.75)`
+  with `sample_schedule = 250`.
 - `turing_kwargs` - forwarded to Turing; the keys `n_samples` and `n_adapt` are interpreted explicitly. Ignored by the native samplers.
 - `sample_schedule` - number of MCMC samples per iteration; accepts an integer, a vector (iteration-indexed), or a function `iter -> n_samples`.
 - `warm_start` - when `true`, reuses previous latent-state values as chain initialization.
@@ -77,7 +79,7 @@ es = NoLimits.MCEM_IS(
     adapt                 = true,
     warm_start_mcmc_iters = 5,
     mcmc_warmup           = NoLimits.MCEM_MCMC(
-        sampler       = MH(),
+        sampler       = Turing.MH(),
         turing_kwargs = (n_samples=50, n_adapt=0, progress=false),
     ),
 )
@@ -117,7 +119,7 @@ If fixed-effect priors are defined in the model, MCEM ignores them in its object
 using NoLimits
 using DataFrames
 using Distributions
-using Turing
+import Turing
 
 model = @Model begin
     @fixedEffects begin
@@ -154,7 +156,7 @@ dm = DataModel(model, df; primary_id=:ID, time_col=:t)
 ```julia
 res = fit_model(dm, NoLimits.MCEM(
     e_step  = NoLimits.MCEM_MCMC(
-        sampler       = MH(),
+        sampler       = Turing.MH(),
         turing_kwargs = (n_samples=50, n_adapt=0, progress=false),
     ),
     maxiters = 30,
@@ -187,7 +189,7 @@ The full set of constructor arguments is shown below. All arguments have default
 using Optimization
 using OptimizationOptimJL
 using LineSearches
-using Turing
+import Turing
 
 method = NoLimits.MCEM(;
     # E-step (new unified interface)
@@ -313,7 +315,7 @@ The legacy MCMC-only keyword interface is fully preserved. Existing code that do
 ```julia
 # Old API - still works
 method = NoLimits.MCEM(
-    sampler       = MH(),
+    sampler       = Turing.MH(),
     turing_kwargs = (n_samples=50, n_adapt=0, progress=false),
     maxiters      = 20,
 )

--- a/docs/src/estimation/mcem.md
+++ b/docs/src/estimation/mcem.md
@@ -247,6 +247,7 @@ method = NoLimits.MCEM(;
 | Logging | `verbose`, `progress` | Diagnostic output and progress bar. |
 | Final EB estimation | `ebe_*` and `ebe_rescue_*` options | Post-fit empirical Bayes mode computation used by random-effects accessors and diagnostics. |
 | Bounds | `lb`, `ub` | Optional transformed-scale bounds for free fixed effects in M-step optimization. |
+| Closed-form M-step | `builtin_stats`, `resid_var_param`, `re_cov_params`, `re_mean_params` | Which parameter blocks are updated from sufficient statistics instead of by the optimizer. |
 
 ## Behavioral Notes
 
@@ -254,7 +255,36 @@ The constructor signature block above lists every keyword with its default. See 
 
 - **EM convergence.** MCEM monitors both fixed-effect stability (`rtol_theta`, `atol_theta`) and Q-function stability (`rtol_Q`, `atol_Q`) with the same windowed drift test used by SAEM: the last `convergence_window` iterates are split into two halves, and each coordinate's drift between the half means must satisfy `drift ≤ max(atol, rtol * scale, 2 * mc_se)`, where `mc_se` is the Monte-Carlo standard error of the half-mean difference estimated from the window itself (drift indistinguishable from sampling noise counts as stationary). `consecutive_params` is the number of consecutive iterations on which both tests must pass before convergence is declared; setting `rtol` and `atol` of a test to `0` disables early stopping. See the SAEM page's [Convergence and Early Stopping](saem.md#Convergence-and-Early-Stopping) section for details. Note that with a fixed, small Monte-Carlo sample size the EM iterates keep jittering at sampling scale and the fit typically uses all `maxiters`; a growing `sample_schedule` (classic MCEM practice) shrinks that jitter so the drift can fall below tolerance and trigger the stop. `verbose` enables iteration-level logging of `Q`, `dtheta`, `dQ`, and the drift values.
 - **Final EB modes.** After the EM iterations complete, MCEM computes empirical Bayes (EB) modal estimates of the random effects used by downstream accessors, configured through the `ebe_*` keywords (`ebe_grad_tol=:auto` selects a data-adaptive tolerance). When `ebe_rescue_on_high_grad=true` (default `false`), a rescue multistart governed by the `ebe_rescue_*` keywords is triggered if the final EB gradient norm remains above threshold.
-- **Bounds.** `lb`, `ub` are optional transformed-scale bounds for free fixed effects in the M-step optimization. Parameters held constant via the `constants` fit keyword are excluded automatically.
+- **Bounds.** `lb`, `ub` are optional transformed-scale bounds for free fixed effects in the M-step optimization. Parameters held constant via the `constants` fit keyword are excluded automatically. They do not apply to closed-form updates, which are clamped to each fixed effect's own declared natural-scale bounds instead.
+
+## Closed-Form M-step
+
+For an exponential-family block the Monte Carlo Q-function is maximized analytically, so the M-step for that block does not need an optimizer at all. `builtin_stats = :auto` (the default) detects those blocks and updates them from the sufficient statistics of the current E-step draws, using the same routing rules as [`SAEM`](@ref):
+
+| Keyword | Default | Meaning |
+| --- | --- | --- |
+| `builtin_stats` | `:auto` | `:auto` infers the eligible blocks from the model, `:closed_form` (alias `:gaussian_re`) uses the maps below without inference, `:none` optimizes everything numerically. |
+| `resid_var_param` | `:σ` | Fixed effect holding the residual standard deviation, or a NamedTuple of outcome column to parameter name. |
+| `re_cov_params` | `NamedTuple()` | Random-effect name to covariance parameter. |
+| `re_mean_params` | `NamedTuple()` | Random-effect name to mean parameter. |
+
+Eligible blocks are Gaussian/log-normal random-effect means and covariances, `Exponential` random-effect scales, the residual scale of `Normal`/`LogNormal`/`Exponential`/`Bernoulli`/`Poisson` outcomes, and supported HMM emissions. A scalar `Normal`/`LogNormal` mean written as `β + offset`, where `β` is a fixed effect and the offset carries none (for example `CL_mean + 0.75 * log(wt / 70)`), is also eligible: the per-level offset is subtracted before the moments are formed, so the covariance update centers on the structured mean. See [Which Models Have Closed-Form M-step Updates?](saem-advanced.md#Which-Models-Have-Closed-Form-M-step-Updates?) for the full list.
+
+Routing is hybrid. Eligible parameters are updated in closed form and held fixed for the iteration, everything else is optimized numerically exactly as before, and the numerical problem is skipped entirely when nothing is left. Two situations disable the path automatically, each with an info message: an [`MCEM_IS`](@ref) E-step (its draws are weighted while the statistics are not) and an `extra_objective` (the M-step is then not separable).
+
+Unlike SAEM, MCEM applies no stochastic-approximation smoothing: the statistics are a plain Monte Carlo average over the current iteration's draws, which is the exact conditional Q-maximizer for that block. Because the closed-form update carries none of the optimizer's own tolerance or jitter, a fit with `builtin_stats = :auto` follows a different iterate path than the same fit with `:none` and generally stops at a different iteration. Pass `builtin_stats = :none` to reproduce the pre-0.2.10 numerical M-step exactly.
+
+The routing is logged once at startup and recorded in the result:
+
+```julia
+res = fit_model(dm, MCEM())
+NoLimits.get_closed_form_mstep_used(get_result(res))   # true when a block was updated in closed form
+notes = get_notes(get_result(res))
+notes.closed_form_targets    # parameters updated from sufficient statistics
+notes.numeric_targets        # parameters left to the optimizer; () means it never ran
+notes.closed_form_mstep_mode # :closed_form_only, :hybrid or :numeric_only
+notes.builtin_stats_closed_form_eligibility.reasons   # why a block was rejected
+```
 
 ## Diagnostics
 

--- a/docs/src/estimation/mcmc.md
+++ b/docs/src/estimation/mcmc.md
@@ -9,8 +9,10 @@ Markov chain Monte Carlo (MCMC) methods provide a principled approach to Bayesia
 
 !!! note "Turing is an optional dependency"
     NoLimits does not install or load Turing for you. Run `Pkg.add("Turing")` and
-    `using Turing` alongside NoLimits; without it, `fit_model(dm, MCMC())` raises an
-    error naming what to install. See [Optional Dependencies](../installation.md#Optional-Dependencies).
+    `import Turing` alongside NoLimits; without it, `fit_model(dm, MCMC())` raises an
+    error naming what to install. Use `import`, not `using`: `using Turing` collides with
+    the NoLimits exports `Laplace`, `MAP`, `MLE`, `loglikelihood`, `logprior` and
+    `predict`. See [Optional Dependencies](../installation.md#Optional-Dependencies).
 
 ## Applicability
 
@@ -29,7 +31,7 @@ Note that `MCMC` samples on the natural (untransformed) parameter scale. The par
 using NoLimits
 using DataFrames
 using Distributions
-using Turing
+import Turing
 
 model = @Model begin
     @fixedEffects begin
@@ -62,7 +64,7 @@ df = DataFrame(
 dm = DataModel(model, df; primary_id=:ID, time_col=:t)
 
 method = NoLimits.MCMC(;
-    sampler=NUTS(0.75),
+    sampler=Turing.NUTS(0.75),
     turing_kwargs=(n_samples=500, n_adapt=250, progress=false),
 )
 
@@ -75,7 +77,7 @@ The `MCMC` constructor accepts the following keyword arguments, which control th
 
 ```julia
 using NoLimits
-using Turing
+import Turing
 
 method = NoLimits.MCMC(;
     sampler=Turing.NUTS(0.75),
@@ -131,7 +133,7 @@ constants_re = (; eta=(; A=0.0))
 
 res_fixed_levels = fit_model(
     dm,
-    NoLimits.MCMC(; sampler=NUTS(0.75), turing_kwargs=(n_samples=300, n_adapt=150, progress=false));
+    NoLimits.MCMC(; sampler=Turing.NUTS(0.75), turing_kwargs=(n_samples=300, n_adapt=150, progress=false));
     constants_re=constants_re,
 )
 ```
@@ -143,7 +145,7 @@ For mixed-effects models, it can be useful to fix all population-level parameter
 ```julia
 res_re_only = fit_model(
     dm,
-    NoLimits.MCMC(; sampler=MH(), turing_kwargs=(n_samples=400, n_adapt=0, progress=false));
+    NoLimits.MCMC(; sampler=Turing.MH(), turing_kwargs=(n_samples=400, n_adapt=0, progress=false));
     constants=(a=0.2, b=0.1, tau=0.4, sigma=0.3),
 )
 ```
@@ -156,7 +158,7 @@ When the model contains no random effects, `MCMC` samples only the fixed effects
 using NoLimits
 using DataFrames
 using Distributions
-using Turing
+import Turing
 
 model_fixed = @Model begin
     @covariates begin
@@ -186,7 +188,7 @@ dm_fixed = DataModel(model_fixed, df_fixed; primary_id=:ID, time_col=:t)
 
 res_fixed = fit_model(
     dm_fixed,
-    NoLimits.MCMC(; sampler=MH(), turing_kwargs=(n_samples=300, n_adapt=0, progress=false)),
+    NoLimits.MCMC(; sampler=Turing.MH(), turing_kwargs=(n_samples=300, n_adapt=0, progress=false)),
 )
 ```
 
@@ -198,7 +200,7 @@ Hidden Markov models (HMMs) with subject-level random effects can also be estima
 using NoLimits
 using DataFrames
 using Distributions
-using Turing
+import Turing
 
 model_hmm = @Model begin
     @covariates begin
@@ -236,7 +238,7 @@ dm_hmm = DataModel(model_hmm, df_hmm; primary_id=:ID, time_col=:t)
 
 res_hmm = fit_model(
     dm_hmm,
-    NoLimits.MCMC(; sampler=MH(), turing_kwargs=(n_samples=200, n_adapt=0, progress=false)),
+    NoLimits.MCMC(; sampler=Turing.MH(), turing_kwargs=(n_samples=200, n_adapt=0, progress=false)),
 )
 ```
 

--- a/docs/src/estimation/multistart.md
+++ b/docs/src/estimation/multistart.md
@@ -318,7 +318,7 @@ While multistart is primarily designed for optimization-based methods, it can be
 using NoLimits
 using DataFrames
 using Distributions
-using Turing
+import Turing
 
 model = @Model begin
     @covariates begin
@@ -347,7 +347,7 @@ ms = NoLimits.Multistart(; n_draws_requested=6, n_draws_used=3)
 
 res_ms = fit_model(
     ms, dm,
-    NoLimits.MCMC(; sampler=MH(), turing_kwargs=(n_samples=200, n_adapt=0, progress=false)),
+    NoLimits.MCMC(; sampler=Turing.MH(), turing_kwargs=(n_samples=200, n_adapt=0, progress=false)),
 )
 
 chain_best = get_chain(res_ms)

--- a/docs/src/estimation/saem-advanced.md
+++ b/docs/src/estimation/saem-advanced.md
@@ -9,13 +9,13 @@ constructor reference.
 
 SAEM accepts three types of E-step sampler.
 
-### `MH()`
+### `Turing.MH()`
 
 Turing's built-in random-walk Metropolis-Hastings. Uses a fixed standard-Normal proposal in the linked (unconstrained) space. Fast per-step but requires careful tuning of `mcmc_steps` to achieve adequate mixing.
 
 ```julia
-using Turing
-res = fit_model(dm, SAEM(sampler=MH()))
+import Turing
+res = fit_model(dm, SAEM(sampler=Turing.MH()))
 ```
 
 ### `SaemixMH` (default)
@@ -48,7 +48,7 @@ Backward-compatible aliases:
 - `target_accept` maps to `proba_mcmc`.
 - `adapt_rate` maps to `stepsize_rw`.
 
-`SaemixMH` pairs naturally with the default `mstep_sa_on_params=true` because kernel-1's prior-proposal draws always produce a finite log-joint, so E-step retries are rarely triggered. For Turing-based samplers (`MH()`, `NUTS`) the E-step retry mechanism (`max_estep_retries=3`) handles the occasional non-finite objective that can arise early in training.
+`SaemixMH` pairs naturally with the default `mstep_sa_on_params=true` because kernel-1's prior-proposal draws always produce a finite log-joint, so E-step retries are rarely triggered. For Turing-based samplers (`Turing.MH()`, `Turing.NUTS`) the E-step retry mechanism (`max_estep_retries=3`) handles the occasional non-finite objective that can arise early in training.
 
 ### `AdaptiveNoLimitsMH`
 
@@ -83,9 +83,9 @@ Constructor keywords:
 Any Turing-compatible sampler can be used:
 
 ```julia
-using Turing
+import Turing
 res = fit_model(dm, SAEM(
-    sampler      = NUTS(0.75),
+    sampler      = Turing.NUTS(0.75),
     turing_kwargs = (n_samples=10, n_adapt=5, progress=false),
     mcmc_steps   = 10,
 ))
@@ -174,7 +174,7 @@ end
 
 # Collapse eta_site toward a fixed effect over the run
 method = NoLimits.SAEM(;
-    sampler=MH(),
+    sampler=Turing.MH(),
     turing_kwargs=(n_samples=20, n_adapt=0, progress=false),
     maxiters=100,
     anneal_to_fixed=(:eta_site,),
@@ -189,7 +189,7 @@ To compare schedules, pass the same `anneal_to_fixed` with a different `anneal_s
 
 ```julia
 method_linear = NoLimits.SAEM(;
-    sampler=MH(),
+    sampler=Turing.MH(),
     turing_kwargs=(n_samples=20, n_adapt=0, progress=false),
     maxiters=100,
     anneal_to_fixed=(:eta_site,),
@@ -197,7 +197,7 @@ method_linear = NoLimits.SAEM(;
 )
 
 method_gamma = NoLimits.SAEM(;
-    sampler=MH(),
+    sampler=Turing.MH(),
     turing_kwargs=(n_samples=20, n_adapt=0, progress=false),
     maxiters=100,
     anneal_to_fixed=(:eta_site,),
@@ -521,7 +521,7 @@ function mstep_closed_form(s, dm)
 end
 
 method = NoLimits.SAEM(;
-    sampler=MH(),
+    sampler=Turing.MH(),
     turing_kwargs=(n_samples=12, n_adapt=0, progress=false),
     maxiters=20,
     suffstats=suffstats,

--- a/docs/src/estimation/saem-advanced.md
+++ b/docs/src/estimation/saem-advanced.md
@@ -219,6 +219,7 @@ SAEM provides two closed-form pathways that can substantially accelerate converg
 Built-in blockwise closed-form updates are available for:
 
 - Random-effect distribution parameters in `Normal`, `MvNormal`, `LogNormal`, and `Exponential` blocks (through `re_mean_params` and `re_cov_params`).
+- Structured scalar `Normal`/`LogNormal` means of the form `β + offset`, where `β` is a fixed effect and the offset carries none (for example the allometric `CL_mean + 0.75 * log(wt / 70)`). The per-level offset is subtracted before the moments are formed, so `β` is updated in closed form and the covariance update centers on the structured mean. A mean with two free fixed effects in it (`μ0 + β * x`) is not eligible and stays numeric.
 - Observation distribution parameters in `Normal`, `LogNormal`, `Exponential`, `Bernoulli`, and `Poisson` blocks (through `resid_var_param`, including named outcome-specific mappings).
 
 These updates are compatible with arbitrarily nonlinear model structure, including ODE-based dynamics and function-approximator components, provided that the updated parameters appear in the supported distribution blocks.

--- a/docs/src/estimation/saem.md
+++ b/docs/src/estimation/saem.md
@@ -399,7 +399,7 @@ After convergence, SAEM computes empirical Bayes modal estimates of the random e
 
 ### Bound Inputs
 
-`lb`, `ub` are optional transformed-scale bounds for free fixed effects. When a closed-form M-step is used, SAEM projects the closed-form updates into these bounds on the transformed scale.
+`lb`, `ub` are optional transformed-scale bounds for the numerical M-step over the free fixed effects. They do not apply to closed-form updates: those are clamped to each fixed effect's own declared natural-scale bounds (`lower`/`upper` in `@fixedEffects`), and scalar variance/scale targets additionally respect the `auto_var_lb`/`var_lb_value` floor.
 
 ### RE Annealing Inputs
 

--- a/docs/src/estimation/vi.md
+++ b/docs/src/estimation/vi.md
@@ -6,8 +6,10 @@ Compared with `MCMC`, VI is often faster and easier to scale, but it returns an 
 
 !!! note "Turing is an optional dependency"
     NoLimits does not install or load Turing for you. Run `Pkg.add("Turing")` and
-    `using Turing` alongside NoLimits; without it, `fit_model(dm, VI())` raises an error
-    naming what to install. See [Optional Dependencies](../installation.md#Optional-Dependencies).
+    `import Turing` alongside NoLimits; without it, `fit_model(dm, VI())` raises an error
+    naming what to install. Use `import`, not `using`: `using Turing` collides with the
+    NoLimits exports `Laplace`, `MAP`, `MLE`, `loglikelihood`, `logprior` and `predict`.
+    See [Optional Dependencies](../installation.md#Optional-Dependencies).
 
 !!! note "VI is fixed-effects only"
     VI is not supported for models with random effects. For full Bayesian inference on

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -82,8 +82,15 @@ always available.
 
 !!! note "Turing samplers"
     `SAEM` and `MCEM` default to the native `SaemixMH` sampler and need no Turing. Pass
-    `MH()`, `NUTS()` or another Turing sampler and the Turing extension is required.
-    `MCMC` and `VI` always require it.
+    `Turing.MH()`, `Turing.NUTS()` or another Turing sampler and the Turing extension is
+    required. `MCMC` and `VI` always require it.
+
+!!! warning "`import Turing`, not `using Turing`"
+    Loading Turing with `import Turing` is enough to trigger the extension. Prefer it over
+    `using Turing`, which brings Turing's own `Laplace`, `MAP`, `MLE`, `loglikelihood`,
+    `logprior` and `predict` into scope alongside the NoLimits exports of the same names:
+    every unqualified use then fails with an ambiguity error. With `import Turing`, refer
+    to Turing's names as `Turing.NUTS()`, `Turing.MH()` and so on.
 
 !!! note "Optimizers"
     Optimizers from `OptimizationBBO` and `OptimizationNLopt` still work with every fitting

--- a/docs/src/plotting/index.md
+++ b/docs/src/plotting/index.md
@@ -39,7 +39,7 @@ CairoMakie.activate!(type = "png")
 using DataFrames
 using Distributions
 using Random
-using Turing
+import Turing
 
 Random.seed!(12)
 
@@ -151,7 +151,7 @@ For vectors, legend labels are assigned as `Model 1`, `Model 2`, and so on in in
 
 ```@example plotting_overview
 saem_quick = NoLimits.SAEM(;
-    sampler=MH(),
+    sampler=Turing.MH(),
     maxiters=20,
     mcmc_steps=8,
     t0=8,

--- a/docs/src/tutorials/mixed-effects-multiple-methods.md
+++ b/docs/src/tutorials/mixed-effects-multiple-methods.md
@@ -22,7 +22,7 @@ using Distributions
 using Downloads
 using Random
 using SciMLBase
-using Turing
+import Turing
 
 include(joinpath(@__DIR__, "_data_loaders.jl"))
 
@@ -184,7 +184,7 @@ mcem_method = NoLimits.MCEM(;
 saem_method = NoLimits.SAEM()
 
 mcmc_method = NoLimits.MCMC(;
-    sampler=NUTS(0.75),
+    sampler=Turing.NUTS(0.75),
     progress=false,
     turing_kwargs=(n_samples=1000, n_adapt=500, progress=false),
 )

--- a/docs/src/tutorials/mixed-effects-nn-saem.md
+++ b/docs/src/tutorials/mixed-effects-nn-saem.md
@@ -28,7 +28,7 @@ using LinearAlgebra
 using OrdinaryDiffEq
 using SciMLBase
 using SimpleChains
-using Turing
+import Turing
 
 include(joinpath(@__DIR__, "_data_loaders.jl"))
 

--- a/docs/src/tutorials/mixed-effects-softtree-saem.md
+++ b/docs/src/tutorials/mixed-effects-softtree-saem.md
@@ -24,7 +24,7 @@ using Random
 using LinearAlgebra
 using OrdinaryDiffEq
 using SciMLBase
-using Turing
+import Turing
 
 include(joinpath(@__DIR__, "_data_loaders.jl"))
 

--- a/docs/src/uncertainty-quantification/mcmc-based-uncertainty.md
+++ b/docs/src/uncertainty-quantification/mcmc-based-uncertainty.md
@@ -116,7 +116,7 @@ Or configure the sampler through individual keyword arguments:
 - `mcmc_fit_kwargs` - additional keyword arguments for the underlying `fit_model` call.
 
 When no explicit configuration is provided, defaults from `NoLimits.MCMC` are used with a
-NUTS sampler. The MCMC refit runs a `MCMC` fit, so it requires `using Turing`.
+NUTS sampler. The MCMC refit runs a `MCMC` fit, so it requires `import Turing`.
 
 ## Returned Quantities
 

--- a/src/estimation/dev_api.jl
+++ b/src/estimation/dev_api.jl
@@ -1548,9 +1548,12 @@ is bit-identical to the SAEM fit's per-iteration current statistics and plugs st
 [`saem_closed_form_mstep`].
 
 `stats` is a NamedTuple `(re, outcome, hmm)`:
-- `re[name] = (family, mean, second, n)`: RE moments, `mean = Σx/n`, `second = Σxx'/n` over
-  the `n` draw contributions (`x` is η; `log η` for lognormal families; the ALR transform
-  for `MvLogitNormal`).
+- `re[name] = (family, mean, second, n, known_mean)`: RE moments, `mean = Σx/n`,
+  `second = Σxx'/n` over the `n` draw contributions (`x` is η; `log η` for lognormal
+  families; the ALR transform for `MvLogitNormal`). When the random effect's declared mean
+  is structured, the level's own mean is subtracted from `x` first; `known_mean` is `true`
+  when that mean carries no fixed effect at all, in which case `second` is already the
+  central second moment and the closed-form variance update uses it directly.
 - `outcome[col] = (family, s1, s2, ss, n)`: additive residual sufficient statistics.
 - `hmm[col] = (family, target, sum_w, sum_wy)`: additive HMM emission statistics.
 

--- a/src/estimation/dev_api.jl
+++ b/src/estimation/dev_api.jl
@@ -1532,7 +1532,8 @@ function _saem_stats_collect(dm::DataModel, batch_infos, b_chains, n_chains, θ,
     return _saem_builtin_collect_current_stats(
         dm, batch_infos, b_chains, n_chains, θ_re, const_cache,
         cfg.resid_var_param, cfg.hmm_emission_params,
-        cfg.re_cov_params, cfg.re_mean_params, cfg.re_family_map, llc, rng
+        cfg.re_cov_params, cfg.re_mean_params, cfg.re_family_map, llc, rng;
+        re_mean_offsets = cfg.re_mean_offsets
     )
 end
 

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -175,7 +175,8 @@ end
            ebe_multistart_sampling, ebe_rescue_on_high_grad, ebe_rescue_multistart_n,
            ebe_rescue_multistart_k, ebe_rescue_max_rounds, ebe_rescue_grad_tol,
            ebe_rescue_multistart_sampling, lb, ub, update_schedule,
-           precondition) <: FittingMethod
+           precondition, builtin_stats, resid_var_param, re_cov_params,
+           re_mean_params) <: FittingMethod
 
 Monte Carlo Expectation-Maximization for random-effects models. At each EM iteration the
 E-step draws random effects; the M-step maximizes the Monte Carlo Q-function over the
@@ -218,6 +219,27 @@ fixed effects.
   `ebe_rescue_multistart_k`, `ebe_rescue_max_rounds`, `ebe_rescue_grad_tol`,
   `ebe_rescue_multistart_sampling`: rescue multistart settings when an EBE mode has a
   high gradient norm. Disabled by default.
+- `builtin_stats = :auto`: closed-form M-step for the parameters whose Monte Carlo
+  Q-maximizer is available in closed form from sufficient statistics (Gaussian/log-normal
+  random-effect means and covariances, the residual scale, supported HMM emissions), with
+  the same routing rules as [`SAEM`](@ref).
+  - `:auto` — detect the eligible blocks from the model (default).
+  - `:closed_form` (alias `:gaussian_re`) — use the maps given below, no detection.
+  - `:none` — optimize every free parameter numerically (the pre-0.2.10 M-step).
+
+  Routing is hybrid: eligible parameters are updated in closed form and frozen for the
+  iteration, everything else is optimized numerically as before, and the numeric problem is
+  skipped entirely when nothing is left. The path is disabled automatically for an
+  [`MCEM_IS`](@ref) E-step (its draws are weighted, the statistics are not) and when
+  `extra_objective` is passed (the M-step is then not separable). The statistics are a plain
+  Monte Carlo average over the current E-step draws — MCEM carries no
+  stochastic-approximation state.
+- `resid_var_param::Symbol = :σ`: fixed-effect name for the residual standard deviation,
+  or a NamedTuple of outcome column to parameter name. Autodetected under `:auto`.
+- `re_cov_params::NamedTuple = NamedTuple()`: mapping of RE name to covariance parameter.
+  Autodetected under `:auto`.
+- `re_mean_params::NamedTuple = NamedTuple()`: mapping of RE name to mean parameter.
+  Autodetected under `:auto`.
 - `lb`, `ub`: bounds on the transformed fixed-effect scale, or `nothing`.
 - `update_schedule = :all`: which RE batches the **E-step** refreshes each iteration
   (same option shapes as [`SAEM`](@ref)):
@@ -237,7 +259,7 @@ fixed effects.
   bit-for-bit. Note that with preconditioning on, the optimizer object behind
   [`get_raw`](@ref) works in `z`; [`get_params`](@ref) always returns the usual scales.
 """
-struct MCEM{O, K, A, ES, EO, EB, ER, L, U, US} <: FittingMethod
+struct MCEM{O, K, A, ES, EO, EB, ER, L, U, US, RV, RC, RM} <: FittingMethod
     optimizer::O
     optim_kwargs::K
     adtype::A
@@ -253,6 +275,10 @@ struct MCEM{O, K, A, ES, EO, EB, ER, L, U, US} <: FittingMethod
     store_diagnostics::Bool
     diagnostics_every::Int
     precondition::Bool
+    builtin_stats::Symbol
+    resid_var_param::RV
+    re_cov_params::RC
+    re_mean_params::RM
 end
 
 function MCEM(;
@@ -292,7 +318,11 @@ function MCEM(;
         update_schedule = :all,
         store_diagnostics::Bool = false,
         diagnostics_every::Int = 1,
-        precondition::Bool = true
+        precondition::Bool = true,
+        builtin_stats = :auto,
+        resid_var_param = :σ,
+        re_cov_params = NamedTuple(),
+        re_mean_params = NamedTuple()
     )
     diagnostics_every >= 1 ||
         error("MCEM: diagnostics_every must be ≥ 1. Got: $diagnostics_every")
@@ -325,11 +355,36 @@ function MCEM(;
     return MCEM(
         optimizer, _as_namedtuple(optim_kwargs), adtype, e_step_actual, em, ebe, ebe_rescue,
         lb, ub, _as_symbol(update_schedule), verbose, progress, store_diagnostics,
-        diagnostics_every, precondition
+        diagnostics_every, precondition, _as_symbol(builtin_stats), resid_var_param,
+        re_cov_params, re_mean_params
     )
 end
 
 # MCEMResult is a StandardOptimizationResult{:mcem} alias (see common.jl).
+
+function get_closed_form_mstep_used(res::MCEMResult)
+    notes = res.notes
+    if notes isa NamedTuple && hasproperty(notes, :closed_form_mstep_used)
+        return Bool(getproperty(notes, :closed_form_mstep_used))
+    end
+    return false
+end
+
+# MCEM's closed-form M-step reuses SAEM's resolver verbatim, so the eligibility rules,
+# autodetection and shared-target exclusions are identical for both estimators.
+function _mcem_saem_opts(method::MCEM)
+    return SAEM(;
+        builtin_stats = method.builtin_stats,
+        resid_var_param = method.resid_var_param,
+        re_cov_params = method.re_cov_params,
+        re_mean_params = method.re_mean_params
+    ).saem
+end
+
+# Floor for closed-form variance/scale updates, mirroring SAEM's `auto_var_lb` /
+# `var_lb_value = 1e-5`: a Monte Carlo variance can come out at zero with few subjects or
+# few draws, and the `:log` transform would then produce `log(0) = -Inf`.
+const _MCEM_VAR_LB = 1.0e-5
 
 mutable struct _MCEMDiagnostics{T}
     θ_hist::Vector{AbstractVector{T}}
@@ -1294,6 +1349,50 @@ function _fit_model(
         Symbol[]
     end
 
+    _cf_cfg = _saem_resolve_closed_form_config(
+        dm, _mcem_saem_opts(method), extra_objective; label = "MCEM"
+    )
+    cf_mode = _cf_cfg.builtin_stats_mode
+    if cf_mode == :closed_form && method.e_step isa MCEM_IS
+        @info "MCEM: importance-sampling E-step — disabling the closed-form M-step. Its sufficient statistics weight every draw equally, so all free parameters are optimized numerically."
+        cf_mode = :none
+    end
+    if !(cf_mode in (:closed_form, :none))
+        @info "MCEM: unknown builtin_stats option; using the numeric M-step." option = method.builtin_stats allowed = (
+            :auto, :closed_form, :gaussian_re, :none,
+        )
+        cf_mode = :none
+    end
+    cf_on = cf_mode == :closed_form
+    cf_cov = cf_on ? _cf_cfg.re_cov_params : NamedTuple()
+    cf_mean = cf_on ? _cf_cfg.re_mean_params : NamedTuple()
+    cf_resid = cf_on ? _cf_cfg.resid_var_param : NamedTuple()
+    cf_hmm = cf_on ? _cf_cfg.hmm_emission_params : NamedTuple()
+    _saem_log_closed_form_plan(
+        method.builtin_stats, cf_mode, _cf_cfg.builtin_cf_elig,
+        cf_cov, cf_mean, cf_resid, cf_hmm, false, free_names,
+        q2_base_free_names, _cf_cfg.shared_excluded; label = "MCEM"
+    )
+    cf_target_syms = Symbol[]
+    for v in values(cf_cov)
+        _saem_collect_target_symbols!(cf_target_syms, v)
+    end
+    for v in values(cf_mean)
+        _saem_collect_target_symbols!(cf_target_syms, v)
+    end
+    _saem_collect_target_symbols!(cf_target_syms, cf_resid)
+    for col in keys(cf_hmm)
+        info_hmm = getfield(cf_hmm, col)
+        hasproperty(info_hmm, :target) &&
+            _saem_collect_target_symbols!(cf_target_syms, getproperty(info_hmm, :target))
+    end
+    closed_form_targets = Tuple(n for n in free_names if n in Set(cf_target_syms))
+    numeric_targets = Tuple(n for n in free_names if !(n in Set(cf_target_syms)))
+    var_lb_targets = cf_on ?
+        _saem_build_var_lb_target_set(cf_cov, _cf_cfg.re_family_map, cf_resid, θ0_u) : ()
+    closed_form_used = false
+    numeric_mstep_used = false
+
     diag = _MCEMDiagnostics{T0}(
         Vector{AbstractVector{T0}}(),
         Vector{T0}(),
@@ -1515,8 +1614,46 @@ function _fit_model(
         # expressions (no ODE needed).  Results are folded into mstep_constants so the
         # Q1 optimizer below sees them as fixed.
         mstep_constants = constants
+        if cf_on
+            cache_cf = ll_cache isa Vector ? ll_cache[1] : ll_cache
+            # Plain Monte Carlo average over THIS iteration's draws. MCEM keeps no
+            # stochastic-approximation state, and routing through `_saem_blend` with
+            # γ = 1 would not be bitwise the draws' own mean.
+            b_chains = [
+                [
+                    view(samples_by_batch[bi], :, c)
+                        for c in 1:size(samples_by_batch[bi], 2)
+                ] for bi in eachindex(batch_infos)
+            ]
+            n_draws = [length(ch) for ch in b_chains]
+            θ_cf = ComponentArray(θu_curr, getaxes(θu_curr))
+            stats_cf = _saem_builtin_collect_current_stats(
+                dm, batch_infos, b_chains, n_draws, θ_cf, const_cache,
+                cf_resid, cf_hmm, cf_cov, cf_mean, _cf_cfg.re_family_map,
+                cache_cf, rng; re_mean_offsets = _cf_cfg.re_mean_offsets
+            )
+            updates = _saem_builtin_updates_from_smoothed_stats(
+                dm, θ_cf, stats_cf, cf_resid, cf_hmm, cf_cov, cf_mean
+            )
+            # User-supplied constants always win over the closed-form updates.
+            for k in keys(constants)
+                haskey(updates, k) &&
+                    (updates = Base.structdiff(updates, NamedTuple{(k,)}((nothing,))))
+            end
+            if !isempty(updates)
+                closed_form_used = true
+                updates = _saem_clamp_constants_to_bounds(updates, fe)
+                if !isempty(var_lb_targets)
+                    updates = _saem_apply_var_lb_to_constants(
+                        updates, var_lb_targets, _MCEM_VAR_LB
+                    )
+                end
+                mstep_constants = merge(mstep_constants, updates)
+            end
+        end
         let q2_free_now = [n for n in q2_base_free_names if n ∉ keys(mstep_constants)]
             if !isempty(q2_free_now)
+                numeric_mstep_used = true
                 θt_q2 = ComponentArray(
                     NamedTuple{Tuple(q2_free_now)}(
                         Tuple(getproperty(θt_full_curr, n) for n in q2_free_now)
@@ -1585,82 +1722,95 @@ function _fit_model(
         θ_const_t_q1 = transform(θ_const_u_q1)
         axs_full_q1 = getaxes(θ_const_t_q1)
 
-        θt_free_iter = ComponentArray(
-            NamedTuple{Tuple(free_names_q1)}(
-                Tuple(getproperty(θt_full_curr, n) for n in free_names_q1)
-            )
-        )
-        axs_free_iter = getaxes(θt_free_iter)
-
-        # Anchored at the current iterate, as for Q2 above.
-        _, _, _θt_from_z, _z_from_θt = _precondition_maps(
-            get_model(dm), free_names_q1, θt_free_iter, axs_free_iter,
-            _precondition_on(method)
-        )
-        # Keyed on θt, not z, and the cache must stay INSIDE this loop: with a per-iteration
-        # anchor, z = 0 means a different θt each iteration, so a hoisted cache would return
-        # iteration 1's objective forever and report instant convergence with no error.
-        obj_cache = (θ = Ref{Any}(nothing), obj = Ref{Any}(nothing))
-        function obj_only(z, p)
-            any(isnan, z) && return Inf
-            θt_free_loc = _θt_from_z(z)
-            θt_vec = θt_free_loc
-            use_cache = !(eltype(θt_free_loc) <: ForwardDiff.Dual)
-            if use_cache && obj_cache.θ[] !== nothing &&
-                    length(obj_cache.θ[]) == length(θt_vec)
-                _maxabsdiff(θt_vec, obj_cache.θ[]) == 0.0 && return obj_cache.obj[]
-            end
-            T = eltype(θt_free_loc)
-            θt_full_loc = ComponentArray(T.(θ_const_t_q1), axs_full_q1)
-            for name in free_names_q1
-                setproperty!(θt_full_loc, name, getproperty(θt_free_loc, name))
-            end
-            θu = inv_transform(θt_full_loc)
-            Q = _mcem_Q(
-                dm, batch_infos, θu, const_cache, ll_cache, samples_by_batch,
-                weights_by_batch; serialization = serialization, q_cache = q_cache
-            )
-            !isfinite(Q) && return Inf
-            obj = -Q + _penalty_value(θu, penalty)
-            extra_objective === nothing || (obj += extra_objective(θu))
-            !isfinite(obj) && return Inf
-            if use_cache
-                obj_cache.θ[] = copy(θt_vec)
-                obj_cache.obj[] = obj
-            end
-            return obj
-        end
-
-        optf = OptimizationFunction(obj_only, method.adtype)
-        lb, ub, use_bounds, θ0_init = _resolve_optim_bounds(
-            fe, free_names_q1, collect(θt_free_iter), method.optimizer, method.lb,
-            method.ub, constants; method_label = "MCEM"
-        )
-        z0 = _z_from_θt(θ0_init)
-        prob = use_bounds ?
-            OptimizationProblem(optf, z0; lb = _z_from_θt(lb), ub = _z_from_θt(ub)) :
-            OptimizationProblem(optf, z0)
-
-        sol = Optimization.solve(prob, method.optimizer; method.optim_kwargs...)
-
-        if any(!isfinite, sol.u)
-            @warn "MCEM M-step iter $iter: optimizer returned non-finite parameters; skipping update."
-            mstep_skipped = true
-            θu_new = θu_curr
-            Q_new = Q_prev
-        else
-            θ_hat_t_free = _θt_from_z(sol.u)
-
-            θt_full_new = ComponentArray(eltype(θ_hat_t_free).(θ_const_t_q1), axs_full_q1)
-            for name in free_names_q1
-                setproperty!(θt_full_new, name, getproperty(θ_hat_t_free, name))
-            end
+        if isempty(free_names_q1)
+            # Every free parameter was fixed by the closed-form M-step, so there is no
+            # numeric problem left: evaluate Q at the closed-form iterate directly.
+            θt_full_new = ComponentArray(T0.(θ_const_t_q1), axs_full_q1)
             θu_new = inv_transform(θt_full_new)
             Q_new = _mcem_Q(
                 dm, batch_infos, θu_new, const_cache, ll_cache, samples_by_batch,
                 weights_by_batch; serialization = serialization, q_cache = q_cache
             )
             Q_new = Q_new == Inf ? T0(Inf) : Q_new
+        else
+            numeric_mstep_used = true
+            θt_free_iter = ComponentArray(
+                NamedTuple{Tuple(free_names_q1)}(
+                    Tuple(getproperty(θt_full_curr, n) for n in free_names_q1)
+                )
+            )
+            axs_free_iter = getaxes(θt_free_iter)
+
+            # Anchored at the current iterate, as for Q2 above.
+            _, _, _θt_from_z, _z_from_θt = _precondition_maps(
+                get_model(dm), free_names_q1, θt_free_iter, axs_free_iter,
+                _precondition_on(method)
+            )
+            # Keyed on θt, not z, and the cache must stay INSIDE this loop: with a per-iteration
+            # anchor, z = 0 means a different θt each iteration, so a hoisted cache would return
+            # iteration 1's objective forever and report instant convergence with no error.
+            obj_cache = (θ = Ref{Any}(nothing), obj = Ref{Any}(nothing))
+            function obj_only(z, p)
+                any(isnan, z) && return Inf
+                θt_free_loc = _θt_from_z(z)
+                θt_vec = θt_free_loc
+                use_cache = !(eltype(θt_free_loc) <: ForwardDiff.Dual)
+                if use_cache && obj_cache.θ[] !== nothing &&
+                        length(obj_cache.θ[]) == length(θt_vec)
+                    _maxabsdiff(θt_vec, obj_cache.θ[]) == 0.0 && return obj_cache.obj[]
+                end
+                T = eltype(θt_free_loc)
+                θt_full_loc = ComponentArray(T.(θ_const_t_q1), axs_full_q1)
+                for name in free_names_q1
+                    setproperty!(θt_full_loc, name, getproperty(θt_free_loc, name))
+                end
+                θu = inv_transform(θt_full_loc)
+                Q = _mcem_Q(
+                    dm, batch_infos, θu, const_cache, ll_cache, samples_by_batch,
+                    weights_by_batch; serialization = serialization, q_cache = q_cache
+                )
+                !isfinite(Q) && return Inf
+                obj = -Q + _penalty_value(θu, penalty)
+                extra_objective === nothing || (obj += extra_objective(θu))
+                !isfinite(obj) && return Inf
+                if use_cache
+                    obj_cache.θ[] = copy(θt_vec)
+                    obj_cache.obj[] = obj
+                end
+                return obj
+            end
+
+            optf = OptimizationFunction(obj_only, method.adtype)
+            lb, ub, use_bounds, θ0_init = _resolve_optim_bounds(
+                fe, free_names_q1, collect(θt_free_iter), method.optimizer, method.lb,
+                method.ub, constants; method_label = "MCEM"
+            )
+            z0 = _z_from_θt(θ0_init)
+            prob = use_bounds ?
+                OptimizationProblem(optf, z0; lb = _z_from_θt(lb), ub = _z_from_θt(ub)) :
+                OptimizationProblem(optf, z0)
+
+            sol = Optimization.solve(prob, method.optimizer; method.optim_kwargs...)
+
+            if any(!isfinite, sol.u)
+                @warn "MCEM M-step iter $iter: optimizer returned non-finite parameters; skipping update."
+                mstep_skipped = true
+                θu_new = θu_curr
+                Q_new = Q_prev
+            else
+                θ_hat_t_free = _θt_from_z(sol.u)
+
+                θt_full_new = ComponentArray(eltype(θ_hat_t_free).(θ_const_t_q1), axs_full_q1)
+                for name in free_names_q1
+                    setproperty!(θt_full_new, name, getproperty(θ_hat_t_free, name))
+                end
+                θu_new = inv_transform(θt_full_new)
+                Q_new = _mcem_Q(
+                    dm, batch_infos, θu_new, const_cache, ll_cache, samples_by_batch,
+                    weights_by_batch; serialization = serialization, q_cache = q_cache
+                )
+                Q_new = Q_new == Inf ? T0(Inf) : Q_new
+            end
         end
 
         # Update θt_free to reflect full current state (use full axes for tracking)
@@ -1767,7 +1917,18 @@ function _fit_model(
             mcmc_candidates_by_batch = last_b_candidates
         )[1] : nothing
 
-    notes = (diagnostics = diag,)
+    mstep_mode = closed_form_used ? (numeric_mstep_used ? :hybrid : :closed_form_only) :
+        :numeric_only
+    notes = (
+        diagnostics = diag,
+        closed_form_mstep_used = closed_form_used,
+        closed_form_mstep_mode = mstep_mode,
+        builtin_stats_mode_requested = method.builtin_stats,
+        builtin_stats_mode_effective = cf_mode,
+        builtin_stats_closed_form_eligibility = _cf_cfg.builtin_cf_elig,
+        closed_form_targets = closed_form_targets,
+        numeric_targets = numeric_targets,
+    )
 
     result = MCEMResult(nothing, Q_prev, length(diag.Q_hist), nothing, notes, eb_modes)
     return FitResult(

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -1623,12 +1623,7 @@ function _fit_model(
             # Plain Monte Carlo average over THIS iteration's draws. MCEM keeps no
             # stochastic-approximation state, and routing through `_saem_blend` with
             # γ = 1 would not be bitwise the draws' own mean.
-            b_chains = [
-                [
-                    view(samples_by_batch[bi], :, c)
-                        for c in 1:size(samples_by_batch[bi], 2)
-                ] for bi in eachindex(batch_infos)
-            ]
+            b_chains = [[view(s, :, c) for c in axes(s, 2)] for s in samples_by_batch]
             n_draws = [length(ch) for ch in b_chains]
             θ_cf = ComponentArray(θu_curr, getaxes(θu_curr))
             stats_cf = _saem_builtin_collect_current_stats(

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -1389,8 +1389,9 @@ function _fit_model(
         hasproperty(info_hmm, :target) &&
             _saem_collect_target_symbols!(cf_target_syms, getproperty(info_hmm, :target))
     end
-    closed_form_targets = Tuple(n for n in free_names if n in Set(cf_target_syms))
-    numeric_targets = Tuple(n for n in free_names if !(n in Set(cf_target_syms)))
+    cf_target_set = Set(cf_target_syms)
+    closed_form_targets = Tuple(n for n in free_names if n in cf_target_set)
+    numeric_targets = Tuple(n for n in free_names if !(n in cf_target_set))
     var_lb_targets = cf_on ?
         _saem_build_var_lb_target_set(cf_cov, _cf_cfg.re_family_map, cf_resid, θ0_u) : ()
     closed_form_used = false

--- a/src/estimation/mcem.jl
+++ b/src/estimation/mcem.jl
@@ -66,8 +66,11 @@ MCMC-based E-step for [`MCEM`](@ref). Accepts the native samplers
 
 # Keyword Arguments
 - `sampler`: Defaults to `SaemixMH()`, which needs no Turing. Turing samplers
-  (`NUTS`, `MH`) require `using Turing`. To restore the pre-0.2.3 default, pass
-  `MCEM_MCMC(sampler = NUTS(0.75), sample_schedule = 250)`.
+  (`NUTS`, `MH`) require `import Turing`. Prefer `import` over `using Turing`: the latter
+  brings Turing's `Laplace`, `MAP`, `MLE`, `loglikelihood`, `logprior` and `predict` into
+  scope alongside the NoLimits exports of the same names, and every unqualified use then
+  fails with an ambiguity error. To restore the pre-0.2.3 default, pass
+  `MCEM_MCMC(sampler = Turing.NUTS(0.75), sample_schedule = 250)`.
 - `turing_kwargs::NamedTuple`: forwarded to `Turing.sample`; ignored by the native samplers.
 - `sample_schedule`: samples per E-step — `Int`, `Vector{Int}`, or `Function(iter)->Int`.
   Defaults to `100`.

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -377,8 +377,13 @@ or closed-form updates (when `builtin_stats` is enabled).
 - `suffstats`: custom sufficient statistics function, or `nothing` to use the built-in.
 - `q_from_stats`: custom Q-function from sufficient statistics, or `nothing`.
 - `mstep_closed_form`: custom closed-form M-step function, or `nothing`.
-- `builtin_stats`: `:auto`, `:on`, or `:off`; controls use of built-in Gaussian statistics.
-- `builtin_mean`: `:none`, `:additive`, or `:all`; controls built-in mean parameterization.
+- `builtin_stats = :auto`: closed-form M-step from built-in sufficient statistics.
+  `:auto` infers the eligible blocks from the model, `:closed_form` (alias `:gaussian_re`)
+  uses the maps below without inference, and `:none` optimizes every free parameter
+  numerically. Routing is hybrid: parameters that are not eligible stay on the numeric
+  M-step.
+- `builtin_mean = :none`: `:glm` adds a numerical generalized-linear sub-step for the RE
+  mean parameters. `:none` leaves them to the closed-form or numeric M-step.
 - `resid_var_param::Symbol = :σ`: fixed-effect name for the residual standard deviation.
 - `re_cov_params::NamedTuple = NamedTuple()`: mapping of RE name to covariance parameter.
 - `re_mean_params::NamedTuple = NamedTuple()`: mapping of RE name to mean parameter.
@@ -2152,6 +2157,10 @@ function _saem_builtin_collect_current_stats(
                     sum_xx = zeros(Tθ, dim, dim)
                 end
                 sum_x .+= x
+                # `vector * adjoint` dispatches to `broadcast(*, u, v)`, so this whole
+                # accumulation is BLAS-free and bit-reproducible across CPU kernels. Do NOT
+                # "optimize" it into `mul!`/`BLAS.syrk!`: that is exactly the dispatch the
+                # closed-form M-step exists to avoid.
                 sum_xx .+= x * x'
                 nvals += 1
             end

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -1097,13 +1097,18 @@ function _saem_expr_has_fixed_symbol(ex, fixed_set::Set{Symbol})
     return any(a -> _saem_expr_has_fixed_symbol(a, fixed_set), args)
 end
 
-# Mean slot of a scalar Normal/LogNormal random effect -> (target, has_offset).
-# A bare fixed-effect symbol is the plain target. `β + offset` (or `offset + β`), with `β`
-# a fixed effect and `offset` free of fixed effects, is a *structured* mean: `β` stays a
-# closed-form target and the per-level offset is subtracted from the moments, so the
-# variance update centers on the structured mean rather than on the pooled empirical one.
-# The fixed-effect-free requirement is what keeps `β` recoverable from the moments alone;
-# `μ0 + β * x` has two fixed effects in the mean and stays numeric.
+# Mean slot of a scalar Normal/LogNormal random effect -> (target, mean_offset).
+# `mean_offset = true` means the level's own mean is subtracted from the moments before
+# they are formed, so the covariance update centers on the model's mean rather than on the
+# pooled empirical one. Three cases:
+#   * bare fixed-effect symbol -> that symbol is the target, no offset needed.
+#   * `β + offset` / `offset + β` with `β` a fixed effect and `offset` free of fixed
+#     effects -> `β` is the target and `offset` is the per-level shift. The
+#     fixed-effect-free requirement is what keeps `β` recoverable from the moments alone;
+#     `μ0 + β * x` has two fixed effects in the mean and stays numeric.
+#   * anything with no fixed effect at all (`0.0`, `log(wt)`) -> the mean is KNOWN. There
+#     is no target, and the exact conditional maximizer of the variance is the second
+#     moment about that known mean, with no empirical-mean correction.
 function _saem_parse_re_mean_target(μarg, fixed_set::Set{Symbol})
     μarg isa Symbol && return ((μarg in fixed_set) ? μarg : nothing, false)
     if μarg isa Expr && μarg.head === :call && length(μarg.args) == 3 &&
@@ -1116,7 +1121,7 @@ function _saem_parse_re_mean_target(μarg, fixed_set::Set{Symbol})
             end
         end
     end
-    return (nothing, false)
+    return (nothing, !_saem_expr_has_fixed_symbol(μarg, fixed_set))
 end
 
 function _saem_parse_re_gaussian_mapping(dist_expr, fixed_set::Set{Symbol})
@@ -1424,6 +1429,9 @@ function _saem_autodetect_gaussian_re(dm::DataModel, fixed_names::Vector{Symbol}
         if mapping.mean !== nothing && !_saem_target_is_shared(mapping.mean, shared)
             push!(mean_pairs, re => mapping.mean)
             mapping.mean_offset && push!(mean_offset_pairs, re => true)
+        elseif mapping.mean === nothing && mapping.mean_offset
+            # Known mean: no target, but still centered on it (see the parser).
+            push!(mean_offset_pairs, re => true)
         end
     end
 
@@ -2074,14 +2082,16 @@ end
 @inline _saem_n_chains_at(n_chains::Int, ::Int) = n_chains
 @inline _saem_n_chains_at(n_chains::AbstractVector{<:Integer}, bi::Int) = Int(n_chains[bi])
 
-# Per-level offsets `c_i` of a structured random-effect mean `β + c_i`, read off the level's
-# own prior distribution as `c_i = μ_i - β`. Random-effect distributions see only constant
-# covariates, so `c_i` is genuinely level-constant.
+# Per-level offsets `c_i` of a random-effect mean `β + c_i`, read off the level's own prior
+# distribution as `c_i = μ_i - β`. Random-effect distributions see only constant covariates,
+# so `c_i` is genuinely level-constant. `mean_sym === nothing` is the known-mean case, where
+# the whole mean is the offset.
 function _saem_re_mean_offsets(
-        dm::DataModel, batch_infos::Vector{REBatchInfo}, re::Symbol, mean_sym::Symbol,
-        θ::ComponentArray, ll_cache::_LLCache, ::Type{Tθ}
+        dm::DataModel, batch_infos::Vector{REBatchInfo}, re::Symbol,
+        mean_sym::Union{Symbol, Nothing}, θ::ComponentArray, ll_cache::_LLCache,
+        ::Type{Tθ}
     ) where {Tθ}
-    β = Tθ(getproperty(θ, mean_sym))
+    β = mean_sym === nothing ? zero(Tθ) : Tθ(getproperty(θ, mean_sym))
     return [
         Tθ[
             Tθ(Distributions.params(d)[1]) - β
@@ -2119,13 +2129,16 @@ function _saem_builtin_collect_current_stats(
         ri === nothing && continue
 
         family = haskey(re_family_map, re) ? getfield(re_family_map, re) : :normal
-        offsets = if haskey(re_mean_offsets, re) && haskey(re_mean_params, re)
-            _saem_re_mean_offsets(
-                dm, batch_infos, re, getfield(re_mean_params, re), θ, ll_cache, Tθ
-            )
+        mean_sym = haskey(re_mean_params, re) ? getfield(re_mean_params, re) : nothing
+        offsets = if haskey(re_mean_offsets, re) && mean_sym isa Union{Symbol, Nothing}
+            _saem_re_mean_offsets(dm, batch_infos, re, mean_sym, θ, ll_cache, Tθ)
         else
             nothing
         end
+        # The mean is known (a literal or covariate-only expression) when it was centered
+        # out and no fixed effect estimates it: the variance maximizer is then the second
+        # moment about that mean, with no empirical-mean correction.
+        known_mean = offsets !== nothing && mean_sym === nothing
         sum_x = nothing
         sum_xx = nothing
         nvals = 0
@@ -2169,7 +2182,11 @@ function _saem_builtin_collect_current_stats(
         mean_x = sum_x ./ nvals
         second_x = sum_xx ./ nvals
         push!(
-            re_pairs, re => (family = family, mean = mean_x, second = second_x, n = nvals)
+            re_pairs,
+            re => (
+                family = family, mean = mean_x, second = second_x, n = nvals,
+                known_mean = known_mean,
+            )
         )
     end
     re_stats = NamedTuple(re_pairs)
@@ -2267,6 +2284,8 @@ function _saem_builtin_smooth_re_stats(prev_re::NamedTuple, curr_re::NamedTuple,
                     mean = _saem_blend(p.mean, c.mean, γ),
                     second = _saem_blend(p.second, c.second, γ),
                     n = c.n,
+                    known_mean = hasproperty(c, :known_mean) ? c.known_mean :
+                        (hasproperty(p, :known_mean) && p.known_mean),
                 )
             )
         elseif haskey(curr_re, re)
@@ -2599,7 +2618,10 @@ function _saem_builtin_updates_from_smoothed_stats(
 
         μ_hat = st.mean
         S2_hat = st.second
-        Σ_hat = S2_hat .- μ_hat * μ_hat'
+        # `vector * adjoint` is a broadcast, not BLAS (see the accumulator). With a known
+        # mean the moments are already central, so there is nothing to subtract.
+        Σ_hat = (hasproperty(st, :known_mean) && st.known_mean) ? S2_hat :
+            S2_hat .- μ_hat * μ_hat'
         if any(!isfinite, Σ_hat)
             @warn "SAEM closed-form: non-finite covariance estimate for RE :$re; skipping update."
             continue
@@ -3157,10 +3179,13 @@ function _saem_resolve_closed_form_config(
             # where the effective target is still the autodetected one.
             offset_pairs = Pair{Symbol, Bool}[]
             for re in keys(auto_cfg.re_mean_offsets)
-                haskey(re_mean_params, re) &&
-                    getfield(re_mean_params, re) ===
-                    getfield(auto_cfg.re_mean_params, re) &&
+                if !haskey(auto_cfg.re_mean_params, re)
+                    push!(offset_pairs, re => true)   # known mean, no target to override
+                elseif haskey(re_mean_params, re) &&
+                        getfield(re_mean_params, re) ===
+                        getfield(auto_cfg.re_mean_params, re)
                     push!(offset_pairs, re => true)
+                end
             end
             re_mean_offsets = NamedTuple(offset_pairs)
             hmm_emission_params = auto_cfg.hmm_emission_params

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -2092,12 +2092,10 @@ function _saem_re_mean_offsets(
         ::Type{Tθ}
     ) where {Tθ}
     β = mean_sym === nothing ? zero(Tθ) : Tθ(getproperty(θ, mean_sym))
-    return [
-        Tθ[
-            Tθ(Distributions.params(d)[1]) - β
-                for d in getproperty(_re_dists_for_info(dm, info, θ, ll_cache), re)
-        ] for info in batch_infos
-    ]
+    return map(batch_infos) do info
+        dists = getproperty(_re_dists_for_info(dm, info, θ, ll_cache), re)
+        return Tθ[Tθ(Distributions.params(d)[1]) - β for d in dists]
+    end
 end
 
 # Collect this iteration's sufficient statistics from EVERY chain's sample. Each chain

--- a/src/estimation/saem.jl
+++ b/src/estimation/saem.jl
@@ -1083,6 +1083,37 @@ end
     return info.family == :bernoulli && info.hmm_type == :discrete_time
 end
 
+# `true` when `ex` mentions any fixed effect. Used to certify that a random-effect mean
+# offset is data-only, so it can be subtracted from the sufficient statistics.
+function _saem_expr_has_fixed_symbol(ex, fixed_set::Set{Symbol})
+    ex isa Symbol && return ex in fixed_set
+    ex isa Expr || return false
+    args = ex.head === :call ? (@view ex.args[2:end]) : (@view ex.args[1:end])
+    return any(a -> _saem_expr_has_fixed_symbol(a, fixed_set), args)
+end
+
+# Mean slot of a scalar Normal/LogNormal random effect -> (target, has_offset).
+# A bare fixed-effect symbol is the plain target. `β + offset` (or `offset + β`), with `β`
+# a fixed effect and `offset` free of fixed effects, is a *structured* mean: `β` stays a
+# closed-form target and the per-level offset is subtracted from the moments, so the
+# variance update centers on the structured mean rather than on the pooled empirical one.
+# The fixed-effect-free requirement is what keeps `β` recoverable from the moments alone;
+# `μ0 + β * x` has two fixed effects in the mean and stays numeric.
+function _saem_parse_re_mean_target(μarg, fixed_set::Set{Symbol})
+    μarg isa Symbol && return ((μarg in fixed_set) ? μarg : nothing, false)
+    if μarg isa Expr && μarg.head === :call && length(μarg.args) == 3 &&
+            μarg.args[1] === :+
+        lhs, rhs = μarg.args[2], μarg.args[3]
+        for (β, offset) in ((lhs, rhs), (rhs, lhs))
+            if β isa Symbol && β in fixed_set &&
+                    !_saem_expr_has_fixed_symbol(offset, fixed_set)
+                return (β, true)
+            end
+        end
+    end
+    return (nothing, false)
+end
+
 function _saem_parse_re_gaussian_mapping(dist_expr, fixed_set::Set{Symbol})
     cname = _saem_call_name(dist_expr)
     cname === nothing && return nothing
@@ -1092,24 +1123,33 @@ function _saem_parse_re_gaussian_mapping(dist_expr, fixed_set::Set{Symbol})
         μarg = dist_expr.args[2]
         σarg = dist_expr.args[3]
         σ_target = (σarg isa Symbol && σarg in fixed_set) ? σarg : nothing
-        mean_target = (μarg isa Symbol && μarg in fixed_set) ? μarg : nothing
-        return (family = :normal, mean = mean_target, cov = σ_target)
+        mean_target, mean_offset = _saem_parse_re_mean_target(μarg, fixed_set)
+        return (
+            family = :normal, mean = mean_target, cov = σ_target,
+            mean_offset = mean_offset,
+        )
     end
 
     if cname == :LogNormal
         (dist_expr isa Expr && length(dist_expr.args) == 3) || return nothing
         μarg = dist_expr.args[2]
         σarg = dist_expr.args[3]
-        mean_target = (μarg isa Symbol && μarg in fixed_set) ? μarg : nothing
+        mean_target, mean_offset = _saem_parse_re_mean_target(μarg, fixed_set)
         cov_target = (σarg isa Symbol && σarg in fixed_set) ? σarg : nothing
-        return (family = :lognormal, mean = mean_target, cov = cov_target)
+        return (
+            family = :lognormal, mean = mean_target, cov = cov_target,
+            mean_offset = mean_offset,
+        )
     end
 
     if cname == :Exponential
         (dist_expr isa Expr && length(dist_expr.args) == 2) || return nothing
         θarg = dist_expr.args[2]
         cov_target = (θarg isa Symbol && θarg in fixed_set) ? θarg : nothing
-        return (family = :exponential, mean = nothing, cov = cov_target)
+        return (
+            family = :exponential, mean = nothing, cov = cov_target,
+            mean_offset = false,
+        )
     end
 
     if cname == :MvNormal
@@ -1146,7 +1186,10 @@ function _saem_parse_re_gaussian_mapping(dist_expr, fixed_set::Set{Symbol})
                 end
             end
         end
-        return (family = :mvnormal, mean = mean_target, cov = cov_target)
+        return (
+            family = :mvnormal, mean = mean_target, cov = cov_target,
+            mean_offset = false,
+        )
     end
 
     if cname == :MvLogNormal || cname == :MvLogitNormal
@@ -1184,7 +1227,10 @@ function _saem_parse_re_gaussian_mapping(dist_expr, fixed_set::Set{Symbol})
             end
         end
         fam = cname == :MvLogNormal ? :mvlognormal : :mvlogitnormal
-        return (family = fam, mean = mean_target, cov = cov_target)
+        return (
+            family = fam, mean = mean_target, cov = cov_target,
+            mean_offset = false,
+        )
     end
 
     return nothing
@@ -1360,6 +1406,7 @@ function _saem_autodetect_gaussian_re(dm::DataModel, fixed_names::Vector{Symbol}
 
     cov_pairs = Pair{Symbol, Any}[]
     mean_pairs = Pair{Symbol, Any}[]
+    mean_offset_pairs = Pair{Symbol, Bool}[]
     family_pairs = Pair{Symbol, Symbol}[]
     for re in re_names
         hasproperty(re_dists, re) || continue
@@ -1371,6 +1418,7 @@ function _saem_autodetect_gaussian_re(dm::DataModel, fixed_names::Vector{Symbol}
         end
         if mapping.mean !== nothing && !_saem_target_is_shared(mapping.mean, shared)
             push!(mean_pairs, re => mapping.mean)
+            mapping.mean_offset && push!(mean_offset_pairs, re => true)
         end
     end
 
@@ -1396,6 +1444,7 @@ function _saem_autodetect_gaussian_re(dm::DataModel, fixed_names::Vector{Symbol}
     return (
         re_cov_params = NamedTuple(cov_pairs),
         re_mean_params = NamedTuple(mean_pairs),
+        re_mean_offsets = NamedTuple(mean_offset_pairs),
         re_families = NamedTuple(family_pairs),
         resid_var_param = resid_var_param,
         hmm_emission_params = hmm_emission_params,
@@ -2015,6 +2064,27 @@ function _saem_collect_outcome_stats_individual(
     return (NamedTuple(pairs), true)
 end
 
+# Number of draws contributed by batch `bi`. MCEM's `update_schedule` can leave batches
+# with different draw counts, so the count may be per-batch rather than shared.
+@inline _saem_n_chains_at(n_chains::Int, ::Int) = n_chains
+@inline _saem_n_chains_at(n_chains::AbstractVector{<:Integer}, bi::Int) = Int(n_chains[bi])
+
+# Per-level offsets `c_i` of a structured random-effect mean `β + c_i`, read off the level's
+# own prior distribution as `c_i = μ_i - β`. Random-effect distributions see only constant
+# covariates, so `c_i` is genuinely level-constant.
+function _saem_re_mean_offsets(
+        dm::DataModel, batch_infos::Vector{REBatchInfo}, re::Symbol, mean_sym::Symbol,
+        θ::ComponentArray, ll_cache::_LLCache, ::Type{Tθ}
+    ) where {Tθ}
+    β = Tθ(getproperty(θ, mean_sym))
+    return [
+        Tθ[
+            Tθ(Distributions.params(d)[1]) - β
+                for d in getproperty(_re_dists_for_info(dm, info, θ, ll_cache), re)
+        ] for info in batch_infos
+    ]
+end
+
 # Collect this iteration's sufficient statistics from EVERY chain's sample. Each chain
 # is a separate E-step draw: second moments must include the across-chain dispersion,
 # so the chains' η are never averaged before the moments are formed (doing so deflates
@@ -2023,7 +2093,7 @@ function _saem_builtin_collect_current_stats(
         dm::DataModel,
         batch_infos::Vector{REBatchInfo},
         b_chains::AbstractVector,
-        n_chains::Int,
+        n_chains::Union{Int, AbstractVector{<:Integer}},
         θ::ComponentArray,
         const_cache::REConstantsCache,
         resid_var_param,
@@ -2032,7 +2102,8 @@ function _saem_builtin_collect_current_stats(
         re_mean_params::NamedTuple,
         re_family_map::NamedTuple,
         ll_cache::_LLCache,
-        rng::AbstractRNG
+        rng::AbstractRNG;
+        re_mean_offsets::NamedTuple = NamedTuple()
     )
     Tθ = promote_type(eltype(θ), Float64)
     cache = get_laplace_cache(get_re_group_info(dm))
@@ -2043,13 +2114,20 @@ function _saem_builtin_collect_current_stats(
         ri === nothing && continue
 
         family = haskey(re_family_map, re) ? getfield(re_family_map, re) : :normal
+        offsets = if haskey(re_mean_offsets, re) && haskey(re_mean_params, re)
+            _saem_re_mean_offsets(
+                dm, batch_infos, re, getfield(re_mean_params, re), θ, ll_cache, Tθ
+            )
+        else
+            nothing
+        end
         sum_x = nothing
         sum_xx = nothing
         nvals = 0
-        for (bi, info) in enumerate(batch_infos), c in 1:n_chains
+        for (bi, info) in enumerate(batch_infos), c in 1:_saem_n_chains_at(n_chains, bi)
             b = b_chains[bi][c]
             rei = get_re_info(info)[ri]
-            for lvl_id in get_levels(get_re_map(rei))
+            for (li, lvl_id) in enumerate(get_levels(get_re_map(rei)))
                 v = _re_value_from_b(rei, lvl_id, b)
                 v === nothing && continue
                 raw = v isa Number ? Tθ[v] : Tθ.(collect(v))
@@ -2067,6 +2145,7 @@ function _saem_builtin_collect_current_stats(
                 else
                     continue
                 end
+                offsets === nothing || (x = x .- offsets[bi][li])
                 if sum_x === nothing
                     dim = length(x)
                     sum_x = zeros(Tθ, dim)
@@ -2091,7 +2170,7 @@ function _saem_builtin_collect_current_stats(
     if !isempty(keys(obs_targets))
         obs_acc = Dict{Symbol, Any}()
         all_supported = true
-        for (bi, info) in enumerate(batch_infos), c in 1:n_chains
+        for (bi, info) in enumerate(batch_infos), c in 1:_saem_n_chains_at(n_chains, bi)
             b = b_chains[bi][c]
             for i in get_inds(info)
                 η_ind = _build_eta_ind(dm, i, info, b, const_cache, θ)
@@ -2126,7 +2205,7 @@ function _saem_builtin_collect_current_stats(
     if !isempty(keys(hmm_emission_params))
         hmm_acc = Dict{Symbol, Any}()
         all_supported = true
-        for (bi, info) in enumerate(batch_infos), c in 1:n_chains
+        for (bi, info) in enumerate(batch_infos), c in 1:_saem_n_chains_at(n_chains, bi)
             b = b_chains[bi][c]
             for i in get_inds(info)
                 η_ind = _build_eta_ind(dm, i, info, b, const_cache, θ)
@@ -2876,7 +2955,8 @@ function _saem_log_closed_form_plan(
         has_custom_closed_form::Bool,
         base_free_names::Vector{Symbol},
         q2_base_free_names::Vector{Symbol},
-        shared_excluded::Vector{Symbol} = Symbol[]
+        shared_excluded::Vector{Symbol} = Symbol[];
+        label::String = "SAEM"
     )
     cf_syms = Symbol[]
     for v in values(re_cov_params)
@@ -2900,12 +2980,12 @@ function _saem_log_closed_form_plan(
     q1_numeric = [n for n in numeric_params if n ∉ q2_set]
     q2_numeric = [n for n in numeric_params if n ∈ q2_set]
     if isempty(numeric_params)
-        @info "SAEM: all parameters handled by closed-form M-step; numeric optimizer inactive."
+        @info "$(label): all parameters handled by closed-form M-step; numeric optimizer inactive."
     else
         groups = String[]
         !isempty(q1_numeric) && push!(groups, string(q1_numeric))
         !isempty(q2_numeric) && push!(groups, string(q2_numeric) * " (Q2-only)")
-        msg = "SAEM: numerically optimized parameters: $(join(groups, "  "))"
+        msg = "$(label): numerically optimized parameters: $(join(groups, "  "))"
         excluded = [n for n in shared_excluded if n in numeric_params]
         isempty(excluded) ||
             (msg *= "; $(excluded) excluded from the closed-form M-step because they are shared with other model blocks")
@@ -3034,12 +3114,16 @@ end
 # the eligibility report, and the RE family map. Shared by `_fit_model(::SAEM)` and the
 # dev_api SAEM primitives so their routing is bit-identical. `extra_objective !== nothing`
 # disables the closed-form path (the M-step is no longer separable), matching the fit.
-function _saem_resolve_closed_form_config(dm::DataModel, saem::SAEMOptions, extra_objective = nothing)
+function _saem_resolve_closed_form_config(
+        dm::DataModel, saem::SAEMOptions, extra_objective = nothing;
+        label::String = "SAEM"
+    )
     fixed_names = get_names(get_fixed(get_model(dm)))
     builtin_stats_mode = _saem_normalize_builtin_stats_mode(saem.builtin_stats)
     resid_var_param = saem.resid_var_param
     re_cov_params = saem.re_cov_params
     re_mean_params = saem.re_mean_params
+    re_mean_offsets = NamedTuple()
     hmm_emission_params = NamedTuple()
     shared_excluded = Symbol[]
     if builtin_stats_mode == :auto
@@ -3060,6 +3144,16 @@ function _saem_resolve_closed_form_config(dm::DataModel, saem::SAEMOptions, extr
                 merge(auto_cfg.re_cov_params, re_cov_params)
             re_mean_params = isempty(keys(re_mean_params)) ? auto_cfg.re_mean_params :
                 merge(auto_cfg.re_mean_params, re_mean_params)
+            # An offset belongs to the mean target it was parsed with, so keep the flag only
+            # where the effective target is still the autodetected one.
+            offset_pairs = Pair{Symbol, Bool}[]
+            for re in keys(auto_cfg.re_mean_offsets)
+                haskey(re_mean_params, re) &&
+                    getfield(re_mean_params, re) ===
+                    getfield(auto_cfg.re_mean_params, re) &&
+                    push!(offset_pairs, re => true)
+            end
+            re_mean_offsets = NamedTuple(offset_pairs)
             hmm_emission_params = auto_cfg.hmm_emission_params
             if resid_var_param isa NamedTuple
                 if isempty(keys(resid_var_param))
@@ -3088,10 +3182,10 @@ function _saem_resolve_closed_form_config(dm::DataModel, saem::SAEMOptions, extr
             resid_var_param, hmm_emission_params
         )
         if !isempty(builtin_cf_elig.outcome_targets_hmm)
-            @info "SAEM builtin_stats ignores HMM outcome targets; applying closed-form updates to eligible non-HMM/re blocks only." hmm_outcomes = builtin_cf_elig.outcome_targets_hmm
+            @info "$(label) builtin_stats ignores HMM outcome targets; applying closed-form updates to eligible non-HMM/re blocks only." hmm_outcomes = builtin_cf_elig.outcome_targets_hmm
         end
         if !builtin_cf_elig.has_any_closed_form_block
-            @info "SAEM builtin_stats has no eligible closed-form blocks; falling back to numeric M-step."
+            @info "$(label) builtin_stats has no eligible closed-form blocks; falling back to numeric M-step."
             builtin_stats_mode = :none
         end
     end
@@ -3101,11 +3195,12 @@ function _saem_resolve_closed_form_config(dm::DataModel, saem::SAEMOptions, extr
     # single joint Q1 M-step (which already adds `extra_objective`).
     if extra_objective !== nothing
         if builtin_stats_mode != :none
-            @info "SAEM: extra_objective present — disabling closed-form M-step; all free parameters (means, σ, ω) optimized numerically in the joint M-step."
+            @info "$(label): extra_objective present — disabling closed-form M-step; all free parameters (means, σ, ω) optimized numerically in the joint M-step."
             builtin_stats_mode = :none
         end
         re_cov_params = NamedTuple()
         re_mean_params = NamedTuple()
+        re_mean_offsets = NamedTuple()
         resid_var_param = NamedTuple()
         hmm_emission_params = NamedTuple()
     end
@@ -3114,6 +3209,7 @@ function _saem_resolve_closed_form_config(dm::DataModel, saem::SAEMOptions, extr
         builtin_stats_mode = builtin_stats_mode,
         re_cov_params = re_cov_params,
         re_mean_params = re_mean_params,
+        re_mean_offsets = re_mean_offsets,
         resid_var_param = resid_var_param,
         hmm_emission_params = hmm_emission_params,
         builtin_cf_elig = builtin_cf_elig,
@@ -3195,6 +3291,7 @@ function _fit_model(
     builtin_stats_mode = _cf_cfg.builtin_stats_mode
     re_cov_params = _cf_cfg.re_cov_params
     re_mean_params = _cf_cfg.re_mean_params
+    re_mean_offsets = _cf_cfg.re_mean_offsets
     resid_var_param = _cf_cfg.resid_var_param
     hmm_emission_params = _cf_cfg.hmm_emission_params
     builtin_cf_elig = _cf_cfg.builtin_cf_elig
@@ -3512,7 +3609,8 @@ function _fit_model(
                 ComponentArray(θu_curr, getaxes(θu_curr)), const_cache,
                 resid_var_param, hmm_emission_params,
                 re_cov_params, re_mean_params,
-                re_family_map, cache, rng
+                re_family_map, cache, rng;
+                re_mean_offsets = re_mean_offsets
             )
             builtin_stats_state = _saem_builtin_smooth_stats(
                 builtin_stats_state, curr_stats, γ

--- a/src/uq/common.jl
+++ b/src/uq/common.jl
@@ -16,6 +16,14 @@ using Statistics
     return Symbol(lowercase(string(nameof(typeof(method)))))
 end
 
+# Which UQ backends can actually replace Wald for a fit produced by `method_sym`. Profile
+# UQ is restricted to MLE/MAP/Laplace/GHQuadrature, so recommending it to an MCEM or SAEM
+# user sends them into an error instead of an alternative.
+@inline function _wald_fallback_methods(method_sym::Symbol)
+    return method_sym in (:mle, :map, :laplace, :ghquadrature) ?
+        "method = :profile / :mcmc_refit" : "method = :mcmc_refit"
+end
+
 function _validate_level(level::Real)
     (0.0 < level < 1.0) || error("UQ level must be strictly between 0 and 1. Got $(level).")
     return Float64(level)
@@ -367,7 +375,10 @@ function _build_ll_cache_uq(
     return build_ll_cache(dm; ode_args = ode_args, ode_kwargs = ode_kwargs)
 end
 
-function _project_psd_covariance(cov_mat::Matrix{Float64})
+function _project_psd_covariance(
+        cov_mat::Matrix{Float64};
+        fallbacks::String = "method = :mcmc_refit"
+    )
     size(cov_mat, 1) == size(cov_mat, 2) || error("Covariance matrix must be square.")
     S = Symmetric(0.5 .* (cov_mat .+ cov_mat'))
     eig = eigen(S)
@@ -401,7 +412,7 @@ function _project_psd_covariance(cov_mat::Matrix{Float64})
             "Standard errors along those directions are shrunk toward zero and understate " *
             "the true uncertainty. "
     ) *
-        "Prefer method = :profile / :mcmc for those parameters." maxlog = 3
+        "Prefer $(fallbacks) for those parameters." maxlog = 3
     diag = (;
         vcov_projected = n_clipped > 0,
         vcov_min_eig_raw = min_raw,

--- a/src/uq/wald.jl
+++ b/src/uq/wald.jl
@@ -152,7 +152,9 @@ function _finalize_wald_uqresult(
         active_names, active_kinds, θu_from_active, Vt_raw, backend_used, vcov,
         pseudo_inverse, n_draws, level, rng, method_sym, extra_diag
     )
-    Vt, vcov_diag = _project_psd_covariance(Vt_raw)
+    Vt, vcov_diag = _project_psd_covariance(
+        Vt_raw; fallbacks = _wald_fallback_methods(method_sym)
+    )
 
     θ_coords_t = _coords_on_transformed_layout(fe, θ_hat_t, free_names; natural = false)
     θ_coords_u = _coords_on_transformed_layout(fe, θ_hat_u, free_names; natural = true)

--- a/src/utils/GeneralUtils.jl
+++ b/src/utils/GeneralUtils.jl
@@ -126,9 +126,16 @@ end
 # `ArgumentError` is the workhorse exception of half of Julia, so classifying all of them
 # as numeric degeneracy masked genuine programming errors as `-Inf` (#326). Only messages
 # that actually signal a numeric failure count: Distributions' `check_args` (a scale
-# driven negative by an optimizer step) and LAPACK/BLAS finite checks.
+# driven negative by an optimizer step), LAPACK/BLAS finite checks, and Roots' bracketing
+# methods, which reject a non-bracketing interval with a plain `ArgumentError`.
+# `Bijectors.find_alpha` hands Roots `[wᵗy - 2|wᵗû|, wᵗy + 2|wᵗû|]`, which brackets the
+# root for every finite input, so a rejection means a non-finite `wᵗy`: a degenerate flow
+# proposal, e.g. a planar layer whose `w` hit exactly zero, at which `get_u_hat` returns
+# `û = NaN` while `wᵗû` stays finite. That is a -Inf point for the optimizer to back off
+# from, not a programming error.
 # Word boundaries matter: a bare "Inf" substring also matches "Information missing".
-const _NUMERIC_ARGUMENT_ERROR_RE = r"is not satisfied|Infs or NaNs|\bNaN\b|\bInf\b"
+const _NUMERIC_ARGUMENT_ERROR_RE =
+    r"is not satisfied|Infs or NaNs|not a bracketing interval|\bNaN\b|\bInf\b"
 
 @inline function _is_numeric_argument_error(err::ArgumentError)
     return occursin(_NUMERIC_ARGUMENT_ERROR_RE, string(err.msg))

--- a/test/estimation_common_tests.jl
+++ b/test/estimation_common_tests.jl
@@ -7,6 +7,7 @@ using Lux
 using ForwardDiff
 using SciMLBase
 using Roots
+import Bijectors
 using DataInterpolations
 using LinearAlgebra
 
@@ -543,6 +544,24 @@ end
         ArgumentError("Normal: the condition σ > 0 is not satisfied.")
     )
     @test NoLimits._is_numeric_error(ArgumentError("matrix contains Infs or NaNs"))
+    # Roots' bracketing methods (A42 since Bijectors 0.16.2, ITP before it) reject a
+    # non-bracketing interval with a plain ArgumentError. `Bijectors.find_alpha` hits this
+    # when a degenerate flow parameter (a planar layer with w = 0) makes wᵗy non-finite:
+    # the same event as the ConvergenceFailed above, and it killed a 0.2.9 flow SAEM fit.
+    @test NoLimits._is_numeric_error(
+        ArgumentError(
+            "The interval [a,b] is not a bracketing interval.\n" *
+                "You need f(a) and f(b) to have different signs (f(a) * f(b) < 0)."
+        )
+    )
+    # The real thing, not just the message: a NaN argument must be classified, not rethrown.
+    @test NoLimits._is_numeric_error(
+        try
+            Bijectors.find_alpha(NaN, -0.76, 1.47)
+        catch err
+            err
+        end
+    )
     # A bare "Inf"/"NaN" substring must not re-open the hole.
     @test !NoLimits._is_numeric_error(ArgumentError("Information missing"))
     @test !NoLimits._is_numeric_error(ArgumentError("Infinite loop guard"))

--- a/test/estimation_mcem_tests.jl
+++ b/test/estimation_mcem_tests.jl
@@ -39,6 +39,56 @@ const _MCEM_DM4 = DataModel(
     primary_id = :ID, time_col = :t
 )
 
+# `fx_re_df`'s `y` is nearly noiseless, which leaves σ and ω at the edge of
+# identifiability. A noisier panel on the same model gives the closed-form and numeric
+# M-steps something to agree on.
+const _MCEM_CF_DM = DataModel(
+    fx_re_model(),
+    let rng = Xoshiro(11), nid = 10, nobs = 4
+        b = randn(rng, nid) .* 0.4
+        ids = repeat(1:nid, inner = nobs)
+        DataFrame(
+            ID = ids,
+            t = repeat(collect(0.0:(nobs - 1)), nid),
+            y = 0.2 .+ b[ids] .+ randn(rng, nid * nobs) .* 0.3
+        )
+    end;
+    primary_id = :ID, time_col = :t
+)
+
+# Structured random-effect mean `cl_mean + 0.75 * log(wt / 70)`: with the additive-offset
+# parser every free parameter is closed-form eligible, so the numeric M-step is empty.
+const _MCEM_OFFSET_MODEL = @Model begin
+    @covariates begin
+        t = Covariate()
+        wt = ConstantCovariate(constant_on = :ID)
+    end
+    @fixedEffects begin
+        cl_mean = RealNumber(0.0)
+        omega_cl = RealNumber(0.3, scale = :log)
+        sigma_y = RealNumber(0.3, scale = :log)
+    end
+    @randomEffects begin
+        CL = RandomEffect(
+            LogNormal(cl_mean + 0.75 * log(wt / 70.0), omega_cl); column = :ID
+        )
+    end
+    @formulas begin
+        y ~ Normal(CL * t, sigma_y)
+    end
+end
+
+const _MCEM_OFFSET_DM = DataModel(
+    _MCEM_OFFSET_MODEL,
+    DataFrame(
+        ID = repeat([:A, :B, :C, :D], inner = 2),
+        t = repeat([1.0, 2.0], outer = 4),
+        wt = repeat([60.0, 70.0, 80.0, 90.0], inner = 2),
+        y = [0.9, 1.9, 1.1, 2.2, 1.0, 2.1, 1.2, 2.3]
+    );
+    primary_id = :ID, time_col = :t
+)
+
 @testset "MCEM default sampler" begin
     method = NoLimits.MCEM()
     @test method.e_step isa NoLimits.MCEM_MCMC
@@ -247,11 +297,15 @@ end
 # which passed `nothing, nothing` where the user bounds belong and let ω run to its
 # unconstrained MLE (natural ~0.29, far below exp(2)).
 @testset "MCEM user bounds reach the Q2-only M-step" begin
+    # `builtin_stats = :none` keeps ω on the numeric Q2 leg. The method-level lb/ub are
+    # transformed-scale bounds for the optimizer, so they do not constrain a closed-form
+    # update (which is clamped to the fixed effect's own declared natural-scale bounds).
     method = NoLimits.MCEM(
         sampler = MH(), turing_kwargs = (n_samples = 2, n_adapt = 2, progress = false),
         maxiters = 2, optim_kwargs = (; maxiters = 5),
         lb = ComponentArray(a = -10.0, σ = -10.0, ω = 2.0),
-        ub = ComponentArray(a = 10.0, σ = 10.0, ω = 3.0)
+        ub = ComponentArray(a = 10.0, σ = 10.0, ω = 3.0),
+        builtin_stats = :none
     )
     res = fit_model(fx_re_dm(), method)
     @test NoLimits.get_params(res; scale = :untransformed).ω >= exp(2.0) - 1.0e-6
@@ -793,4 +847,145 @@ end
     @test isapprox(θ_rt.a, p_ref.a; atol = 0.05)
     @test isapprox(θ_rt.σ, p_ref.σ; atol = 0.03)
     @test isapprox(θ_rt.ω, p_ref.ω; atol = 0.03)
+end
+
+@testset "MCEM closed-form M-step routing and agreement" begin
+    tk = (n_samples = 20, n_adapt = 5, progress = false)
+    mcem_cf(bs; kw...) = NoLimits.MCEM(;
+        sampler = MH(), turing_kwargs = tk, maxiters = 15, progress = false,
+        builtin_stats = bs, kw...
+    )
+    fit_cf(dm, bs; kw...) = fit_model(
+        dm, mcem_cf(bs); rng = Xoshiro(3),
+        serialization = NoLimits.EnsembleSerial(), kw...
+    )
+    notes_of(res) = NoLimits.get_notes(NoLimits.get_result(res))
+
+    # `:auto` is the default and routes σ/ω through the closed form, `a` (obs-side) numeric.
+    @test NoLimits.MCEM().builtin_stats == :auto
+    res_auto = fit_cf(fx_re_dm(), :auto)
+    n_auto = notes_of(res_auto)
+    @test n_auto.builtin_stats_mode_effective == :closed_form
+    @test n_auto.closed_form_mstep_used
+    @test n_auto.closed_form_mstep_mode == :hybrid
+    @test n_auto.closed_form_targets == (:σ, :ω)
+    @test n_auto.numeric_targets == (:a,)
+    @test isempty(n_auto.builtin_stats_closed_form_eligibility.reasons)
+    @test NoLimits.get_closed_form_mstep_used(NoLimits.get_result(res_auto))
+
+    # `:none` reproduces the pre-change path: every free parameter stays numeric.
+    res_none = fit_cf(fx_re_dm(), :none)
+    n_none = notes_of(res_none)
+    @test n_none.builtin_stats_mode_effective == :none
+    @test !n_none.closed_form_mstep_used
+    @test n_none.closed_form_mstep_mode == :numeric_only
+    @test n_none.closed_form_targets == ()
+    @test n_none.numeric_targets == (:a, :σ, :ω)
+
+    @test all(isfinite, collect(NoLimits.get_params(res_auto; scale = :untransformed)))
+
+    # Same Q, two different M-steps: agreement in the limit, not bitwise.
+    m_agree(bs) = NoLimits.MCEM(;
+        sampler = MH(), turing_kwargs = (n_samples = 60, n_adapt = 10, progress = false),
+        maxiters = 40, progress = false, builtin_stats = bs
+    )
+    p_auto = NoLimits.get_params(
+        fit_model(
+            _MCEM_CF_DM, m_agree(:auto); rng = Xoshiro(3),
+            serialization = NoLimits.EnsembleSerial()
+        ); scale = :untransformed
+    )
+    p_none = NoLimits.get_params(
+        fit_model(
+            _MCEM_CF_DM, m_agree(:none); rng = Xoshiro(3),
+            serialization = NoLimits.EnsembleSerial()
+        ); scale = :untransformed
+    )
+    for k in (:a, :σ, :ω)
+        @test isapprox(getproperty(p_auto, k), getproperty(p_none, k); rtol = 0.15)
+    end
+
+    # A constant drops its parameter from both routes.
+    res_c = fit_cf(fx_re_dm(), :auto; constants = (; σ = 0.3))
+    n_c = notes_of(res_c)
+    @test n_c.closed_form_targets == (:ω,)
+    @test n_c.numeric_targets == (:a,)
+    @test NoLimits.get_params(res_c; scale = :untransformed).σ == 0.3
+
+    # Same rng, same closed-form M-step -> bitwise identical parameters and Q history.
+    m_det = NoLimits.MCEM(;
+        sampler = MH(), turing_kwargs = tk, maxiters = 8, progress = false,
+        store_diagnostics = true
+    )
+    d1 = fit_model(
+        fx_re_dm(), m_det; rng = Xoshiro(3), serialization = NoLimits.EnsembleSerial()
+    )
+    d2 = fit_model(
+        fx_re_dm(), m_det; rng = Xoshiro(3), serialization = NoLimits.EnsembleSerial()
+    )
+    @test collect(NoLimits.get_params(d1; scale = :untransformed)) ==
+        collect(NoLimits.get_params(d2; scale = :untransformed))
+    @test notes_of(d1).diagnostics.Q_hist == notes_of(d2).diagnostics.Q_hist
+    @test NoLimits.get_iterations(NoLimits.get_result(d1)) ==
+        NoLimits.get_iterations(NoLimits.get_result(d2))
+
+    # An importance-sampling E-step weights its draws; the statistics do not, so the
+    # closed-form path switches itself off.
+    res_is = fit_model(
+        fx_re_dm(),
+        NoLimits.MCEM(;
+            e_step = NoLimits.MCEM_IS(; n_samples = 20), maxiters = 3, progress = false
+        );
+        rng = Xoshiro(3), serialization = NoLimits.EnsembleSerial()
+    )
+    @test notes_of(res_is).builtin_stats_mode_effective == :none
+    @test !notes_of(res_is).closed_form_mstep_used
+
+    # `extra_objective` makes the M-step non-separable; same fallback.
+    res_eo = fit_model(
+        fx_re_dm(), mcem_cf(:auto); rng = Xoshiro(3),
+        serialization = NoLimits.EnsembleSerial(), extra_objective = θ -> 0.5 * θ.a^2
+    )
+    @test notes_of(res_eo).builtin_stats_mode_effective == :none
+    @test !notes_of(res_eo).closed_form_mstep_used
+end
+
+@testset "MCEM closed-form M-step with a structured random-effect mean" begin
+    tk = (n_samples = 20, n_adapt = 5, progress = false)
+    notes_of(res) = NoLimits.get_notes(NoLimits.get_result(res))
+    m(bs) = NoLimits.MCEM(;
+        sampler = MH(), turing_kwargs = tk, maxiters = 15, progress = false,
+        builtin_stats = bs
+    )
+
+    # The additive `0.75 * log(wt / 70)` offset keeps `cl_mean` a closed-form target, so
+    # nothing is left for the optimizer and the empty-free-set branch carries the M-step.
+    cfg = NoLimits._saem_resolve_closed_form_config(
+        _MCEM_OFFSET_DM, NoLimits._mcem_saem_opts(NoLimits.MCEM())
+    )
+    @test cfg.re_mean_params == (; CL = :cl_mean)
+    @test cfg.re_mean_offsets == (; CL = true)
+    @test cfg.re_cov_params == (; CL = :omega_cl)
+    @test cfg.resid_var_param == :sigma_y
+
+    res_auto = fit_model(
+        _MCEM_OFFSET_DM, m(:auto); rng = Xoshiro(3),
+        serialization = NoLimits.EnsembleSerial()
+    )
+    n_auto = notes_of(res_auto)
+    @test n_auto.closed_form_targets == (:cl_mean, :omega_cl, :sigma_y)
+    @test n_auto.numeric_targets == ()
+    @test n_auto.closed_form_mstep_mode == :closed_form_only
+    p_auto = NoLimits.get_params(res_auto; scale = :untransformed)
+    @test all(isfinite, collect(p_auto))
+    @test isfinite(NoLimits.get_objective(res_auto))
+
+    res_none = fit_model(
+        _MCEM_OFFSET_DM, m(:none); rng = Xoshiro(3),
+        serialization = NoLimits.EnsembleSerial()
+    )
+    p_none = NoLimits.get_params(res_none; scale = :untransformed)
+    for k in (:cl_mean, :omega_cl, :sigma_y)
+        @test isapprox(getproperty(p_auto, k), getproperty(p_none, k); rtol = 0.15)
+    end
 end

--- a/test/estimation_mcem_tests.jl
+++ b/test/estimation_mcem_tests.jl
@@ -786,6 +786,20 @@ end
         @test upd == upd_ref
         @test haskey(upd, :σ) && haskey(upd, :ω) && !haskey(upd, :a)
     end
+    # `fx_re_dm`'s random effect is `Normal(0.0, ω)`: the mean is known, so the exact
+    # conditional maximizer of ω is the second moment about that mean. The moments come
+    # back already central, with no empirical-mean correction.
+    @test pop.re.η.known_mean
+    η_all = reduce(vcat, [vec(NoLimits.get_draws(draws[bi])) for bi in 1:nb])
+    @test length(η_all) == pop.re.η.n
+    m2 = sum(abs2, η_all) / length(η_all)
+    @test isapprox(pop.re.η.second[1, 1], m2; rtol = 1.0e-12)
+    upd_km, _ = NoLimits.saem_closed_form_mstep(dm, pop, nothing, θ, 1.0)
+    @test isapprox(upd_km.ω, sqrt(m2); rtol = 1.0e-10)
+    # Strictly above the pre-0.2.10 centring, which subtracted the pooled empirical mean
+    # and so discarded the part of the spread that a nonzero E[η] carries.
+    @test upd_km.ω > sqrt(m2 - (sum(η_all) / length(η_all))^2)
+
     # User constants win over closed-form updates.
     stats1 = NoLimits.saem_sufficient_statistics(dm, θ, draws)
     updc, _ = NoLimits.saem_closed_form_mstep(dm, stats1, nothing, θ, 1.0; constants = (; σ = 0.3))

--- a/test/estimation_saem_autodetect_tests.jl
+++ b/test/estimation_saem_autodetect_tests.jl
@@ -599,7 +599,7 @@ end
     @test :ω ∈ cf_ok
 end
 
-@testset "SAEM parse: additive random-effect mean offset" begin
+@testset "SAEM parse: random-effect mean centring" begin
     fs = Set([:a, :b, :τ])
     parse = NoLimits._saem_parse_re_gaussian_mapping
 
@@ -614,16 +614,25 @@ end
         family = :normal, mean = :a, cov = :τ, mean_offset = true,
     )
 
-    # A bare symbol is the plain target; an offset carrying a fixed effect, a product, or a
-    # numeric-only mean map no mean target at all.
+    # A bare symbol is the plain target and needs no centring.
     @test parse(:(Normal(a, τ)), fs) == (
         family = :normal, mean = :a, cov = :τ, mean_offset = false,
     )
-    @test parse(:(Normal(a + b, τ)), fs).mean === nothing
-    @test parse(:(Normal(a * b, τ)), fs).mean === nothing
-    @test parse(:(Normal(a + b * x, τ)), fs).mean === nothing
-    @test parse(:(Normal(0.0, τ)), fs).mean === nothing
-    @test !parse(:(Normal(0.0, τ)), fs).mean_offset
+
+    # A mean with no fixed effect at all is KNOWN: no target, but still centered out, so
+    # the variance update is the second moment about it.
+    @test parse(:(Normal(0.0, τ)), fs) == (
+        family = :normal, mean = nothing, cov = :τ, mean_offset = true,
+    )
+    @test parse(:(LogNormal(0.0, τ)), fs).mean_offset
+    @test parse(:(Normal(log(x), τ)), fs).mean_offset
+
+    # A mean carrying a fixed effect we cannot extract is neither a target nor centrable:
+    # it stays numeric and the moments stay about the pooled empirical mean.
+    for ex in (:(Normal(a + b, τ)), :(Normal(a * b, τ)), :(Normal(a + b * x, τ)))
+        @test parse(ex, fs).mean === nothing
+        @test !parse(ex, fs).mean_offset
+    end
 end
 
 @testset "SAEM auto-detect: warfarin-style model is fully closed-form" begin

--- a/test/estimation_saem_autodetect_tests.jl
+++ b/test/estimation_saem_autodetect_tests.jl
@@ -598,3 +598,96 @@ end
     cf_ok, _ = NoLimits.saem_closed_form_eligibility(dm_ok)
     @test :ω ∈ cf_ok
 end
+
+@testset "SAEM parse: additive random-effect mean offset" begin
+    fs = Set([:a, :b, :τ])
+    parse = NoLimits._saem_parse_re_gaussian_mapping
+
+    # `β + offset` with a fixed-effect-free offset keeps β as the closed-form mean target
+    # and flags the offset, in either operand order.
+    m = parse(:(LogNormal(a + 0.75 * log(wt / 70.0), τ)), fs)
+    @test m.mean == :a
+    @test m.cov == :τ
+    @test m.mean_offset
+    @test parse(:(Normal(0.75 * log(wt / 70.0) + a, τ)), fs).mean_offset
+    @test parse(:(Normal(a + 1.0, τ)), fs) == (
+        family = :normal, mean = :a, cov = :τ, mean_offset = true,
+    )
+
+    # A bare symbol is the plain target; an offset carrying a fixed effect, a product, or a
+    # numeric-only mean map no mean target at all.
+    @test parse(:(Normal(a, τ)), fs) == (
+        family = :normal, mean = :a, cov = :τ, mean_offset = false,
+    )
+    @test parse(:(Normal(a + b, τ)), fs).mean === nothing
+    @test parse(:(Normal(a * b, τ)), fs).mean === nothing
+    @test parse(:(Normal(a + b * x, τ)), fs).mean === nothing
+    @test parse(:(Normal(0.0, τ)), fs).mean === nothing
+    @test !parse(:(Normal(0.0, τ)), fs).mean_offset
+end
+
+@testset "SAEM auto-detect: warfarin-style model is fully closed-form" begin
+    # Three log-normal REs, allometric weight scaling on clearance, one Normal outcome:
+    # all seven fixed effects are closed-form targets once the additive offset is parsed.
+    model = @Model begin
+        @helpers begin
+            bateman(t, dose, ka, ke) = dose * ka / (ka - ke) *
+                (exp(-ke * t) - exp(-ka * t))
+        end
+
+        @fixedEffects begin
+            ka_mean = RealNumber(0.0)
+            CL_mean = RealNumber(-0.5)
+            V_mean = RealNumber(4.0)
+            sigma_ka = RealNumber(2.0, scale = :log)
+            sigma_CL = RealNumber(2.0, scale = :log)
+            sigma_V = RealNumber(2.0, scale = :log)
+            sigma_C_error = RealNumber(2.0, scale = :log)
+        end
+
+        @covariates begin
+            t = Covariate()
+            d = ConstantCovariate(constant_on = :id)
+            wt = ConstantCovariate(constant_on = :id)
+        end
+
+        @randomEffects begin
+            ka = RandomEffect(LogNormal(ka_mean, sigma_ka); column = :id)
+            CL = RandomEffect(
+                LogNormal(CL_mean + 0.75 * log(wt / 70.0), sigma_CL); column = :id
+            )
+            V = RandomEffect(LogNormal(V_mean, sigma_V); column = :id)
+        end
+
+        @formulas begin
+            C ~ Normal(bateman(t, d, ka, CL / V) / V, sigma_C_error)
+        end
+    end
+
+    df = DataFrame(
+        id = [:A, :A, :B, :B],
+        t = [1.0, 2.0, 1.0, 2.0],
+        d = [100.0, 100.0, 100.0, 100.0],
+        wt = [66.7, 66.7, 80.0, 80.0],
+        C = [8.0, 6.0, 7.0, 5.0]
+    )
+    dm = DataModel(model, df; primary_id = :id, time_col = :t)
+
+    auto_cfg = _auto_cfg(model, df; primary_id = :id)
+    @test auto_cfg.re_mean_params == (; ka = :ka_mean, CL = :CL_mean, V = :V_mean)
+    @test auto_cfg.re_cov_params == (; ka = :sigma_ka, CL = :sigma_CL, V = :sigma_V)
+    @test auto_cfg.re_mean_offsets == (; CL = true)
+    @test auto_cfg.resid_var_param == :sigma_C_error
+
+    for opts in (NoLimits.SAEM().saem, NoLimits._mcem_saem_opts(NoLimits.MCEM()))
+        cfg = NoLimits._saem_resolve_closed_form_config(dm, opts)
+        @test cfg.builtin_stats_mode == :closed_form
+        @test cfg.re_mean_offsets == (; CL = true)
+        @test isempty(cfg.builtin_cf_elig.reasons)
+        @test isempty(cfg.shared_excluded)
+    end
+
+    cf, num = NoLimits.saem_closed_form_eligibility(dm)
+    @test Set(cf) == Set(NoLimits.get_names(model.fixed.fixed))
+    @test isempty(num)
+end

--- a/test/random_effects_tests.jl
+++ b/test/random_effects_tests.jl
@@ -242,6 +242,32 @@ end
     @test occursin("Unsupported keyword", sprint(showerror, err))
 end
 
+# A planar layer with w = 0 makes Bijectors' `get_u_hat` return u_hat = NaN, and a
+# multi-layer chain reports that as a Roots bracketing ArgumentError rather than as NaN.
+# The RE prior must score such a point -Inf instead of throwing: regression for the 0.2.9
+# normalizing-flow SAEM crash, whose Q2 M-step drove a layer's weight to exactly zero.
+@testset "flow prior with a zero planar weight scores -Inf" begin
+    # `[w(d); u(d); b(1)]` per layer, layers in chain order; the last layer has w = 0, so
+    # the inverse chain hits the degeneracy first and passes NaN to the layer before it.
+    psi_bad = [
+        -1.3104712579054207, 0.9974286247290959, 1.4732993220574093,
+        0.0, 3.2382304226542815, -1.8312014258434777,
+    ]
+    flow = NormalizingPlanarFlow(
+        psi_bad, NormalizingPlanarFlow(1, 2).rebuild, MvNormal(zeros(1), I)
+    )
+    x_bad = [-0.643686975316279]
+    # Documents the upstream contract; drop it if Bijectors ever returns NaN here instead.
+    @test_throws ArgumentError logpdf(flow, x_bad)
+    @test NoLimits._is_numeric_error(
+        try
+            logpdf(flow, x_bad)
+        catch err
+            err
+        end
+    )
+end
+
 # #246: sampled `mean` alongside the sampled `cov`, plus the `params` interface.
 @testset "NormalizingPlanarFlow moments and params" begin
     f = NormalizingPlanarFlow(2, 1)

--- a/test/uq_tests.jl
+++ b/test/uq_tests.jl
@@ -835,6 +835,21 @@ end
     @test_logs (:warn, r"far beyond roundoff") NoLimits._project_psd_covariance(
         [-1.0 0.0; 0.0 1.0]
     )
+
+    # The alternative the warning names must exist for the fit at hand: profile UQ is
+    # restricted to MLE/MAP/Laplace/GHQuadrature, so an MCEM or SAEM fit is sent to
+    # :mcmc_refit only.
+    @test NoLimits._wald_fallback_methods(:laplace) == "method = :profile / :mcmc_refit"
+    @test NoLimits._wald_fallback_methods(:ghquadrature) == "method = :profile / :mcmc_refit"
+    @test NoLimits._wald_fallback_methods(:mcem) == "method = :mcmc_refit"
+    @test NoLimits._wald_fallback_methods(:saem) == "method = :mcmc_refit"
+    @test NoLimits._wald_fallback_methods(:focei) == "method = :mcmc_refit"
+    @test_logs (:warn, r"Prefer method = :mcmc_refit for those parameters\.") NoLimits._project_psd_covariance(
+        [-1.0 0.0; 0.0 1.0]; fallbacks = NoLimits._wald_fallback_methods(:mcem)
+    )
+    @test_logs (:warn, r"Prefer method = :profile / :mcmc_refit") NoLimits._project_psd_covariance(
+        [-1.0 0.0; 0.0 1.0]; fallbacks = NoLimits._wald_fallback_methods(:laplace)
+    )
     Vp, dp = @test_logs (:warn, r"shrunk toward zero") NoLimits._project_psd_covariance(
         [1.0 0.0; 0.0 -1.0e-20]
     )


### PR DESCRIPTION
Eight commits. Nothing merged, tagged, or registered — that is the maintainer's call.

## Commits

- **`feat(saem)`: closed-form targets for structured random-effect means.** A random-effect
  mean written as `β + offset`, where `β` is a fixed effect and the offset carries none
  (`LogNormal(CL_mean + 0.75 * log(wt / 70), sigma_CL)`), now maps `β` to a closed-form
  target. The per-level offset `c_i = μ_i - β` is subtracted before the moments are formed,
  so the covariance update centers on the structured mean instead of the pooled empirical
  one. Also generalizes `_saem_builtin_collect_current_stats` to a per-batch draw count and
  gives the closed-form config resolution and routing log an estimator label.
- **`feat(mcem)`: closed-form, sufficient-statistics M-step.** Four keywords with SAEM's
  names, meanings and defaults: `builtin_stats` (default `:auto`), `resid_var_param`,
  `re_cov_params`, `re_mean_params`. Eligibility, autodetection and the shared-target
  exclusions come from SAEM's own resolver, so the routing is identical for the two
  estimators. Hybrid: eligible parameters are updated from the sufficient statistics of the
  current E-step draws and frozen into `mstep_constants`, the existing Q2/Q1 legs optimize
  what is left, and the numerical problem is skipped entirely when nothing is. The
  statistics are a plain Monte Carlo average over this iteration's draws — MCEM carries no
  stochastic-approximation state, and a `gamma = 1` blend would not be bitwise that mean.
  The path is BLAS-free, which is the point: it removes the LBFGS `ddot` whose kernel
  dispatch made the same fit differ in its last bits between AVX-512 and AVX2/Zen. It
  disables itself with an info message for an `MCEM_IS` E-step (weighted draws, unweighted
  statistics) and for `extra_objective` (non-separable M-step). Closed-form values respect
  `constants`, the fixed effect's declared natural-scale bounds and SAEM's `var_lb` floor,
  so a degenerate variance cannot reach `log(0)`. Routing is logged at startup and recorded
  in `notes`, with `get_closed_form_mstep_used(::MCEMResult)` as the one-line check.
- **`docs`: recommend `import Turing` over `using Turing`.** `using Turing` brings Turing's
  own `Laplace`, `MAP`, `MLE`, `loglikelihood`, `logprior` and `predict` into scope
  alongside the NoLimits exports of the same names, so every unqualified use afterwards
  fails with an ambiguity error. Samplers are now referenced as `Turing.MH()` /
  `Turing.NUTS()`; the reason is spelled out once under Optional Dependencies. The
  `using Turing` inside `ext/NoLimitsTuringExt.jl` and the docs build scripts is untouched —
  those load the package for their own use, they are not recommendations.
- **`docs`: changelog for the M-step work, plus the missing `## v0.2.0` heading.** The
  v0.2.0 notes were folded into the v0.2.1 section when the changelog was first written;
  comparing `git show v0.2.0:CHANGELOG.md` with `git show v0.2.1:CHANGELOG.md` puts the
  boundary at the "Breaking changes" run that opens with the Plots.jl→Makie migration.
- **`fix`: classify Roots' bracketing `ArgumentError` as a numeric error.** A
  normalizing-flow random effect could kill a whole SAEM fit. When the Q2 M-step drives a
  planar layer's weight to exactly `w = [0.0]`, `Bijectors.get_u_hat` returns
  `u_hat = NaN` while `w'u_hat` stays finite; the NaN propagates into the next layer's
  `find_alpha`, and Roots rejects the `[NaN, NaN]` bracket with
  `ArgumentError("The interval [a,b] is not a bracketing interval...")`.
  `_re_logpdf_batch` already wraps that call intending to score the point `-Inf`, but
  `_is_numeric_error` classifies `ArgumentError` by message and this one matched none of
  the alternatives in `_NUMERIC_ARGUMENT_ERROR_RE` (tightened in #326), so the guard
  rethrew. Adding the bracketing message closes the same hole in `_laplace_logf_batch` and
  the FOCEI/GHQ/MCMC wrappers at once. Only paths that previously threw reach the new
  branch, so no successful fit changes. **Not** a Bijectors 0.16 regression: both
  `Roots.ITP` and `Roots.A42` call `assert_bracket` before their first iteration, and the
  failure reproduces on Bijectors 0.15.24 (verified on this repo's pinned test
  environment). The Bijectors compat bound is unchanged.
- **`refactor(mcem)`: build the closed-form target set once.** The generator body rebuilt
  the `Set` per free parameter.
- **`fix(saem)`: center the closed-form variance on a literal random-effect mean.**
  `Normal(0.0, ω)` declares a *known* mean, so the exact conditional maximizer of the
  variance is the second moment about that mean. The update computed `second - mean * mean'`
  instead, subtracting the pooled empirical mean of the draws, which is the maximizer only
  when the mean is a free parameter estimated from those same moments. The old estimate was
  biased low by `E[η - μ]²`, and not always slightly: on `fx_re_dm` the closed-form ω moves
  from **0.162 to 0.228** at identical draws. The parser now reports `mean_offset = true`
  for any mean carrying no fixed effect, routing it through the same per-level centring the
  additive-offset case uses; the statistics carry a `known_mean` flag so the update skips
  the empirical-mean correction. Shared parser/resolver/collector, so SAEM, MCEM and
  `dev_api`'s federated statistics all get it. Deliberately unchanged: a multivariate
  literal mean (`MvNormal(zeros(k), Ω)`) still centers on the empirical mean (needs
  per-level offset vectors and a check of what `params` returns for `MvLogitNormal` in ALR
  space), and a mean with an unextractable fixed effect (`μ0 + β * x`) stays numeric.
- **`chore`: bump version to v0.2.10.** `Project.toml` only, per
  `docs/src/developers-guide.md` "Release Process", matching the v0.2.9 bump.

## Behavior changes (all in the changelog)

- **MCEM results change for models with an exponential-family block**, because
  `builtin_stats` defaults to `:auto`. Same estimator target — the closed-form value is the
  exact maximizer of the same Monte Carlo Q over those parameters — but it carries none of
  the optimizer's tolerance or jitter, so the iterate path differs, the drift test fires
  earlier, and the reported iteration count and objective move. `builtin_stats = :none`
  restores the previous fully numerical M-step exactly.
- **SAEM and MCEM closed-form variance estimates change** for structured-mean and
  literal-mean random effects, for the two reasons above.
- Method-level `lb`/`ub` never constrained closed-form updates (they are transformed-scale
  optimizer bounds); closed-form values are clamped to each fixed effect's own declared
  natural-scale bounds. `docs/src/estimation/saem.md` claimed otherwise and is corrected.
- The `SAEM` docstring listed `builtin_stats = :on`/`:off` and
  `builtin_mean = :additive`/`:all`, none of which exist. Corrected to
  `:auto`/`:closed_form`/`:gaussian_re`/`:none` and `:none`/`:glm`.

## Verification on the JSS warfarin model

Fitted in a scratch project that dev-installs this branch, with the replication script's
data and model (269 rows, 30 subjects) and its exact call
`Random.seed!(12243); fit_model(dm, MCEM(maxiters = ..., store_diagnostics = true); rng = Xoshiro(3))`.

The closed-form path engages for **all seven** parameters and the numeric optimizer never
runs — `[ Info: MCEM: all parameters handled by closed-form M-step; numeric optimizer inactive.`

```
re_mean_params = (ka = :ka_mean, CL = :CL_mean, V = :V_mean)
re_mean_offset = (CL = true,)          # the 0.75 * log(wt / 70) offset was parsed
re_cov_params  = (ka = :sigma_ka, CL = :sigma_CL, V = :sigma_V)
resid_var      = sigma_C_error
reasons        = ()
closed_form_mstep_mode = closed_form_only ;  numeric_targets = ()
```

| | `maxiters = 60` (`:auto`) | `maxiters = 60` (`:none`) | `maxiters = 200` (`:auto`) |
|---|---|---|---|
| converged | false | false | **true** |
| iterations | 60 | 60 | **102** |
| objective | -334.84853211771065 | -336.4600619734183 | -333.90662930468005 |
| `ka_mean` | -0.5123 | -0.4941 | -0.5141 |
| `CL_mean` | -2.0445 | -2.0465 | -2.0471 |
| `V_mean` | 2.0501 | 2.0499 | 2.0543 |
| `sigma_ka` | 0.6912 | 0.7025 | 0.6583 |
| `sigma_CL` | 0.1705 | — | 0.1725 |
| `sigma_V` | 0.2197 | — | 0.2180 |
| `sigma_C_error` | 1.0456 | — | 1.0474 |

So `maxiters = 60` stops short; the drift test converges at iteration 102.

Wald UQ on the converged fit (`compute_uq(fit; rng = Xoshiro(3))`, 17 s):

```
  parameter          Estimate    Std. Error      CI Lower      CI Upper
  ka_mean             -0.5141        0.1981       -0.9024       -0.1257
  CL_mean             -2.0471        0.0385       -2.1226       -1.9716
  V_mean               2.0543        0.0476        1.9609        2.1476
  sigma_ka             0.6583        0.0253        0.6105        0.7098
  sigma_CL             0.1725        0.0340        0.1185        0.2512
  sigma_V              0.2180        0.0372        0.1571        0.3025
  sigma_C_error        1.0474        0.0590        0.9382        1.1694
```

The "Wald covariance was projected to the nearest PSD matrix" warning **still fires**, and
it is not caused by the new M-step: most negative eigenvalue / fraction of matrix scale is
`-0.0556` / `1.00` at convergence, `-0.0420` / `0.87` at `maxiters = 60` with `:auto`, and
`-0.0394` / `0.80` at `maxiters = 60` with `:none`. Running to convergence does not remove
it. Note that the warning's advice to prefer `method = :profile` does not apply to an MCEM
fit: profile UQ errors at `src/uq/profile.jl:250` ("supported for MLE, MAP, Laplace, and
GHQuadrature"). For MCEM, `compute_uq` supports `:wald` and `:mcmc`.

## Tests run (`julia --project=. -t 1`, via `NL_TEST_FILES=... Pkg.test()`)

`estimation_mcem_tests.jl` 175/175 · `estimation_saem_autodetect_tests.jl` 100/100 ·
`estimation_saem_tests.jl` 83/83 · `estimation_saem2_tests.jl` 107/107 ·
`saem_schedule_tests.jl` 65/65 · `saem_sa_anneal_tests.jl` 55/55 ·
`saem_mh_kernel_tests.jl` 67/67 · `saem_var_lb_tests.jl` 87/87 ·
`extra_objective_tests.jl` 24/24 · `estimation_common_tests.jl` 312/312 ·
`random_effects_tests.jl` 43/43 · `uq_tests.jl` 238/238 · `uq_edge_cases_tests.jl` 19/19 ·
`estimation_multistart_tests.jl` 57/57 · `estimation_precondition_tests.jl` 32/32 ·
`plotting_functions_tests.jl` 101/101 · `api_primitives_tests.jl` 429/429 ·
`accessors_tests.jl` 42/42 · `summaries_tests.jl` 263/263 ·
`serialization_tests.jl` 53/53 · `aqua_tests.jl` 9/9 · `aqua_ambiguities_tests.jl` 1/1.

All green. The full suite was not run locally (hours); CI covers it.

## The one re-pinned test

`"MCEM user bounds reach the Q2-only M-step"` (`test/estimation_mcem_tests.jl`) now passes
`builtin_stats = :none`. It asserts that a method-level `lb` on the transformed scale pushes
ω to the bound, which is a property of the *numeric* Q2 leg. With the new default ω is
updated in closed form and clamped to its own declared natural-scale bounds instead, so the
assertion measured the wrong thing under `:auto`. This is the only existing test whose
expectation had to change.

## New tests

`estimation_mcem_tests.jl`: `"MCEM closed-form M-step routing and agreement"` (default is
`:auto`; `(:σ, :ω)` closed form vs `(:a,)` numeric with `reasons` empty; `:none` reproduces
the old path; `:auto`/`:none` agree to `rtol = 0.15` on a noisier panel; `constants` drop a
parameter from both routes; two seeded runs bitwise-identical on `get_params`, `Q_hist` and
iteration count; `MCEM_IS` and `extra_objective` each force `:none`);
`"MCEM closed-form M-step with a structured random-effect mean"` (`numeric_targets == ()`,
mode `:closed_form_only`, exercising the empty-free-set branch); and, in the existing SAEM
dev_api testset, the literal-mean check that the closed-form ω equals `sqrt(Σηᵢ²/n)`
exactly and exceeds the old empirical-mean-centered value.
`estimation_saem_autodetect_tests.jl`: parser cases for all three mean forms, and a
warfarin-shaped model asserting all seven parameters closed form with `reasons` empty for
both the SAEM and the MCEM resolver.
`estimation_common_tests.jl` / `random_effects_tests.jl`: the Roots bracketing message and
the degenerate `w = 0` planar flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
